### PR TITLE
fix: clear lastBroadcastError on successful broadcast retry

### DIFF
--- a/src/services/settlement.ts
+++ b/src/services/settlement.ts
@@ -625,6 +625,7 @@ export class SettlementService {
           }
 
           txid = parsedTxid;
+          lastBroadcastError = undefined; // Clear so post-loop guard doesn't falsely trigger (#147)
           this.logger.info("Transaction broadcast successful", { txid, attempt });
           break; // Success — exit retry loop and fall through to polling
         }


### PR DESCRIPTION
## Summary

- Fixes #147: `broadcastAndConfirm()` logged `ERROR "Broadcast failed after all attempts"` even when a retry attempt succeeded.
- Root cause: `lastBroadcastError` was set on each failed attempt but never cleared on success. When attempt 1 failed (e.g. HTTP 503) and attempt 2 succeeded, the post-loop guard `if (lastBroadcastError)` still evaluated as truthy, logging the error and returning the stale failure instead of falling through to confirmation polling.
- Fix: set `lastBroadcastError = undefined` immediately after a successful broadcast, before breaking out of the retry loop.

## Test plan

- [ ] Verify that a broadcast succeeding on retry (attempt 2+) no longer logs an ERROR or returns a failure result
- [ ] Verify that a broadcast failing on all attempts still correctly logs the ERROR and returns the last error
- [ ] Verify that a broadcast succeeding on attempt 1 (no prior errors) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)