### PR TITLE
feat: improve nonce pool resilience under burst traffic

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -1340,6 +1340,9 @@ export class NonceDO {
       this.cascadeQuarantineKey
     )) ?? [];
     const pruned = existing.filter((e) => new Date(e.ts).getTime() >= cutoff);
+    if (pruned.length !== existing.length) {
+      await this.state.storage.put(this.cascadeQuarantineKey, pruned);
+    }
     return pruned.length >= CASCADE_DETECTION_THRESHOLD;
   }
 

--- a/src/endpoints/BaseEndpoint.ts
+++ b/src/endpoints/BaseEndpoint.ts
@@ -256,7 +256,7 @@ export class BaseEndpoint extends OpenAPIRoute {
    * wallets have their circuit breaker open. Returns 30 (neutral default) if NonceDO
    * is not configured or the call fails, so this never blocks the error path.
    */
-  protected async getPoolPressureRetryAfter(env: Env, logger: Logger): Promise<number> {
+  protected async getPoolPressureRetryAfter(env: Env): Promise<number> {
     if (!env.NONCE_DO) {
       return 30;
     }

--- a/src/endpoints/relay.ts
+++ b/src/endpoints/relay.ts
@@ -293,11 +293,33 @@ export class Relay extends BaseEndpoint {
         });
       }
 
-      // Step A0 — Sender conflict dedup: short-circuit if sender is in a conflict cooldown.
-      // If the same sender got a 409/429 (nonce conflict or too-much-chaining) within the
-      // last retryAfter seconds, return the cached error without assigning a nonce or hitting
-      // the mempool. This prevents the assign→broadcast→conflict→quarantine cycle from
-      // repeating on every agent retry during a nonce storm.
+      // Step A — Dedup check on original tx (stable across retries with different sponsor nonces).
+      // Runs before the conflict cooldown so that idempotent retries of already-succeeded
+      // transactions return the cached success even if the sender is in a conflict window.
+      const dedupResult = await settlementService.checkDedup(body.transaction);
+      if (dedupResult) {
+        logger.info("Dedup hit, returning cached result", {
+          txid: dedupResult.txid,
+          status: dedupResult.status,
+        });
+        return this.okWithTx(c, {
+          txid: dedupResult.txid,
+          settlement: {
+            success: true,
+            status: dedupResult.status,
+            sender: dedupResult.sender,
+            recipient: dedupResult.recipient,
+            amount: dedupResult.amount,
+            blockHeight: dedupResult.blockHeight,
+          },
+          sponsoredTx: dedupResult.sponsoredTx,
+          receiptId: dedupResult.receiptId,
+        });
+      }
+
+      // Step A1 — Sender conflict cooldown: short-circuit if sender recently hit a nonce
+      // conflict or too-much-chaining error. Prevents the assign→broadcast→conflict→quarantine
+      // cycle from repeating on every agent retry during a nonce storm.
       const senderConflictKey = `conflict:${validation.senderAddress}`;
       const cachedConflict = c.env.RELAY_KV ? await c.env.RELAY_KV.get(senderConflictKey, "text") : null;
       if (cachedConflict) {
@@ -326,28 +348,6 @@ export class Relay extends BaseEndpoint {
         } catch {
           // Malformed KV value — ignore and proceed normally
         }
-      }
-
-      // Step A — Dedup check on original tx (stable across retries with different sponsor nonces)
-      const dedupResult = await settlementService.checkDedup(body.transaction);
-      if (dedupResult) {
-        logger.info("Dedup hit, returning cached result", {
-          txid: dedupResult.txid,
-          status: dedupResult.status,
-        });
-        return this.okWithTx(c, {
-          txid: dedupResult.txid,
-          settlement: {
-            success: true,
-            status: dedupResult.status,
-            sender: dedupResult.sender,
-            recipient: dedupResult.recipient,
-            amount: dedupResult.amount,
-            blockHeight: dedupResult.blockHeight,
-          },
-          sponsoredTx: dedupResult.sponsoredTx,
-          receiptId: dedupResult.receiptId,
-        });
       }
 
       // Step B — Sponsor the transaction
@@ -619,7 +619,7 @@ export class Relay extends BaseEndpoint {
           // Retry did not succeed — schedule a delayed resync so the pool self-heals,
           // then return the appropriate error code.
           this.scheduleNonceResync(c, sponsorService.resyncNonceDODelayed(), logger);
-          const conflictTtl = await this.getPoolPressureRetryAfter(c.env, logger);
+          const conflictTtl = await this.getPoolPressureRetryAfter(c.env);
           const conflictCode = broadcastResult.nonceConflict ? "NONCE_CONFLICT" as const : "TOO_MUCH_CHAINING" as const;
           this.writeSenderConflict(c, validation.senderAddress, conflictCode, conflictTtl, logger);
           const isConflict = conflictCode === "NONCE_CONFLICT";
@@ -774,21 +774,6 @@ export class Relay extends BaseEndpoint {
   }
 
   /**
-   * Handle self-pay settlement (X-Settlement: self-pay).
-   *
-   * The caller provides a fully-signed standard (non-sponsored) transaction and
-   * covers their own network fees. The relay skips sponsoring and only:
-   *   1. Validates and deserializes the transaction (must NOT be sponsored)
-   *   2. Applies rate limiting by sender
-   *   3. Checks the dedup cache for idempotent retries
-   *   4. Verifies payment parameters (recipient, amount, token type)
-   *   5. Broadcasts and polls for confirmation
-   *   6. Records stats and dedup entry
-   *
-   * Response format is identical to the sponsored path. sponsoredTx is null
-   * since no sponsor signature was applied.
-   */
-  /**
    * Write a sender conflict record to KV so subsequent retries from the same sender
    * short-circuit without assigning a nonce or hitting the mempool.
    */
@@ -811,6 +796,21 @@ export class Relay extends BaseEndpoint {
     );
   }
 
+  /**
+   * Handle self-pay settlement (X-Settlement: self-pay).
+   *
+   * The caller provides a fully-signed standard (non-sponsored) transaction and
+   * covers their own network fees. The relay skips sponsoring and only:
+   *   1. Validates and deserializes the transaction (must NOT be sponsored)
+   *   2. Applies rate limiting by sender
+   *   3. Checks the dedup cache for idempotent retries
+   *   4. Verifies payment parameters (recipient, amount, token type)
+   *   5. Broadcasts and polls for confirmation
+   *   6. Records stats and dedup entry
+   *
+   * Response format is identical to the sponsored path. sponsoredTx is null
+   * since no sponsor signature was applied.
+   */
   private async handleSelfPay(
     c: AppContext,
     body: RelayRequest,


### PR DESCRIPTION
## Summary

Closes #241

Makes the relay self-heal during nonce storms instead of passively returning 409s and waiting for agent retries. During the 2026-03-26 storm, 9 agents created 326 NONCE_CONFLICT errors over 20 min — these changes address the root causes.

- **Inline resync+retry on `/relay`**: When a nonce conflict occurs, the relay now does `await resyncNonceDO()` + re-sponsor + re-broadcast inline (same pattern as `/settle`). Falls back to 409 only if the retry also fails.
- **Per-sender dedup window**: Short-circuits repeat requests from the same sender within the retryAfter cooldown via KV TTL. Prevents the assign→broadcast→conflict→quarantine cycle from amplifying cascades.
- **Dynamic retryAfter**: Queries NonceDO pool health to compute tiered back-off (10s/30s/60s) based on circuit breaker state instead of hardcoded 30s. Moved to `BaseEndpoint` for reuse across endpoints.
- **Cascade-aware RBF timing + alarm tuning**: RBF threshold drops from 15min → 5min (cascade) → 3min (circuit breaker open). Gap-fill limit bumps from 5 → 15 during cascades. Alarm interval drops to 20s during active cascades.

## Test plan

- [x] `npm run check` passes on all commits
- [ ] Deploy to staging, simulate burst: 10 concurrent `/relay` requests from different senders
- [ ] Verify inline resync succeeds on first conflict (check logs for "Retry after inline resync succeeded")
- [ ] Verify dedup window short-circuits repeat requests (check logs for "Sender in conflict cooldown")
- [ ] Verify retryAfter varies with pool pressure (check `Retry-After` headers)
- [ ] Monitor wallet drain time after deploying — target: <5 min vs current ~hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)