### PR TITLE
feat(inbox): POST /inbox endpoint for on-chain message posting

### DIFF
--- a/src/endpoints/inbox.ts
+++ b/src/endpoints/inbox.ts
@@ -1,0 +1,572 @@
+import { deserializeTransaction } from "@stacks/transactions";
+import { BaseEndpoint } from "./BaseEndpoint";
+import {
+  SponsorService,
+  SettlementService,
+  StatsService,
+  ReceiptService,
+  StxVerifyService,
+  extractSponsorNonce,
+  recordNonceTxid,
+  releaseNonceDO,
+} from "../services";
+import { InboxService, MIN_PAYMENT_STX, MIN_PAYMENT_SBTC, MAX_CONTENT_LENGTH } from "../services/inbox";
+import { checkRateLimit, RATE_LIMIT } from "../middleware";
+import { stripHexPrefix } from "../utils";
+import type { AppContext, InboxRequest, SettlementResult } from "../types";
+import {
+  Error400Response,
+  Error401Response,
+  Error409Response,
+  Error429Response,
+  Error500Response,
+  Error502Response,
+  Error503Response,
+} from "../schemas";
+
+/**
+ * Inbox endpoint — accepts paid messages for on-chain storage via arc-inbox contract.
+ *
+ * Flow:
+ * 1. Validate message content (non-empty, ≤1024 UTF-8 chars)
+ * 2. Validate x402 payment (sponsored STX/sBTC transfer, min 1 STX or 1000 sats)
+ * 3. Sponsor & broadcast the payment transaction
+ * 4. Build & broadcast a contract-call to arc-inbox.post-message
+ * 5. Return {txid, inboxTxid, messageId, status}
+ *
+ * POST /inbox
+ */
+export class Inbox extends BaseEndpoint {
+  schema = {
+    tags: ["Inbox"],
+    summary: "Post a paid message to Arc's on-chain inbox",
+    description:
+      "Accepts a message and an x402 payment transaction. Validates payment (min 1 STX or 1000 sats sBTC), " +
+      "sponsors and broadcasts the payment, then posts the message on-chain via the arc-inbox Clarity contract. " +
+      "Returns both the payment txid and the inbox contract-call txid.",
+    request: {
+      body: {
+        content: {
+          "application/json": {
+            schema: {
+              type: "object" as const,
+              required: ["content", "transaction", "settle"],
+              properties: {
+                content: {
+                  type: "string" as const,
+                  description: "Message content (max 1024 UTF-8 characters)",
+                  maxLength: MAX_CONTENT_LENGTH,
+                  example: "Hello Arc, I have a question about x402 integration.",
+                },
+                transaction: {
+                  type: "string" as const,
+                  description: "Hex-encoded signed sponsored payment transaction (STX or sBTC transfer)",
+                  example: "0x00000001...",
+                },
+                settle: {
+                  type: "object" as const,
+                  required: ["expectedRecipient", "minAmount"],
+                  properties: {
+                    expectedRecipient: {
+                      type: "string" as const,
+                      description: "Expected payment recipient (Arc's Stacks address)",
+                      example: "SP2GHQRCRMYY4S8PMBR49BEKX144VR437YT42SF3B",
+                    },
+                    minAmount: {
+                      type: "string" as const,
+                      description: `Minimum payment amount (${MIN_PAYMENT_STX} microSTX or ${MIN_PAYMENT_SBTC} sats sBTC)`,
+                      example: MIN_PAYMENT_STX,
+                    },
+                    tokenType: {
+                      type: "string" as const,
+                      enum: ["STX", "sBTC"],
+                      default: "STX",
+                      description: "Payment token type (STX or sBTC only for inbox)",
+                    },
+                    maxTimeoutSeconds: {
+                      type: "number" as const,
+                      description: "Maximum timeout for payment settlement polling (optional, default 60s)",
+                      example: 30,
+                    },
+                  },
+                },
+                auth: {
+                  type: "object" as const,
+                  description: "Optional SIP-018 structured data signature for authentication",
+                  properties: {
+                    signature: {
+                      type: "string" as const,
+                      description: "RSV signature of the structured data",
+                    },
+                    message: {
+                      type: "object" as const,
+                      required: ["action", "nonce", "expiry"],
+                      properties: {
+                        action: { type: "string" as const, example: "relay" },
+                        nonce: { type: "string" as const, example: "1708099200000" },
+                        expiry: { type: "string" as const, example: "1708185600000" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      "200": {
+        description: "Message posted to on-chain inbox successfully",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object" as const,
+              properties: {
+                success: { type: "boolean" as const, example: true },
+                requestId: { type: "string" as const, format: "uuid" },
+                txid: {
+                  type: "string" as const,
+                  description: "Payment transaction ID",
+                },
+                inboxTxid: {
+                  type: "string" as const,
+                  description: "Inbox contract-call transaction ID",
+                },
+                messageId: {
+                  type: "number" as const,
+                  description: "Estimated on-chain message ID",
+                },
+                explorerUrl: {
+                  type: "string" as const,
+                  description: "Explorer link for the inbox transaction",
+                },
+                settlement: {
+                  type: "object" as const,
+                  properties: {
+                    success: { type: "boolean" as const },
+                    status: { type: "string" as const, enum: ["pending", "confirmed", "failed"] },
+                    sender: { type: "string" as const },
+                    recipient: { type: "string" as const },
+                    amount: { type: "string" as const },
+                    blockHeight: { type: "number" as const },
+                  },
+                },
+                inboxStatus: {
+                  type: "string" as const,
+                  enum: ["pending", "confirmed"],
+                  description: "Status of the inbox contract-call",
+                },
+                receiptId: { type: "string" as const, format: "uuid" },
+              },
+            },
+          },
+        },
+      },
+      "400": Error400Response,
+      "401": { ...Error401Response, description: "Authentication failed (invalid SIP-018 signature)" },
+      "409": { ...Error409Response, description: "Nonce conflict — resubmit with a new transaction" },
+      "429": { ...Error429Response, description: "Rate limit exceeded" },
+      "500": Error500Response,
+      "502": { ...Error502Response, description: "Broadcast or network error" },
+      "503": { ...Error503Response, description: "Nonce coordinator unavailable" },
+    },
+  };
+
+  async handle(c: AppContext) {
+    const logger = this.getLogger(c);
+    logger.info("Inbox request received");
+
+    const statsService = new StatsService(c.env, logger);
+
+    try {
+      const body = (await c.req.json()) as InboxRequest;
+
+      // ── Step 1: Validate message content ──────────────────────────────
+      if (!body.content || typeof body.content !== "string") {
+        c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+        return this.err(c, {
+          error: "Missing message content",
+          code: "MISSING_CONTENT",
+          status: 400,
+          retryable: false,
+        });
+      }
+
+      if (body.content.length === 0) {
+        c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+        return this.err(c, {
+          error: "Empty message content",
+          code: "EMPTY_CONTENT",
+          status: 400,
+          retryable: false,
+        });
+      }
+
+      if (body.content.length > MAX_CONTENT_LENGTH) {
+        c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+        return this.err(c, {
+          error: "Message content too long",
+          code: "CONTENT_TOO_LONG",
+          status: 400,
+          details: `Content length ${body.content.length} exceeds maximum ${MAX_CONTENT_LENGTH} characters`,
+          retryable: false,
+        });
+      }
+
+      if (!body.transaction) {
+        c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+        return this.err(c, {
+          error: "Missing payment transaction",
+          code: "MISSING_TRANSACTION",
+          status: 400,
+          retryable: false,
+        });
+      }
+
+      if (!body.settle) {
+        c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+        return this.err(c, {
+          error: "Missing settle options",
+          code: "MISSING_SETTLE_OPTIONS",
+          status: 400,
+          retryable: false,
+        });
+      }
+
+      // Enforce token type: only STX and sBTC for inbox
+      const tokenType = body.settle.tokenType || "STX";
+      if (tokenType !== "STX" && tokenType !== "sBTC") {
+        c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+        return this.err(c, {
+          error: "Unsupported payment token for inbox",
+          code: "INVALID_SETTLE_OPTIONS",
+          status: 400,
+          details: `Inbox accepts STX or sBTC only, got ${tokenType}`,
+          retryable: false,
+        });
+      }
+
+      // Enforce minimum payment
+      const minRequired = tokenType === "sBTC" ? MIN_PAYMENT_SBTC : MIN_PAYMENT_STX;
+      try {
+        if (BigInt(body.settle.minAmount) < BigInt(minRequired)) {
+          c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+          return this.err(c, {
+            error: "Payment below inbox minimum",
+            code: "INVALID_SETTLE_OPTIONS",
+            status: 400,
+            details: `Minimum payment is ${minRequired} ${tokenType === "sBTC" ? "sats" : "microSTX"}`,
+            retryable: false,
+          });
+        }
+      } catch {
+        c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+        return this.err(c, {
+          error: "Invalid minAmount",
+          code: "INVALID_SETTLE_OPTIONS",
+          status: 400,
+          details: "settle.minAmount must be a numeric string",
+          retryable: false,
+        });
+      }
+
+      // ── Step 2: Optional SIP-018 auth ─────────────────────────────────
+      if (body.auth) {
+        const stxVerifyService = new StxVerifyService(logger, c.env.STACKS_NETWORK);
+        const authError = stxVerifyService.verifySip018Auth(body.auth, "relay");
+        if (authError) {
+          c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+          return this.err(c, {
+            error: authError.error,
+            code: authError.code,
+            status: 401,
+            retryable: false,
+          });
+        }
+      }
+
+      // ── Step 3: Validate & sponsor payment transaction ────────────────
+      const sponsorService = new SponsorService(c.env, logger);
+      const settlementService = new SettlementService(c.env, logger);
+
+      const settleValidation = settlementService.validateSettleOptions(body.settle);
+      if (settleValidation.valid === false) {
+        c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+        return this.err(c, {
+          error: settleValidation.error,
+          code: "INVALID_SETTLE_OPTIONS",
+          status: 400,
+          details: settleValidation.details,
+          retryable: false,
+        });
+      }
+
+      const validation = sponsorService.validateTransaction(body.transaction);
+      if (validation.valid === false) {
+        c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+        const code = validation.error === "Transaction must be sponsored"
+          ? "NOT_SPONSORED"
+          : "INVALID_TRANSACTION";
+        return this.err(c, {
+          error: validation.error,
+          code,
+          status: 400,
+          details: validation.details,
+          retryable: false,
+        });
+      }
+
+      if (!checkRateLimit(validation.senderAddress)) {
+        c.executionCtx.waitUntil(statsService.recordError("rateLimit").catch(() => {}));
+        return this.err(c, {
+          error: "Rate limit exceeded",
+          code: "RATE_LIMIT_EXCEEDED",
+          status: 429,
+          details: `Maximum ${RATE_LIMIT} requests per minute`,
+          retryable: true,
+          retryAfter: 60,
+        });
+      }
+
+      // Dedup check
+      const dedupResult = await settlementService.checkDedup(body.transaction);
+      if (dedupResult) {
+        logger.info("Inbox dedup hit on payment tx", { txid: dedupResult.txid });
+        // Payment already processed — still need to post the message
+        // Fall through to inbox posting below with the existing payment data
+      }
+
+      let paymentTxid: string;
+      let settlement: SettlementResult;
+      let sponsoredTxHex: string | undefined;
+      let receiptId: string | undefined;
+
+      if (dedupResult) {
+        paymentTxid = dedupResult.txid;
+        settlement = {
+          success: true,
+          status: dedupResult.status,
+          sender: dedupResult.sender,
+          recipient: dedupResult.recipient,
+          amount: dedupResult.amount,
+          blockHeight: dedupResult.blockHeight,
+        };
+        sponsoredTxHex = dedupResult.sponsoredTx;
+        receiptId = dedupResult.receiptId;
+      } else {
+        // Sponsor the payment transaction
+        const sponsorResult = await sponsorService.sponsorTransaction(validation.transaction);
+        if (sponsorResult.success === false) {
+          return this.sponsorFailureResponse(
+            c,
+            sponsorResult,
+            statsService.recordError("sponsoring").catch(() => {})
+          );
+        }
+
+        // Verify payment parameters
+        const verifyResult = settlementService.verifyPaymentParams(
+          sponsorResult.sponsoredTxHex,
+          body.settle
+        );
+
+        const sponsoredTx = deserializeTransaction(stripHexPrefix(sponsorResult.sponsoredTxHex));
+        const sponsorNonce = extractSponsorNonce(sponsoredTx);
+        const sponsorWalletIndex = sponsorResult.walletIndex;
+
+        if (!verifyResult.valid) {
+          if (sponsorNonce !== null) {
+            c.executionCtx.waitUntil(
+              releaseNonceDO(c.env, logger, sponsorNonce, undefined, sponsorWalletIndex).catch(() => {})
+            );
+          }
+          c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
+          return this.err(c, {
+            error: verifyResult.error,
+            code: "SETTLEMENT_VERIFICATION_FAILED",
+            status: 400,
+            details: verifyResult.details,
+            retryable: false,
+          });
+        }
+
+        // Broadcast payment
+        const RELAY_OVERHEAD_MS = 5_000;
+        const maxPollTimeMs =
+          body.settle.maxTimeoutSeconds != null && body.settle.maxTimeoutSeconds > 0
+            ? Math.max(body.settle.maxTimeoutSeconds * 1000 - RELAY_OVERHEAD_MS, 1_000)
+            : undefined;
+        const broadcastResult = await settlementService.broadcastAndConfirm(
+          verifyResult.data.transaction,
+          maxPollTimeMs
+        );
+
+        if ("error" in broadcastResult) {
+          if (sponsorNonce !== null) {
+            c.executionCtx.waitUntil(
+              releaseNonceDO(c.env, logger, sponsorNonce, undefined, sponsorWalletIndex).catch(() => {})
+            );
+          }
+          c.executionCtx.waitUntil(statsService.recordError("internal").catch(() => {}));
+
+          if (broadcastResult.nonceConflict) {
+            this.scheduleNonceResync(c, sponsorService.resyncNonceDODelayed(), logger);
+            return this.err(c, {
+              error: "Nonce conflict — resubmit with a new transaction",
+              code: "NONCE_CONFLICT",
+              status: 409,
+              details: broadcastResult.details,
+              retryable: true,
+              retryAfter: 1,
+            });
+          }
+
+          return this.err(c, {
+            error: broadcastResult.error,
+            code: broadcastResult.retryable ? "SETTLEMENT_BROADCAST_FAILED" : "SETTLEMENT_FAILED",
+            status: broadcastResult.retryable ? 502 : 422,
+            details: broadcastResult.details,
+            retryable: broadcastResult.retryable,
+            retryAfter: broadcastResult.retryable ? 5 : undefined,
+          });
+        }
+
+        // Release nonce
+        if (sponsorNonce !== null) {
+          c.executionCtx.waitUntil(
+            releaseNonceDO(c.env, logger, sponsorNonce, broadcastResult.txid, sponsorWalletIndex, sponsorResult.fee).catch(() => {})
+          );
+          c.executionCtx.waitUntil(
+            recordNonceTxid(c.env, logger, broadcastResult.txid, sponsorNonce).catch(() => {})
+          );
+        }
+
+        paymentTxid = broadcastResult.txid;
+        sponsoredTxHex = sponsorResult.sponsoredTxHex;
+
+        const senderAddress = settlementService.senderToAddress(
+          verifyResult.data.transaction,
+          c.env.STACKS_NETWORK
+        );
+
+        settlement = {
+          success: true,
+          status: broadcastResult.status,
+          sender: senderAddress,
+          recipient: verifyResult.data.recipient,
+          amount: verifyResult.data.amount,
+          blockHeight:
+            broadcastResult.status === "confirmed"
+              ? broadcastResult.blockHeight
+              : undefined,
+        };
+
+        // Store receipt + dedup
+        const receiptService = new ReceiptService(c.env.RELAY_KV, logger);
+        const newReceiptId = crypto.randomUUID();
+        const storedReceipt = await receiptService.storeReceipt({
+          receiptId: newReceiptId,
+          senderAddress: validation.senderAddress,
+          sponsoredTx: sponsorResult.sponsoredTxHex,
+          fee: sponsorResult.fee,
+          txid: broadcastResult.txid,
+          settlement,
+          settleOptions: body.settle,
+        });
+        receiptId = storedReceipt ? newReceiptId : undefined;
+
+        await settlementService.recordDedup(body.transaction, {
+          txid: broadcastResult.txid,
+          receiptId,
+          status: broadcastResult.status,
+          sender: senderAddress,
+          recipient: verifyResult.data.recipient,
+          amount: verifyResult.data.amount,
+          sponsoredTx: sponsorResult.sponsoredTxHex,
+          blockHeight:
+            broadcastResult.status === "confirmed"
+              ? broadcastResult.blockHeight
+              : undefined,
+        });
+
+        // Log payment stats
+        c.executionCtx.waitUntil(
+          statsService.logTransaction({
+            timestamp: new Date().toISOString(),
+            endpoint: "relay",
+            success: true,
+            tokenType,
+            amount: body.settle.minAmount,
+            fee: sponsorResult.fee,
+            txid: broadcastResult.txid,
+            sender: senderAddress,
+            recipient: verifyResult.data.recipient,
+            status: broadcastResult.status,
+            blockHeight:
+              broadcastResult.status === "confirmed"
+                ? broadcastResult.blockHeight
+                : undefined,
+          }).catch(() => {})
+        );
+      }
+
+      // ── Step 4: Post message to arc-inbox contract ────────────────────
+      const inboxService = new InboxService(c.env, logger);
+      const inboxResult = await inboxService.postMessage(body.content);
+
+      if (!inboxResult.success) {
+        // Payment succeeded but inbox posting failed — return partial success
+        // The payment is already broadcast, so we return the payment data
+        // along with the inbox error
+        logger.warn("Payment succeeded but inbox posting failed", {
+          paymentTxid,
+          inboxError: inboxResult.error,
+        });
+        return this.ok(c, {
+          txid: paymentTxid,
+          inboxTxid: null,
+          messageId: null,
+          settlement,
+          inboxStatus: "failed",
+          inboxError: inboxResult.error,
+          inboxDetails: inboxResult.details,
+          receiptId,
+        });
+      }
+
+      // ── Step 5: Return combined result ────────────────────────────────
+      logger.info("Inbox message posted successfully", {
+        paymentTxid,
+        inboxTxid: inboxResult.inboxTxid,
+        messageId: inboxResult.messageId,
+      });
+
+      return this.ok(c, {
+        txid: paymentTxid,
+        inboxTxid: inboxResult.inboxTxid,
+        messageId: inboxResult.messageId,
+        explorerUrl: `https://explorer.hiro.so/txid/${inboxResult.inboxTxid}?chain=${c.env.STACKS_NETWORK}`,
+        settlement,
+        inboxStatus: inboxResult.status,
+        ...(inboxResult.blockHeight !== undefined && {
+          inboxBlockHeight: inboxResult.blockHeight,
+        }),
+        receiptId,
+      });
+    } catch (e) {
+      logger.error("Unexpected error in inbox handler", {
+        error: e instanceof Error ? e.message : "Unknown error",
+      });
+      c.executionCtx.waitUntil(statsService.recordError("internal").catch(() => {}));
+      return this.err(c, {
+        error: "Internal server error",
+        code: "INTERNAL_ERROR",
+        status: 500,
+        details: e instanceof Error ? e.message : "Unknown error",
+        retryable: true,
+        retryAfter: 5,
+      });
+    }
+  }
+}

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -17,3 +17,4 @@ export { Settle } from "./settle";
 export { VerifyV2 } from "./verify-v2";
 export { Supported } from "./supported";
 export { Wallets } from "./wallets";
+export { Inbox } from "./inbox";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { fromHono } from "chanfana";
 import type { Env, AppVariables, Logger } from "./types";
 import { loggerMiddleware, authMiddleware, requireAuthMiddleware } from "./middleware";
-import { Health, Relay, Sponsor, DashboardStats, TransactionLog, Verify, Access, Provision, ProvisionStx, Fees, FeesConfig, NonceStatsEndpoint, NonceReset, NonceHistory, NonceSurgeHistory, Settle, VerifyV2, Supported, Wallets } from "./endpoints";
+import { Health, Relay, Sponsor, DashboardStats, TransactionLog, Verify, Access, Provision, ProvisionStx, Fees, FeesConfig, NonceStatsEndpoint, NonceReset, NonceHistory, NonceSurgeHistory, Settle, VerifyV2, Supported, Wallets, Inbox } from "./endpoints";
 import { dashboard } from "./dashboard";
 import { discovery } from "./routes/discovery";
 import { VERSION } from "./version";
@@ -51,6 +51,7 @@ const openapi = fromHono(app, {
       { name: "Nonce", description: "Nonce coordinator diagnostics" },
       { name: "x402 V2", description: "x402 V2 facilitator API (spec-compliant)" },
       { name: "Wallets", description: "Sponsor wallet monitoring (balance, fees, pool state)" },
+      { name: "Inbox", description: "On-chain message inbox (paid messages via arc-inbox contract)" },
     ],
     servers: [
       {
@@ -101,6 +102,7 @@ openapi.post("/settle", Settle as unknown as typeof Settle);
 openapi.post("/verify", VerifyV2 as unknown as typeof VerifyV2);
 openapi.get("/supported", Supported as unknown as typeof Supported);
 openapi.get("/wallets", Wallets as unknown as typeof Wallets);
+openapi.post("/inbox", Inbox as unknown as typeof Inbox);
 
 // Mount dashboard routes (HTML pages, not OpenAPI)
 app.route("/dashboard", dashboard);
@@ -140,6 +142,7 @@ app.get("/", (c) => {
       settle: "POST /settle - x402 V2 facilitator settle",
       verifyV2: "POST /verify - x402 V2 facilitator verify",
       supported: "GET /supported - x402 V2 supported payment kinds",
+      inbox: "POST /inbox - Post paid message to on-chain inbox (arc-inbox contract)",
     },
     payment: {
       tokens: ["STX", "sBTC", "USDCx"],

--- a/src/services/inbox.ts
+++ b/src/services/inbox.ts
@@ -1,0 +1,493 @@
+/**
+ * InboxService — builds and broadcasts contract-calls to the arc-inbox contract.
+ *
+ * After validating an x402 payment, this service constructs a `post-message`
+ * contract-call signed by the sponsor wallet and broadcasts it to the Stacks
+ * network. The sponsor wallet becomes tx-sender on-chain, acting as the
+ * relay intermediary. The payment tx proves who actually sent the message.
+ */
+
+import {
+  makeContractCall,
+  getAddressFromPrivateKey,
+  stringUtf8CV,
+  type StacksTransactionWire,
+} from "@stacks/transactions";
+import { STACKS_MAINNET, STACKS_TESTNET } from "@stacks/network";
+import {
+  generateWallet,
+} from "@stacks/wallet-sdk";
+import type { Env, Logger } from "../types";
+import { getHiroBaseUrl, getHiroHeaders } from "../utils";
+
+/**
+ * arc-inbox contract addresses per network.
+ * Deployer: SP2GHQRCRMYY4S8PMBR49BEKX144VR437YT42SF3B (arc0.btc)
+ */
+const ARC_INBOX_CONTRACT = {
+  mainnet: {
+    address: "SP2GHQRCRMYY4S8PMBR49BEKX144VR437YT42SF3B",
+    name: "arc-inbox",
+  },
+  testnet: {
+    address: "ST2GHQRCRMYY4S8PMBR49BEKX144VR437YMPD0AEH",
+    name: "arc-inbox",
+  },
+} as const;
+
+/** Maximum message content length (matches contract's string-utf8 1024) */
+export const MAX_CONTENT_LENGTH = 1024;
+
+/** Minimum payment: 1 STX = 1_000_000 microSTX */
+export const MIN_PAYMENT_STX = "1000000";
+
+/** Minimum payment: 1000 sats sBTC */
+export const MIN_PAYMENT_SBTC = "1000";
+
+/** Timeout for Hiro API read-only call (ms) */
+const HIRO_READ_TIMEOUT_MS = 10_000;
+/** Timeout for Hiro API nonce fetch (ms) */
+const HIRO_NONCE_TIMEOUT_MS = 10_000;
+/** Timeout for Hiro API broadcast (ms) */
+const HIRO_BROADCAST_TIMEOUT_MS = 12_000;
+/** Timeout for Hiro API poll (ms) */
+const HIRO_POLL_TIMEOUT_MS = 10_000;
+
+/** Polling configuration */
+const MAX_POLL_TIME_MS = 30_000;
+const INITIAL_POLL_DELAY_MS = 2_000;
+const POLL_BACKOFF_FACTOR = 1.5;
+const MAX_POLL_DELAY_MS = 8_000;
+
+/** Broadcast retry configuration */
+const BROADCAST_MAX_ATTEMPTS = 3;
+const BROADCAST_RETRY_BASE_DELAY_MS = 1_000;
+const BROADCAST_RETRY_MAX_DELAY_MS = 2_000;
+
+export interface InboxPostResult {
+  success: true;
+  inboxTxid: string;
+  messageId: number;
+  status: "pending" | "confirmed";
+  blockHeight?: number;
+}
+
+export interface InboxPostFailure {
+  success: false;
+  error: string;
+  details: string;
+  retryable: boolean;
+}
+
+export type InboxPostOutcome = InboxPostResult | InboxPostFailure;
+
+/**
+ * Module-level cache for derived keys (same pattern as SponsorService).
+ * Worker instances restart on secret updates — safe to cache indefinitely.
+ */
+const cachedInboxKeys: Map<number, string> = new Map();
+
+export class InboxService {
+  private env: Env;
+  private logger: Logger;
+
+  constructor(env: Env, logger: Logger) {
+    this.env = env;
+    this.logger = logger;
+  }
+
+  private getNetwork() {
+    return this.env.STACKS_NETWORK === "mainnet"
+      ? STACKS_MAINNET
+      : STACKS_TESTNET;
+  }
+
+  private getContract() {
+    return ARC_INBOX_CONTRACT[this.env.STACKS_NETWORK];
+  }
+
+  /**
+   * Derive the sponsor wallet private key for inbox contract-calls.
+   * Uses wallet index 0 (primary sponsor wallet).
+   */
+  private async getSponsorKey(): Promise<string | null> {
+    const cached = cachedInboxKeys.get(0);
+    if (cached) return cached;
+
+    if (this.env.SPONSOR_MNEMONIC) {
+      const words = this.env.SPONSOR_MNEMONIC.trim().split(/\s+/);
+      if (words.length !== 12 && words.length !== 24) {
+        this.logger.error("Invalid SPONSOR_MNEMONIC for inbox service");
+        return null;
+      }
+      try {
+        const wallet = await generateWallet({
+          secretKey: this.env.SPONSOR_MNEMONIC,
+          password: "",
+        });
+        const account = wallet.accounts[0];
+        if (!account) return null;
+        cachedInboxKeys.set(0, account.stxPrivateKey);
+        return account.stxPrivateKey;
+      } catch (e) {
+        this.logger.error("Failed to derive inbox sponsor key", {
+          error: e instanceof Error ? e.message : String(e),
+        });
+        return null;
+      }
+    }
+
+    if (this.env.SPONSOR_PRIVATE_KEY) {
+      cachedInboxKeys.set(0, this.env.SPONSOR_PRIVATE_KEY);
+      return this.env.SPONSOR_PRIVATE_KEY;
+    }
+
+    return null;
+  }
+
+  /**
+   * Fetch the current message-count from the arc-inbox contract.
+   * Returns null if the read-only call fails (contract may not be deployed).
+   */
+  async getMessageCount(): Promise<number | null> {
+    const contract = this.getContract();
+    const hiroBase = getHiroBaseUrl(this.env.STACKS_NETWORK);
+    const url = `${hiroBase}/v2/contracts/call-read/${contract.address}/${contract.name}/get-message-count`;
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...getHiroHeaders(this.env.HIRO_API_KEY),
+        },
+        body: JSON.stringify({
+          sender: contract.address,
+          arguments: [],
+        }),
+        signal: AbortSignal.timeout(HIRO_READ_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        this.logger.warn("Failed to read message-count from contract", {
+          status: response.status,
+        });
+        return null;
+      }
+
+      const data = (await response.json()) as {
+        okay?: boolean;
+        result?: string;
+      };
+
+      if (!data.okay || !data.result) {
+        this.logger.warn("Contract read-only call returned not-okay", { data });
+        return null;
+      }
+
+      // Result is a Clarity hex value. For uint, format is 0x0100000000000000000000000000000005
+      // Type prefix 01 = uint, followed by 16 hex chars (128-bit big-endian)
+      const hex = data.result.replace("0x", "");
+      if (hex.startsWith("01") && hex.length === 34) {
+        const valueHex = hex.slice(2); // strip type prefix
+        return Number(BigInt("0x" + valueHex));
+      }
+
+      this.logger.warn("Unexpected message-count result format", {
+        result: data.result,
+      });
+      return null;
+    } catch (e) {
+      this.logger.warn("Error fetching message-count", {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Fetch the current nonce for the sponsor wallet from Hiro API.
+   * Uses direct Hiro fetch (not NonceDO) to avoid nonce pool conflicts
+   * with the main sponsoring flow.
+   */
+  private async fetchNonce(address: string): Promise<bigint | null> {
+    const url = `${getHiroBaseUrl(this.env.STACKS_NETWORK)}/v2/accounts/${address}?proof=0`;
+    try {
+      const response = await fetch(url, {
+        headers: getHiroHeaders(this.env.HIRO_API_KEY),
+        signal: AbortSignal.timeout(HIRO_NONCE_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        this.logger.warn("Failed to fetch nonce for inbox tx", {
+          status: response.status,
+        });
+        return null;
+      }
+      const data = (await response.json()) as { nonce?: number };
+      if (typeof data?.nonce !== "number") return null;
+      return BigInt(data.nonce);
+    } catch (e) {
+      this.logger.warn("Error fetching inbox nonce", {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Build, sign, and broadcast a contract-call to arc-inbox.post-message.
+   *
+   * The sponsor wallet (index 0) is the signer — it becomes tx-sender on-chain.
+   * This is a regular (non-sponsored) transaction; the relay pays its own fee.
+   */
+  async postMessage(content: string): Promise<InboxPostOutcome> {
+    // Validate content
+    if (!content || content.length === 0) {
+      return {
+        success: false,
+        error: "Empty message content",
+        details: "Content must not be empty",
+        retryable: false,
+      };
+    }
+    if (content.length > MAX_CONTENT_LENGTH) {
+      return {
+        success: false,
+        error: "Message content too long",
+        details: `Content length ${content.length} exceeds maximum ${MAX_CONTENT_LENGTH}`,
+        retryable: false,
+      };
+    }
+
+    // Get sponsor key
+    const sponsorKey = await this.getSponsorKey();
+    if (!sponsorKey) {
+      return {
+        success: false,
+        error: "Inbox service not configured",
+        details: "Set SPONSOR_MNEMONIC or SPONSOR_PRIVATE_KEY",
+        retryable: false,
+      };
+    }
+
+    const network = this.getNetwork();
+    const contract = this.getContract();
+    const senderAddress = getAddressFromPrivateKey(sponsorKey, network);
+
+    // Fetch nonce
+    const nonce = await this.fetchNonce(senderAddress);
+    if (nonce === null) {
+      return {
+        success: false,
+        error: "Failed to fetch nonce for inbox transaction",
+        details: "Could not determine nonce from Hiro API",
+        retryable: true,
+      };
+    }
+
+    // Get current message count for estimated messageId
+    const currentCount = await this.getMessageCount();
+    const estimatedMessageId = currentCount !== null ? currentCount + 1 : 0;
+
+    // Build the contract-call transaction
+    let transaction: StacksTransactionWire;
+    try {
+      transaction = await makeContractCall({
+        contractAddress: contract.address,
+        contractName: contract.name,
+        functionName: "post-message",
+        functionArgs: [stringUtf8CV(content)],
+        senderKey: sponsorKey,
+        network,
+        nonce,
+      });
+    } catch (e) {
+      this.logger.error("Failed to build inbox contract-call", {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return {
+        success: false,
+        error: "Failed to build contract-call",
+        details: e instanceof Error ? e.message : String(e),
+        retryable: false,
+      };
+    }
+
+    // Broadcast
+    const broadcastResult = await this.broadcastAndPoll(transaction);
+    if (!broadcastResult.success) {
+      return broadcastResult;
+    }
+
+    return {
+      success: true,
+      inboxTxid: broadcastResult.txid,
+      messageId: estimatedMessageId,
+      status: broadcastResult.status,
+      blockHeight: broadcastResult.blockHeight,
+    };
+  }
+
+  /**
+   * Broadcast a signed transaction and poll for confirmation.
+   * Simplified version of SettlementService.broadcastAndConfirm for
+   * relay-originated transactions.
+   */
+  private async broadcastAndPoll(
+    transaction: StacksTransactionWire
+  ): Promise<
+    | { success: true; txid: string; status: "pending" | "confirmed"; blockHeight?: number }
+    | { success: false; error: string; details: string; retryable: boolean }
+  > {
+    const txHex = transaction.serialize();
+    if (typeof txHex !== "string" || txHex.length === 0) {
+      return {
+        success: false,
+        error: "Failed to serialize transaction",
+        details: "Serialized transaction is empty",
+        retryable: false,
+      };
+    }
+
+    const bytePairs = txHex.match(/.{2}/g);
+    if (!bytePairs) {
+      return {
+        success: false,
+        error: "Failed to serialize transaction",
+        details: "Could not convert hex to bytes",
+        retryable: false,
+      };
+    }
+    const txBytes = new Uint8Array(bytePairs.map((b) => parseInt(b, 16)));
+
+    const hiroBaseUrl = getHiroBaseUrl(this.env.STACKS_NETWORK);
+    const broadcastUrl = `${hiroBaseUrl}/v2/transactions`;
+    const headers: Record<string, string> = {
+      "Content-Type": "application/octet-stream",
+      ...getHiroHeaders(this.env.HIRO_API_KEY),
+    };
+
+    let txid = "";
+
+    // Broadcast with retries
+    for (let attempt = 1; attempt <= BROADCAST_MAX_ATTEMPTS; attempt++) {
+      try {
+        const response = await fetch(broadcastUrl, {
+          method: "POST",
+          headers,
+          body: txBytes,
+          signal: AbortSignal.timeout(HIRO_BROADCAST_TIMEOUT_MS),
+        });
+
+        const responseText = await response.text();
+
+        if (response.ok) {
+          try {
+            txid = JSON.parse(responseText) as string;
+          } catch {
+            txid = responseText.trim().replace(/^"|"$/g, "");
+          }
+          this.logger.info("Inbox contract-call broadcast successful", { txid, attempt });
+          break;
+        }
+
+        // 4xx: don't retry
+        if (response.status >= 400 && response.status < 500) {
+          return {
+            success: false,
+            error: "Inbox broadcast rejected",
+            details: responseText.slice(0, 500),
+            retryable: false,
+          };
+        }
+
+        // 5xx: retry
+        if (attempt < BROADCAST_MAX_ATTEMPTS) {
+          const delay = attempt === 1
+            ? BROADCAST_RETRY_BASE_DELAY_MS
+            : BROADCAST_RETRY_MAX_DELAY_MS;
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      } catch (e) {
+        if (attempt === BROADCAST_MAX_ATTEMPTS) {
+          return {
+            success: false,
+            error: "Inbox broadcast failed",
+            details: e instanceof Error ? e.message : String(e),
+            retryable: true,
+          };
+        }
+        const delay = attempt === 1
+          ? BROADCAST_RETRY_BASE_DELAY_MS
+          : BROADCAST_RETRY_MAX_DELAY_MS;
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    }
+
+    if (!txid) {
+      return {
+        success: false,
+        error: "Inbox broadcast failed after all attempts",
+        details: "No txid received",
+        retryable: true,
+      };
+    }
+
+    // Poll for confirmation (shorter timeout than relay — 30s)
+    const pollUrl = `${hiroBaseUrl}/extended/v1/tx/${txid}`;
+    const hiroHeaders = getHiroHeaders(this.env.HIRO_API_KEY);
+    const startTime = Date.now();
+    let delay = 0;
+
+    while (true) {
+      const elapsed = Date.now() - startTime;
+      if (elapsed >= MAX_POLL_TIME_MS) {
+        return { success: true, txid, status: "pending" };
+      }
+
+      if (delay > 0) {
+        const remaining = MAX_POLL_TIME_MS - (Date.now() - startTime);
+        if (remaining <= 0) break;
+        await new Promise((r) => setTimeout(r, Math.min(delay, remaining)));
+      }
+
+      try {
+        const remaining = MAX_POLL_TIME_MS - (Date.now() - startTime);
+        if (remaining <= 0) break;
+        const response = await fetch(pollUrl, {
+          headers: hiroHeaders,
+          signal: AbortSignal.timeout(Math.min(HIRO_POLL_TIMEOUT_MS, remaining)),
+        });
+
+        if (response.ok) {
+          const data = (await response.json()) as {
+            tx_status?: string;
+            block_height?: number;
+          };
+          if (data.tx_status === "success" && typeof data.block_height === "number") {
+            return {
+              success: true,
+              txid,
+              status: "confirmed",
+              blockHeight: data.block_height,
+            };
+          }
+          if (data.tx_status?.startsWith("abort_")) {
+            return {
+              success: false,
+              error: "Inbox transaction aborted on-chain",
+              details: `tx_status: ${data.tx_status}`,
+              retryable: false,
+            };
+          }
+        }
+      } catch {
+        // Network error during polling — continue
+      }
+
+      delay = delay === 0 ? INITIAL_POLL_DELAY_MS : Math.min(delay * POLL_BACKOFF_FACTOR, MAX_POLL_DELAY_MS);
+    }
+
+    return { success: true, txid, status: "pending" };
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -36,3 +36,7 @@ export { SettlementService } from "./settlement";
 export { SettlementHealthService } from "./settlement-health";
 
 export { PaymentIdService } from "./payment-identifier";
+
+export { InboxService } from "./inbox";
+export type { InboxPostResult, InboxPostFailure, InboxPostOutcome } from "./inbox";
+export { MAX_CONTENT_LENGTH, MIN_PAYMENT_STX, MIN_PAYMENT_SBTC } from "./inbox";

--- a/src/types.ts
+++ b/src/types.ts
@@ -473,6 +473,20 @@ export interface RelayRequest {
 }
 
 /**
+ * Request body for /inbox endpoint
+ */
+export interface InboxRequest {
+  /** Message content (max 1024 UTF-8 characters) */
+  content: string;
+  /** Hex-encoded signed sponsored payment transaction (STX or sBTC transfer) */
+  transaction: string;
+  /** Settlement options for payment validation */
+  settle: SettleOptions;
+  /** Optional SIP-018 authentication */
+  auth?: Sip018Auth;
+}
+
+/**
  * Settlement result in API response format
  */
 export interface SettlementResult {
@@ -578,7 +592,10 @@ export type RelayErrorCode =
   | "NONCE_RESET_FAILED"
   | "NONCE_DO_UNAVAILABLE"
   | "UNSUPPORTED_ADDRESS_TYPE"
-  | "INVALID_BTC_ADDRESS";
+  | "INVALID_BTC_ADDRESS"
+  | "MISSING_CONTENT"
+  | "EMPTY_CONTENT"
+  | "CONTENT_TOO_LONG";
 
 /**
  * Structured error response with retry guidance


### PR DESCRIPTION
## Summary

- Adds `POST /inbox` endpoint that accepts paid messages and posts them on-chain via the `arc-inbox` Clarity contract
- New `InboxService` builds and broadcasts `post-message` contract-calls using the sponsor wallet
- Payment validation reuses existing relay settlement flow (SponsorService + SettlementService)
- Supports STX (min 1 STX) and sBTC (min 1000 sats) payments

## Design

The endpoint combines two operations:
1. **Payment settlement** — validates and broadcasts the agent's x402 payment transaction (standard relay flow)
2. **Message posting** — builds a contract-call to `arc-inbox.post-message(content)` signed by the sponsor wallet and broadcasts it

The sponsor wallet becomes `tx-sender` on-chain. The payment transaction proves who actually sent the message. Returns both txids so agents can track both operations.

## New Files

- `src/endpoints/inbox.ts` — POST /inbox handler with OpenAPI schema, content validation, payment settlement, and inbox orchestration
- `src/services/inbox.ts` — InboxService: contract-call construction, nonce fetching (direct Hiro, avoids NonceDO conflicts), broadcast + poll

## Modified Files

- `src/types.ts` — InboxRequest interface, new error codes (MISSING_CONTENT, EMPTY_CONTENT, CONTENT_TOO_LONG)
- `src/index.ts` — Route registration, OpenAPI tag, service info
- `src/endpoints/index.ts` — Barrel export
- `src/services/index.ts` — Barrel export

## Dependencies

- Requires `arc-inbox` contract deployed on Stacks (built in parent task #7064)
- Contract address: `SP2GHQRCRMYY4S8PMBR49BEKX144VR437YT42SF3B.arc-inbox`
- Uses existing `@stacks/transactions` makeContractCall + stringUtf8CV

## Test plan

- [ ] Type check passes (`tsc --noEmit` — no new errors)
- [ ] Deploy to staging after arc-inbox contract is deployed on testnet
- [ ] Test with sponsored STX payment + message content
- [ ] Test with sponsored sBTC payment + message content
- [ ] Verify message appears on-chain via `get-message` read-only call
- [ ] Test error cases: empty content, content > 1024 chars, insufficient payment

🤖 Generated with [Claude Code](https://claude.com/claude-code)