### PR TITLE
fix: add KV → StatsDO backfill for dashboard stats recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:sip018-auth": "set -a && . ./.env && set +a && tsx scripts/test-sip018-auth.ts",
     "test:settle": "set -a && . ./.env && set +a && tsx scripts/test-settle.ts",
     "test:fees": "set -a && . ./.env && set +a && tsx scripts/test-fees.ts",
-    "keys": "set -a && . ./.env && set +a && tsx scripts/manage-api-keys.ts"
+    "keys": "set -a && . ./.env && set +a && tsx scripts/manage-api-keys.ts",
+    "backfill": "set -a && . ./.env && set +a && tsx scripts/backfill-stats.ts"
   },
   "devDependencies": {
     "@types/node": "^25.0.3",

--- a/scripts/backfill-stats.ts
+++ b/scripts/backfill-stats.ts
@@ -1,0 +1,59 @@
+/**
+ * One-time backfill script: migrate stats from KV to StatsDO
+ *
+ * Reads old stats:daily:*, stats:hourly:*, and tx:log:* keys from RELAY_KV
+ * and imports them into the new StatsDO SQLite tables.
+ *
+ * Safe to run multiple times (uses INSERT OR REPLACE / INSERT OR IGNORE).
+ *
+ * Usage:
+ *   npm run backfill                                    # staging (default)
+ *   npm run backfill -- https://x402-relay.aibtc.com    # production
+ *
+ * Environment variables (in .env):
+ *   TEST_API_KEY   API key with admin access (required)
+ *   RELAY_URL      Relay endpoint URL (optional, default: staging)
+ */
+
+const DEFAULT_URL = "https://x402-relay.aibtc.dev";
+
+async function main() {
+  const apiKey = process.env.TEST_API_KEY;
+  if (!apiKey) {
+    console.error("ERROR: TEST_API_KEY not set in .env");
+    process.exit(1);
+  }
+
+  const relayUrl = process.argv[2] || process.env.RELAY_URL || DEFAULT_URL;
+  const url = `${relayUrl}/admin/backfill`;
+
+  console.log(`Backfilling stats: ${url}`);
+  console.log("Sending request (this may take a moment)...\n");
+
+  const start = Date.now();
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: "{}",
+  });
+
+  const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+  const body = await resp.json();
+
+  if (!resp.ok) {
+    console.error(`FAILED (${resp.status}): ${JSON.stringify(body, null, 2)}`);
+    process.exit(1);
+  }
+
+  console.log(`Completed in ${elapsed}s\n`);
+  console.log(JSON.stringify(body, null, 2));
+}
+
+main().catch((e) => {
+  console.error("Unexpected error:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- PR #70 migrated stats from KV to StatsDO but didn't migrate historical data, leaving the dashboard empty
- Adds `POST /admin/backfill` endpoint (API key protected) that reads old KV stats keys and bulk-imports into StatsDO SQLite
- Adds `POST /backfill` route to StatsDO for receiving bulk data (INSERT OR REPLACE, safe to re-run)
- Adds `scripts/backfill-stats.ts` trigger script (`npm run backfill`)

## Usage
```bash
# After deploy, run once per environment:
npm run backfill                                    # staging
npm run backfill -- https://x402-relay.aibtc.com    # production
```

## Test plan
- [ ] Deploy to staging via merge
- [ ] Run `npm run backfill` against staging
- [ ] Verify dashboard at https://x402-relay.aibtc.dev/dashboard shows restored data
- [ ] Remove `/admin/backfill` route in follow-up commit after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)