### PR TITLE
fix: remove release-type input so release-please uses config file

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
-        with:
-          release-type: node

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
  * Single source of truth for application version
  * Updated automatically by release-please
  */
-export const VERSION = "1.12.0"; // x-release-please-version
+export const VERSION = "1.12.2"; // x-release-please-version


### PR DESCRIPTION
## Summary
- Removes `release-type: node` from the release-please workflow, which was triggering "simple mode" and bypassing `release-please-config.json`
- Syncs `src/version.ts` to current release (1.12.2) since the `extra-files` updater wasn't running

## Context
With `release-type` set in the workflow inputs, release-please ignores the config file entirely. This meant the `extra-files` entry for `src/version.ts` was never processed, leaving the version constant stale. Removing the input lets the config file drive everything.

## Test plan
- [ ] Merge this PR and verify release-please creates a release PR that includes `src/version.ts` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)