### PR TITLE
feat: support self-pay (non-sponsored) transaction settlement via X-Settlement header

### DIFF
--- a/src/endpoints/relay.ts
+++ b/src/endpoints/relay.ts
@@ -708,8 +708,9 @@ export class Relay extends BaseEndpoint {
     const storedReceipt = await receiptService.storeReceipt({
       receiptId,
       senderAddress: validation.senderAddress,
-      // No sponsor tx for self-pay — store the original tx for auditability
-      sponsoredTx: body.transaction,
+      // No sponsor tx for self-pay — sponsoredTx is intentionally undefined.
+      // The original transaction hex is available in the request log if needed.
+      sponsoredTx: undefined,
       fee: "0",
       txid: broadcastResult.txid,
       settlement,
@@ -738,7 +739,11 @@ export class Relay extends BaseEndpoint {
     return this.okWithTx(c, {
       txid: broadcastResult.txid,
       settlement,
-      sponsoredTx: null,
+      // sponsoredTx omitted (undefined not null): okWithTx's conditional spread skips
+      // falsy values so this field is absent from the JSON response — self-pay callers
+      // already have their tx and don't need it echoed back. Using undefined (not null)
+      // matches the optional field type and keeps JSON output consistent with omission.
+      sponsoredTx: undefined,
       receiptId: storedReceipt ? receiptId : undefined,
     });
   }

--- a/src/services/receipt.ts
+++ b/src/services/receipt.ts
@@ -15,7 +15,7 @@ export class ReceiptService {
   async storeReceipt(data: {
     receiptId: string;
     senderAddress: string;
-    sponsoredTx: string;
+    sponsoredTx?: string;
     fee: string;
     txid: string;
     settlement: SettlementResult;
@@ -36,7 +36,7 @@ export class ReceiptService {
       createdAt: now.toISOString(),
       expiresAt: expiresAt.toISOString(),
       senderAddress: data.senderAddress,
-      sponsoredTx: data.sponsoredTx,
+      ...(data.sponsoredTx !== undefined ? { sponsoredTx: data.sponsoredTx } : {}),
       fee: data.fee,
       txid: data.txid,
       settlement: data.settlement,

--- a/src/services/sponsor.ts
+++ b/src/services/sponsor.ts
@@ -4,6 +4,10 @@ import {
   getAddressFromPrivateKey,
   AuthType,
   PayloadType,
+  AddressHashMode,
+  addressHashModeToVersion,
+  addressFromVersionHash,
+  addressToString,
   type StacksTransactionWire,
 } from "@stacks/transactions";
 import { STACKS_MAINNET, STACKS_TESTNET } from "@stacks/network";
@@ -545,10 +549,13 @@ export class SponsorService {
       };
     }
 
-    // Extract sender address for rate limiting (same field as sponsored path)
-    const senderAddress = Buffer.from(
-      transaction.auth.spendingCondition.signer
-    ).toString("hex");
+    // Derive a proper c32check-encoded Stacks address from the signer hash160.
+    // Uses the same hashMode-aware derivation as SettlementService.senderToAddress()
+    // so the address format is consistent across sponsored and self-pay paths.
+    const network = this.env.STACKS_NETWORK === "mainnet" ? STACKS_MAINNET : STACKS_TESTNET;
+    const { hashMode, signer } = transaction.auth.spendingCondition;
+    const version = addressHashModeToVersion(hashMode as AddressHashMode, network);
+    const senderAddress = addressToString(addressFromVersionHash(version, signer));
 
     return {
       valid: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -493,8 +493,11 @@ export interface PaymentReceipt {
   expiresAt: string;
   /** Agent's Stacks address (from the signed transaction) */
   senderAddress: string;
-  /** The fully-sponsored transaction hex */
-  sponsoredTx: string;
+  /**
+   * The fully-sponsored transaction hex. Undefined for self-pay settlements
+   * where no sponsor signature was applied (use the request log for the original tx).
+   */
+  sponsoredTx?: string;
   /** Fee paid by sponsor in microSTX */
   fee: string;
   /** Blockchain transaction ID */


### PR DESCRIPTION
## Summary

Closes #128

Adds `X-Settlement: self-pay` header support to the `/relay` endpoint. When this header is present, the relay skips sponsoring entirely — the caller provides a fully-signed standard (non-sponsored) transaction and covers their own network fees.

- **`src/endpoints/relay.ts`**: Detects the `X-Settlement: self-pay` header after settle options validation and delegates to a new private `handleSelfPay()` method. The existing sponsored path is completely unchanged — no behaviour change for callers that omit the header.
- **`src/services/sponsor.ts`**: Adds `validateNonSponsoredTransaction()` which deserialises the tx and explicitly rejects it if `authType === AuthType.Sponsored` (caller error — a sponsored tx makes no sense for self-pay).

The self-pay path mirrors the sponsored flow step-by-step:
1. Validate + deserialize tx (standard auth only)
2. Rate limit by sender (same policy)
3. Dedup check (keyed on original tx for idempotent retries)
4. `SettlementService.verifyPaymentParams()` — auth-agnostic, no changes needed
5. `SettlementService.broadcastAndConfirm()` — auth-agnostic, no changes needed
6. Stats recording, receipt storage, dedup entry
7. Response — same shape as sponsored path; `sponsoredTx` is omitted (undefined) since no sponsor signature was applied

## Test plan

- [ ] `POST /relay` without `X-Settlement` header continues to sponsor and settle as before (backward compat)
- [ ] `POST /relay` with `X-Settlement: self-pay` and a standard auth tx: verifies payment params and broadcasts directly, response has no `sponsoredTx` field
- [ ] `POST /relay` with `X-Settlement: self-pay` and a sponsored tx: rejected with `400 INVALID_TRANSACTION` — "Transaction must not be sponsored for self-pay settlement"
- [ ] `POST /relay` with `X-Settlement: self-pay` and an invalid tx hex: rejected with `400 INVALID_TRANSACTION`
- [ ] `POST /relay` with `X-Settlement: self-pay` where payment params don't match: rejected with `400 SETTLEMENT_VERIFICATION_FAILED`
- [ ] Rate limiting applies to self-pay requests the same as sponsored
- [ ] Dedup returns cached result on retry with same tx hex

All 23 existing unit tests pass (`npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)