### PR TITLE
fix(sponsor): add broadcast retry with backoff and raw response logging

### DIFF
--- a/src/endpoints/sponsor.ts
+++ b/src/endpoints/sponsor.ts
@@ -296,7 +296,7 @@ export class Sponsor extends BaseEndpoint {
       );
 
       if (!broadcastResult.success) {
-        const { errorMessage, errorDetails, httpStatus, isNonceConflict, clientRejection } = broadcastResult;
+        const { errorMessage, errorDetails, httpStatus, isNonceConflict, clientRejection, nodeUrl } = broadcastResult;
         const isClientError = clientRejection !== undefined;
 
         c.executionCtx.waitUntil(statsService.recordError(isClientError ? "validation" : "sponsoring").catch(() => {}));
@@ -305,11 +305,10 @@ export class Sponsor extends BaseEndpoint {
         // Record broadcast outcome in the intent ledger.
         // httpStatus 0 = network/timeout exception (no HTTP response received).
         if (sponsorNonce !== null) {
-          const rejectHttpStatus = httpStatus;
           c.executionCtx.waitUntil(
             recordBroadcastOutcomeDO(
               c.env, logger, sponsorNonce, sponsorWalletIndex,
-              undefined, rejectHttpStatus, undefined, errorDetails
+              undefined, httpStatus, nodeUrl, errorDetails
             ).catch((e) => {
               logger.warn("Failed to record broadcast outcome", { error: String(e) });
             })


### PR DESCRIPTION
## Summary

- Replace library `broadcastTransaction()` with raw `fetch()` to `/v2/transactions` on the `/sponsor` endpoint, adding retry with backoff and node failover (same strategy as `/relay` via SettlementService)
- Log raw response body, status code, and content-type when Hiro returns non-JSON error responses for faster upstream diagnosis
- Extract helper methods (`parseTxid`, `parseErrorBody`, `handle4xxRejection`, `logRetriableFailure`, `retryDelay`) for cleaner broadcast logic

Closes #210
Closes #211

## Test plan

- [ ] `npm run check` passes (type check)
- [ ] `npm run deploy:dry-run` passes (build verification)
- [ ] Deploy to staging and verify `/sponsor` endpoint works for normal broadcasts
- [ ] Verify retry behavior: 5xx responses trigger up to 3 retries per node with 1s/2s backoff
- [ ] Verify 4xx responses (nonce conflicts, client errors) fail fast without retry
- [ ] Verify non-JSON error responses are logged with `bodyPreview` and `contentType` fields
- [ ] Verify node failover works when primary Hiro node returns repeated 5xx errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)