### PR TITLE
fix(settlement): suppress false error log when broadcast succeeds on retry

### DIFF
--- a/src/services/settlement.ts
+++ b/src/services/settlement.ts
@@ -771,8 +771,10 @@ export class SettlementService {
       }
     }
 
-    // All attempts exhausted — return the last error
-    if (lastBroadcastError) {
+    // All attempts exhausted without a successful broadcast — return the last error.
+    // Guard on !txid: if a later retry succeeded (txid is set), lastBroadcastError
+    // reflects an earlier failed attempt and must NOT be treated as a final failure.
+    if (!txid && lastBroadcastError) {
       this.logger.error("Broadcast failed after all attempts", {
         maxAttempts: BROADCAST_MAX_ATTEMPTS,
         lastError: "error" in lastBroadcastError ? lastBroadcastError.details : "unknown",


### PR DESCRIPTION
## Summary

- Fixes #147
- In the broadcast retry loop inside `SettlementService.broadcastAndConfirm`, `lastBroadcastError` is set on every failed attempt. After the loop, the original guard `if (lastBroadcastError)` would fire even when a later attempt had already succeeded and `txid` was set, incorrectly logging "Broadcast failed after all attempts" and returning a failure response.
- Fix: tighten the post-loop guard to `if (!txid && lastBroadcastError)` so the error path is only taken when **no** attempt ever produced a txid.

## Root Cause

```typescript
// Before: lastBroadcastError set on attempt 1 failure
// attempt 2 succeeds → txid is set, loop breaks
// post-loop: lastBroadcastError is still truthy → false error logged
if (lastBroadcastError) { ... }

// After: guard also checks that txid was never populated
if (!txid && lastBroadcastError) { ... }
```

## Test plan

- [ ] Manually verify: simulate a transient broadcast failure on attempt 1 followed by success on attempt 2; confirm no ERROR log is emitted and the txid is returned correctly
- [ ] Run `npm run check` for type safety
- [ ] Review `src/services/settlement.ts` diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)