### PR TITLE
fix: capture generateNewAccount return value for wallet derivation

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -387,12 +387,13 @@ export class NonceDO {
       const words = this.env.SPONSOR_MNEMONIC.trim().split(/\s+/);
       if (!VALID_MNEMONIC_LENGTHS.includes(words.length)) return null;
       try {
-        const wallet = await generateWallet({
+        let wallet = await generateWallet({
           secretKey: this.env.SPONSOR_MNEMONIC,
           password: "",
         });
+        // generateNewAccount returns a new wallet object (wallet-sdk v7)
         for (let i = wallet.accounts.length; i <= walletIndex; i++) {
-          generateNewAccount(wallet);
+          wallet = generateNewAccount(wallet);
         }
         const account = wallet.accounts[walletIndex];
         return account?.stxPrivateKey ?? null;

--- a/src/services/sponsor.ts
+++ b/src/services/sponsor.ts
@@ -157,7 +157,7 @@ export class SponsorService {
     this.logger.info("Deriving sponsor key from mnemonic", { accountIndex });
 
     try {
-      const wallet = await generateWallet({
+      let wallet = await generateWallet({
         secretKey: this.env.SPONSOR_MNEMONIC,
         // Empty password is intentional: the mnemonic is the sole secret in this
         // server-side context, no additional user passphrase is used.
@@ -165,8 +165,9 @@ export class SponsorService {
       });
 
       // Generate accounts up to the needed index
+      // generateNewAccount returns a new wallet object (wallet-sdk v7)
       for (let i = wallet.accounts.length; i <= accountIndex; i++) {
-        generateNewAccount(wallet);
+        wallet = generateNewAccount(wallet);
       }
 
       const account = wallet.accounts[accountIndex];

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
  * Single source of truth for application version
  * Updated automatically by release-please
  */
-export const VERSION = "1.5.0"; // x-release-please-version
+export const VERSION = "1.12.0"; // x-release-please-version


### PR DESCRIPTION
## Summary

- **Fix wallet derivation** — `generateNewAccount()` in `@stacks/wallet-sdk` v7 returns a new wallet object instead of mutating. Both `SponsorService.deriveSponsorKeyForIndex` and `NonceDO.derivePrivateKeyForWallet` discarded the return value, making wallets 1–4 always fail with `SPONSOR_CONFIG_ERROR`
- **Sync version.ts** — was stuck at 1.5.0, now matches package.json (1.12.0)

## Test plan

- [ ] Deploy to staging and verify `/relay` works with all 5 wallet indices
- [ ] Confirm NonceDO gap-fill alarm can derive keys for wallets 1–4
- [ ] Run `npm run test:relay -- https://x402-relay.aibtc.dev` multiple times to hit different wallet indices

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)