### PR TITLE
fix: update serialize() calls for stacks.js v7 compatibility

### DIFF
--- a/scripts/test-relay.ts
+++ b/scripts/test-relay.ts
@@ -122,8 +122,8 @@ async function main() {
     fee: 0n, // Sponsor will pay
   });
 
-  // Serialize to hex
-  const txHex = Buffer.from(transaction.serialize()).toString("hex");
+  // Serialize to hex (v7: serialize() returns hex string directly)
+  const txHex = transaction.serialize();
   console.log(`Transaction hex: ${txHex.slice(0, 50)}...`);
   console.log(`Transaction length: ${txHex.length} chars`);
 

--- a/src/services/sponsor.ts
+++ b/src/services/sponsor.ts
@@ -145,9 +145,8 @@ export class SponsorService {
         network,
       });
 
-      const sponsoredTxHex = Buffer.from(sponsoredTx.serialize()).toString(
-        "hex"
-      );
+      // v7: serialize() returns hex string directly
+      const sponsoredTxHex = sponsoredTx.serialize();
 
       return {
         success: true,


### PR DESCRIPTION
## Summary
- Fix transaction serialization in `src/services/sponsor.ts` - removes double-encoding that caused "Invalid byte sequence" errors
- Fix test script serialization in `scripts/test-relay.ts` - removes double-encoding that caused "Could not parse 48 as TransactionVersion" errors

## Root Cause
In stacks.js v7, `serialize()` returns a hex string directly instead of `Uint8Array`. The previous code wrapped `serialize()` with `Buffer.from().toString("hex")`, which double-encoded the data:

1. `serialize()` returns `"808000..."` (hex string)
2. `Buffer.from("808000...")` interprets each char as ASCII: `[0x38, 0x30, ...]`
3. `.toString("hex")` re-encodes as hex: `"3830..."` (garbage)

Reference: https://github.com/stx-labs/stacks.js/blob/main/.github/MIGRATION.md

## Test plan
- [ ] Run `npm run check` to verify types
- [ ] Run `npm run test:relay` against local dev server
- [ ] Deploy to staging and verify transactions process correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)