### PR TITLE
chore: simplify nested ternary and round effectiveCapacity

### DIFF
--- a/src/endpoints/health.ts
+++ b/src/endpoints/health.ts
@@ -201,7 +201,8 @@ export class Health extends BaseEndpoint {
 
       const totalPool = raw.poolAvailable + raw.poolReserved;
       // When pool is idle (nothing reserved), treat as fully available
-      const effectiveCapacity = totalPool === 0 ? 1.0 : raw.poolAvailable / totalPool;
+      const effectiveCapacity =
+        totalPool === 0 ? 1.0 : Math.round((raw.poolAvailable / totalPool) * 100) / 100;
       const poolStatus = derivePoolStatus(effectiveCapacity, circuitBreakerOpen);
 
       return {

--- a/src/services/sponsor.ts
+++ b/src/services/sponsor.ts
@@ -669,7 +669,14 @@ export class SponsorService {
         // Propagate specific error codes from NonceDO (e.g. 429 CHAINING_LIMIT_EXCEEDED, 503 LOW_HEADROOM)
         const isChainingLimit = doResult.code === "CHAINING_LIMIT_EXCEEDED";
         const isLowHeadroom = doResult.code === "LOW_HEADROOM";
-        const code = isChainingLimit ? "RATE_LIMIT_EXCEEDED" : isLowHeadroom ? "LOW_HEADROOM" : "NONCE_DO_UNAVAILABLE";
+        let code: string;
+        if (isChainingLimit) {
+          code = "RATE_LIMIT_EXCEEDED";
+        } else if (isLowHeadroom) {
+          code = "LOW_HEADROOM";
+        } else {
+          code = "NONCE_DO_UNAVAILABLE";
+        }
         this.logger.error("NonceDO nonce assignment failed", {
           code: doResult.code,
           error: doResult.error,


### PR DESCRIPTION
## Summary
- Replace nested ternary in sponsor.ts with if/else chain for clarity
- Round effectiveCapacity to 2 decimal places for cleaner API response

Post-merge cleanup from PRs #192 and #194.

## Test plan
- [x] `npm run check` passes
- [x] `npm run deploy:dry-run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)