### PR TITLE
fix(nonce-do): resolve RBF broadcast failures for stuck wallets

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -603,23 +603,29 @@ export class NonceDO {
     // Non-OK: try to parse JSON error, fall back to raw text
     let reason = `http_${response.status}`;
     let body = responseText.slice(0, 500);
+    let parsedJson = false;
     try {
       const errorJson = JSON.parse(responseText) as {
         error?: string;
         reason?: string;
         reason_data?: unknown;
       };
+      parsedJson = true;
       if (errorJson.reason) reason = errorJson.reason;
       if (errorJson.error) body = errorJson.error;
     } catch {
       // Non-JSON response — keep raw text (could be HTML error page)
     }
 
-    this.log("warn", `${context}_raw_response`, {
-      httpStatus: response.status,
-      reason,
-      body: responseText.slice(0, 500),
-    });
+    // Only log here for unexpected cases (5xx or non-JSON responses).
+    // Callers log expected outcomes (ConflictingNonceInMempool, BadNonce) at appropriate levels.
+    if (response.status >= 500 || !parsedJson) {
+      this.log("warn", `${context}_raw_response`, {
+        httpStatus: response.status,
+        reason,
+        body: responseText.slice(0, 500),
+      });
+    }
 
     return { ok: false, status: response.status, reason, body };
   }
@@ -747,8 +753,8 @@ export class NonceDO {
       // Cap attempts to prevent further retries — the reconcile loop's
       // last_executed_tx_nonce check will mark it confirmed on the next cycle.
       if (result.reason === "BadNonce") {
-        state.rbfAttempts = MAX_RBF_ATTEMPTS;
-        await this.state.storage.put(key, state);
+        // Terminal — delete stuck-tx state entirely to avoid orphaned entries
+        await this.state.storage.delete(key);
         this.log("info", "rbf_nonce_consumed", {
           walletIndex,
           nonce,
@@ -2595,6 +2601,7 @@ export class NonceDO {
             // Clean up stuck-tx state for aborted nonce
             const abortStuckKey = this.walletStuckTxKey(walletIndex, nonce);
             await this.state.storage.delete(abortStuckKey);
+            verdictRbfCandidate--;
             continue;
           }
           if (txStatus === "success") {


### PR DESCRIPTION
## Summary

- Replace `broadcastTransaction()` from `@stacks/transactions` with direct `fetch()` to `/v2/transactions` in NonceDO's gap-fill and RBF broadcast methods. The library function throws a generic "unable to parse node response" error on non-JSON node responses, losing all diagnostic info (HTTP status, response body, rejection reason).
- Add `last_executed_tx_nonce` guard before RBF attempts — if a nonce is already consumed on-chain, mark it confirmed and clean up stuck-tx state instead of broadcasting a doomed RBF.
- Handle `BadNonce` node rejections by capping RBF attempts immediately.
- Clean up orphaned `StuckTxState` entries on all terminal paths (abort, confirm, consumed).

Fixes #184

## Root Cause

Three sponsor wallets (0, 1, 4) were stuck in endless RBF cycles because:
1. `broadcastTransaction()` swallowed the raw node response on non-JSON bodies, logging only "unable to parse node response" with no HTTP status or rejection reason
2. The RBF candidate check only looked at the original txid's status via Hiro, not whether the nonce itself was already consumed (`last_executed_tx_nonce`)

## Changes

| File | Change |
|------|--------|
| `src/durable-objects/nonce-do.ts` | New `broadcastRawTx()` helper using direct fetch; updated `fillGapNonce()` and `broadcastRbfForNonce()`; added `last_executed_tx_nonce` guard; `BadNonce` handling; stuck-tx cleanup |

## Test plan

- [ ] `npm run check` passes (verified)
- [ ] `npm run deploy:dry-run` succeeds (verified)
- [ ] Deploy to staging and monitor logs for:
  - `gap_fill_raw_response` / `rbf_raw_response` log entries showing raw HTTP status and body
  - `reconcile_nonce_already_executed` entries for nonces that were stuck
  - `rbf_nonce_consumed` entries if BadNonce rejections occur
  - Stuck wallets (0, 1, 4) recovering and re-entering rotation
- [ ] Verify wallets 2, 3 continue operating normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)