### PR TITLE
fix(version): sync version.ts with package.json

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
  * Single source of truth for application version
  * Updated automatically by release-please
  */
-export const VERSION = "0.3.0"; // x-release-please-version
+export const VERSION = "1.4.0"; // x-release-please-version


### PR DESCRIPTION
## Summary
- Sync `src/version.ts` from stale `0.3.0` to `1.4.0` to match `package.json` — release-please annotation ensures future releases stay in sync
- Investigated post-condition handling in sponsor flow for issue #113 — confirmed the relay does NOT strip post-conditions during transaction sponsorship

## Investigation Findings
Traced the full sponsor flow through `relay.ts` → `sponsor.ts` → `@stacks/transactions` library:
- `setSponsor()` only modifies the `auth` field, leaving `postConditions` intact
- Serialization/deserialization preserves post-conditions at every step
- Root cause of #113 likely lies in the MCP server's transaction builder, not the relay

## Test plan
- [x] Verified all version references match (package.json, version.ts, .release-please-manifest.json)
- [x] Build passes
- [x] No behavioral changes — version string only affects metadata endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)