### PR TITLE
fix: reduce health check cron to 30min for KV free tier

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -35,9 +35,9 @@
     "SPONSOR_WALLET_COUNT": "5",
     "FLUSH_RECIPIENT": "STEB8Z3TAY2130B8M5THXZEQQ4D6S3RMYRENN2KB"
   },
-  // Cron trigger: run health check every 5 minutes
+  // Cron trigger: run health check every 30 minutes (free-tier KV budget)
   "triggers": {
-    "crons": ["*/5 * * * *"]
+    "crons": ["*/30 * * * *"]
   },
 
   /**
@@ -79,9 +79,9 @@
         { "binding": "RELAY_KV", "id": "3851254fa8f9494189689ce5a726b773" },
         { "binding": "API_KEYS_KV", "id": "20be33ef450a4c31a128dd80a1ff3bd9" }
       ],
-      // Cron trigger: run health check every 5 minutes
+      // Cron trigger: run health check every 30 minutes (free-tier KV budget)
       "triggers": {
-        "crons": ["*/5 * * * *"]
+        "crons": ["*/30 * * * *"]
       }
     },
     "production": {
@@ -113,9 +113,9 @@
         { "binding": "RELAY_KV", "id": "56f3b1596357434291161238d40cbd81" },
         { "binding": "API_KEYS_KV", "id": "307c3134a46e4d5a94e2d0b7f1d97cbf" }
       ],
-      // Cron trigger: run health check every 5 minutes
+      // Cron trigger: run health check every 30 minutes (free-tier KV budget)
       "triggers": {
-        "crons": ["*/5 * * * *"]
+        "crons": ["*/30 * * * *"]
       }
     }
   }


### PR DESCRIPTION
## Summary

- Health check cron reduced from `*/5` to `*/30` across all environments (top-level, staging, production)
- Cuts KV writes from ~576/day to ~96/day, freeing up budget for actual relay traffic

The 5-minute interval was consuming over half the free tier's 1,000 daily KV write limit just on self-monitoring, leaving little headroom for dedup, receipts, and fee caching.

## Test plan

- [ ] `npm run deploy:dry-run` — build succeeds
- [ ] Deploy to staging, verify cron fires every 30 min (check dashboard uptime still populates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)