### PR TITLE
fix(nonce): increase NONCE_CONFLICT retry backoff from 1s to 30s

### DIFF
--- a/src/endpoints/relay.ts
+++ b/src/endpoints/relay.ts
@@ -392,14 +392,17 @@ export class Relay extends BaseEndpoint {
             walletIndex: sponsorWalletIndex,
             broadcastDetails: broadcastResult.details,
           });
+          // Trigger async nonce resync — the DO alarm will reconcile within 60s.
+          // Clients should back off for at least 30s and check GET /health (nonce.circuitBreakerOpen)
+          // before retrying. Rapid retries during nonce drift amplify the cascade.
           this.scheduleNonceResync(c, sponsorService.resyncNonceDODelayed(), logger);
           return this.err(c, {
-            error: "Nonce conflict — resubmit with a new transaction",
+            error: "Nonce conflict — back off and retry after checking GET /health for nonce pool status",
             code: "NONCE_CONFLICT",
             status: 409,
             details: broadcastResult.details,
             retryable: true,
-            retryAfter: 1,
+            retryAfter: 30,
           });
         }
 

--- a/src/endpoints/sponsor.ts
+++ b/src/endpoints/sponsor.ts
@@ -307,14 +307,17 @@ export class Sponsor extends BaseEndpoint {
               walletIndex: sponsorWalletIndex,
               broadcastDetails: errorReason,
             });
+            // Trigger async nonce resync — the DO alarm will reconcile within 60s.
+            // Clients should back off for at least 30s and check GET /health (nonce.circuitBreakerOpen)
+            // before retrying. Rapid retries during nonce drift amplify the cascade.
             this.scheduleNonceResync(c, sponsorService.resyncNonceDODelayed(), logger);
             return this.err(c, {
-              error: "Nonce conflict — resubmit with a new transaction",
+              error: "Nonce conflict — back off and retry after checking GET /health for nonce pool status",
               code: "NONCE_CONFLICT",
               status: 409,
               details: errorReason,
               retryable: true,
-              retryAfter: 1,
+              retryAfter: 30,
             });
           }
 


### PR DESCRIPTION
## Summary

- Increases `retryAfter` on `NONCE_CONFLICT` (409) responses from `1` second to `30` seconds in both `/relay` and `/sponsor` endpoints
- Updates the error message to direct clients to `GET /health` (`nonce.circuitBreakerOpen`) as a readiness signal before retrying
- No breaking changes — the `Retry-After` header value increases, making clients back off more aggressively during nonce drift

## Root cause (from incident #151)

The 2026-03-11 nonce drift incident produced 121 failed tasks and a 42-task retry chain before a client-side circuit breaker was deployed. The `retryAfter: 1` in the NONCE_CONFLICT response was too aggressive — clients retried every second while the relay was stuck, turning a recoverable drift into a full cascade.

The NonceDO alarm fires every 60 seconds when there are in-flight nonces. A 30-second backoff gives the DO approximately half an alarm cycle to reconcile before clients retry, dramatically reducing the retry storm.

## Client recovery pattern (documented in error message)

1. Receive `NONCE_CONFLICT` (409) with `Retry-After: 30`
2. Wait at least 30 seconds
3. Poll `GET /health` until `nonce.circuitBreakerOpen === false` (requires PR #154)
4. Rebuild the transaction with fresh state and resubmit

## Related

- PR #154 adds `nonce.circuitBreakerOpen` to `GET /health` (the readiness signal referenced in the error message)

## Test plan

- [ ] Submit a transaction that triggers NONCE_CONFLICT — verify `Retry-After: 30` in response headers
- [ ] Verify error message includes reference to `GET /health`
- [ ] `npm run check` passes

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)