### PR TITLE
fix(nonce): fill-gaps includes first-blocker nonces before mempool

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -6149,32 +6149,46 @@ export class NonceDO {
         return this.jsonResponse({ error: "Hiro API unavailable" }, 503);
       }
 
-      const { possible_next_nonce, detected_missing_nonces } = nonceInfo;
+      const { possible_next_nonce, detected_missing_nonces, last_executed_tx_nonce } = nonceInfo;
       this.advanceChainFrontier(walletIndex, possible_next_nonce);
       const head = this.ledgerGetWalletHead(walletIndex);
 
-      // Compute gaps: Hiro-reported missing nonces + any range between
-      // last_executed and head that Hiro doesn't see (ledger-only gaps)
+      // Compute gaps: three sources
       const gapSet = new Set(detected_missing_nonces);
 
-      // Also check contiguous range from possible_next_nonce to head for
-      // nonces not in the mempool (Hiro won't report these as "missing"
-      // if it doesn't know about them)
+      // Source 2: the range between last_executed_tx_nonce and the first mempool tx.
+      // Hiro's detected_missing_nonces only reports gaps *between* mempool txs — it
+      // does not include the gap between last_executed and the first mempool nonce.
+      // This is the most critical range: a missing nonce here blocks the entire chain.
+      // Nonces already occupied in the mempool will fail with ConflictingNonceInMempool
+      // (handled as a no-op in fillGapNonce), so over-including is safe.
+      if (last_executed_tx_nonce !== null) {
+        for (let n = last_executed_tx_nonce + 1; n < possible_next_nonce; n++) {
+          gapSet.add(n);
+        }
+      }
+
+      // Source 3: contiguous range from possible_next_nonce to head for nonces not
+      // yet in the mempool (Hiro won't report these as "missing" if it doesn't know
+      // about them — ledger-only gaps above the chain frontier)
       if (head !== null && head > possible_next_nonce) {
         for (let n = possible_next_nonce; n < head; n++) {
           gapSet.add(n);
         }
       }
 
-      // Remove nonces that are already in the mempool (assigned/broadcasted/confirmed).
+      // Remove nonces that are already managed by our ledger (assigned/broadcasted/confirmed).
+      // Lower bound covers the full gap range added above (last_executed + 1 or 0).
       // 'confirmed' = broadcast accepted, still pending on-chain — same as ledgerInFlightCount.
+      const inFlightLowerBound =
+        last_executed_tx_nonce !== null ? last_executed_tx_nonce + 1 : 0;
       const inFlightRows = this.sql
         .exec<{ nonce: number }>(
           `SELECT nonce FROM nonce_intents
            WHERE wallet_index = ? AND state IN ('assigned', 'broadcasted', 'confirmed')
              AND nonce >= ?`,
           walletIndex,
-          possible_next_nonce
+          inFlightLowerBound
         )
         .toArray();
       for (const row of inFlightRows) {


### PR DESCRIPTION
## Problem

`POST /nonce/fill-gaps/:wallet` was missing the most critical gap nonces — those between `last_executed_tx_nonce` and the first mempool transaction. These are the "first blocker" nonces that prevent the entire pending chain from confirming.

Hiro's `detected_missing_nonces` only reports gaps *between* mempool txs. It does **not** include the gap between `last_executed_tx_nonce` and the first mempool nonce. The existing gap set was built from two sources:
- `detected_missing_nonces` (inter-mempool gaps)
- Range from `possible_next_nonce` to `head` (ledger-only gaps above chain frontier)

Neither covered the range `[last_executed_tx_nonce + 1, possible_next_nonce)`.

## Fix

Add a second gap source in `handleFillGaps()`: the full range from `last_executed_tx_nonce + 1` to `possible_next_nonce`. Nonces already occupied in the mempool fail harmlessly with `ConflictingNonceInMempool` (existing no-op in `fillGapNonce`), so over-including is safe. The existing `MAX_ADMIN_GAP_FILLS` cap (50) prevents runaway fills.

Also expand the in-flight filter lower bound from `possible_next_nonce` to `last_executed_tx_nonce + 1`, so relay-managed nonces in the new range are excluded via ledger lookup rather than via `ConflictingNonceInMempool`.

## Before / After

**Before** — Wallet 1 (last_executed=676, mempool=[678,680-683,685-689]):
- `detected_missing_nonces`: [679, 684]
- fill-gaps fills 679 ✓, skips 677 entirely ✗ — chain stays blocked

**After**:
- Gap range adds [677..689] to gapSet
- In-flight filter removes ledger-known nonces (678, 680-683, 685-689)
- Remaining: 677 (true gap) + 679, 684 (from detected_missing)
- fill-gaps broadcasts self-transfers for 677, 679, 684 ✓ — chain unblocked

Closes #254

## Test plan

- [ ] Verify `POST /nonce/fill-gaps/:wallet` now fills the first-blocker nonce (e.g. wallet 1 nonce 677)
- [ ] Verify `ConflictingNonceInMempool` nonces appear in `failed` (not `filled`) and don't error
- [ ] Verify truncated=true fires when gap range exceeds MAX_ADMIN_GAP_FILLS (50)
- [ ] Verify no change when `last_executed_tx_nonce` is null (fresh wallet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)