### PR TITLE
fix(settlement): relax testnet sBTC matching and DRY token dispatch

### DIFF
--- a/src/services/settlement.ts
+++ b/src/services/settlement.ts
@@ -138,9 +138,10 @@ export class SettlementService {
   }
 
   private isUsdcxContract(address: string, contractName: string): boolean {
+    const upper = address.toUpperCase();
     return (
-      (address === USDCX_CIRCLE_CONTRACT_MAINNET && contractName === USDCX_CIRCLE_CONTRACT_NAME) ||
-      (address === USDCX_AEUSDC_CONTRACT_MAINNET && contractName === USDCX_AEUSDC_CONTRACT_NAME)
+      (upper === USDCX_CIRCLE_CONTRACT_MAINNET && contractName === USDCX_CIRCLE_CONTRACT_NAME) ||
+      (upper === USDCX_AEUSDC_CONTRACT_MAINNET && contractName === USDCX_AEUSDC_CONTRACT_NAME)
     );
   }
 


### PR DESCRIPTION
## Summary
- On testnet, match sBTC by contract name (`sbtc-token`) only, ignoring the deployer address which drifts across SDKs
- On mainnet, keep strict address matching against `SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4`
- Extract `matchTokenContract()` as single dispatch point for all token contract matching, eliminating 3x duplicated logic
- Fix latent CAIP-19 USDCx path that only checked address, not contract name

Closes #120

## Changes
Single file: `src/services/settlement.ts` (-67/+41 lines)

| Change | Impact |
|--------|--------|
| Remove `SBTC_CONTRACT_TESTNET` constant | Eliminates recurring testnet drift |
| Add `isSbtcContract()` helper | Testnet: name-only match. Mainnet: strict address |
| Add `isUsdcxContract()` helper | Symmetric with sBTC pattern |
| Add `matchTokenContract()` dispatch | Single point of truth for (address, contractName) → TokenType |
| Simplify `matchBareContractPrincipal()` | 16 → 6 lines via delegation |
| Simplify `verifyPaymentParams()` token detection | 12-line if/else → 7 lines |

## Test plan
- [x] `npm run check` passes (TypeScript)
- [x] Dev server starts, `/health` responds
- [ ] Deploy to staging and run `npm run test:relay`

🤖 Generated with [Claude Code](https://claude.com/claude-code)