### PR TITLE
chore: standardize wrangler env config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "x402stacks-sponsor-relay",
+  "name": "x402-sponsor-relay",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
-    "deploy:dry-run": "wrangler deploy --dry-run",
+    "dev": "npm run wrangler -- dev",
+    "deploy:staging": "npm run wrangler -- deploy --env staging",
+    "deploy:production": "npm run wrangler -- deploy --env production",
+    "deploy:dry-run": "npm run wrangler -- deploy --dry-run",
     "check": "tsc --noEmit",
     "wrangler": "set -a && . ./.env && set +a && npx wrangler",
-    "cf-typegen": "wrangler types",
+    "cf-typegen": "npm run wrangler -- types",
     "test:relay": "tsx scripts/test-relay.ts"
   },
   "devDependencies": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,7 +14,7 @@
    * These are NOT inherited by environments - each env must define its own.
    */
   "services": [
-    { "binding": "LOGS", "service": "worker-logs", "entrypoint": "LogsRPC" }
+    { "binding": "LOGS", "service": "worker-logs-staging", "entrypoint": "LogsRPC" }
   ],
   "vars": {
     "STACKS_NETWORK": "testnet"
@@ -39,7 +39,7 @@
       },
       // Bindings must be duplicated per environment
       "services": [
-        { "binding": "LOGS", "service": "worker-logs", "entrypoint": "LogsRPC" }
+        { "binding": "LOGS", "service": "worker-logs-staging", "entrypoint": "LogsRPC" }
       ]
     },
     "production": {
@@ -52,7 +52,7 @@
       },
       // Bindings must be duplicated per environment
       "services": [
-        { "binding": "LOGS", "service": "worker-logs", "entrypoint": "LogsRPC" }
+        { "binding": "LOGS", "service": "worker-logs-production", "entrypoint": "LogsRPC" }
       ]
     }
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,60 +1,56 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "x402stacks-sponsor-relay",
+  "name": "x402-sponsor-relay",
   "main": "src/index.ts",
-  "compatibility_date": "2025-01-08",
-  // nodejs_compat_v2 includes RPC support for service bindings
+  "compatibility_date": "2026-01-01",
   "compatibility_flags": ["nodejs_compat_v2"],
-
-  // Observability for debugging
-  "observability": {
-    "enabled": true
-  },
+  // Local development settings
+  "workers_dev": true,
+  "preview_urls": true,
+  "observability": { "enabled": false },
 
   /**
-   * Service Bindings
-   * LOGS: Universal logging service (RPC, no API key needed)
+   * Top-level bindings are for local development only (wrangler dev).
+   * These are NOT inherited by environments - each env must define its own.
    */
   "services": [
     { "binding": "LOGS", "service": "worker-logs", "entrypoint": "LogsRPC" }
   ],
-
-  /**
-   * Environment Variables
-   * Secrets should be set via `wrangler secret put` or Cloudflare dashboard:
-   * - SPONSOR_PRIVATE_KEY: Private key for sponsoring transactions
-   */
   "vars": {
     "STACKS_NETWORK": "testnet"
   },
 
   /**
-   * Preview Environment (local dev)
-   */
-  // [env.preview] - uses default bindings
-
-  /**
-   * Staging Environment
+   * Environments
+   * Note: services are NOT inherited by environments.
+   * Each environment must explicitly define all bindings it needs.
+   *
+   * Secrets (set via `wrangler secret put --env <env>`):
+   * - SPONSOR_PRIVATE_KEY: Private key for sponsoring transactions
    */
   "env": {
     "staging": {
+      "name": "x402-sponsor-relay-staging",
+      "workers_dev": false,
       "routes": [{ "pattern": "x402-relay.aibtc.dev", "custom_domain": true }],
+      "observability": { "enabled": true },
       "vars": {
         "STACKS_NETWORK": "testnet"
       },
+      // Bindings must be duplicated per environment
       "services": [
         { "binding": "LOGS", "service": "worker-logs", "entrypoint": "LogsRPC" }
       ]
     },
-
-    /**
-     * Production Environment
-     */
     "production": {
+      "name": "x402-sponsor-relay-production",
+      "workers_dev": false,
       "routes": [{ "pattern": "x402-relay.aibtc.com", "custom_domain": true }],
+      "observability": { "enabled": true },
       "vars": {
         "STACKS_NETWORK": "mainnet"
       },
+      // Bindings must be duplicated per environment
       "services": [
         { "binding": "LOGS", "service": "worker-logs", "entrypoint": "LogsRPC" }
       ]


### PR DESCRIPTION
## Summary
- Add workers_dev and preview_urls settings for local development
- Standardize naming pattern for staging/production environments
- Add observability for deployed environments
- Update package.json scripts for environment-based deploys (`deploy:staging`, `deploy:production`)

## Cloudflare Best Practices
Bindings like `services` are NOT inherited by environments in wrangler.jsonc, so they must be explicitly defined in each environment.

## Test plan
- [x] Verify `npm run deploy:dry-run -- --env staging` works
- [x] Verify `npm run deploy:dry-run -- --env production` works
- [x] Set secrets and deploy to staging
- [x] Test staging endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)