### PR TITLE
fix(health): top-level status reflects pool degradation

### DIFF
--- a/src/__tests__/health-status.test.ts
+++ b/src/__tests__/health-status.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for /health status derivation logic.
+ *
+ * Covers:
+ * - derivePoolStatus — maps (effectiveCapacity, circuitBreakerOpen) → PoolStatus
+ * - top-level status derivation — "ok" vs "degraded" based on poolStatus
+ *
+ * Pure functions inlined here (no Worker runtime, no crypto dependencies).
+ * Mirrors the logic in src/endpoints/health.ts exactly.
+ */
+
+import { describe, it, expect } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Inline mirrors of health.ts pure logic
+// These must stay in sync with src/endpoints/health.ts
+// ---------------------------------------------------------------------------
+
+const CAPACITY_HEALTHY_THRESHOLD = 0.6;
+const CAPACITY_CRITICAL_THRESHOLD = 0.2;
+
+type PoolStatus = "healthy" | "degraded" | "critical";
+
+function derivePoolStatus(effectiveCapacity: number, circuitBreakerOpen: boolean): PoolStatus {
+  if (circuitBreakerOpen || effectiveCapacity < CAPACITY_CRITICAL_THRESHOLD) {
+    return "critical";
+  }
+  if (effectiveCapacity < CAPACITY_HEALTHY_THRESHOLD) {
+    return "degraded";
+  }
+  return "healthy";
+}
+
+function deriveTopLevelStatus(poolStatus: PoolStatus | null): "ok" | "degraded" {
+  // Mirrors Health.handle():
+  //   const status = nonceState !== null && nonceState.poolStatus !== "healthy" ? "degraded" : "ok";
+  return poolStatus !== null && poolStatus !== "healthy" ? "degraded" : "ok";
+}
+
+// ---------------------------------------------------------------------------
+// derivePoolStatus
+// ---------------------------------------------------------------------------
+
+describe("derivePoolStatus", () => {
+  it("returns 'healthy' when capacity ≥ 60% and circuit breaker closed", () => {
+    expect(derivePoolStatus(1.0, false)).toBe("healthy");
+    expect(derivePoolStatus(0.6, false)).toBe("healthy");
+    expect(derivePoolStatus(0.75, false)).toBe("healthy");
+  });
+
+  it("returns 'degraded' when capacity is between 20% and 60% and circuit breaker closed", () => {
+    expect(derivePoolStatus(0.59, false)).toBe("degraded");
+    expect(derivePoolStatus(0.4, false)).toBe("degraded");
+    expect(derivePoolStatus(0.2, false)).toBe("degraded");
+  });
+
+  it("returns 'critical' when capacity < 20%", () => {
+    expect(derivePoolStatus(0.19, false)).toBe("critical");
+    expect(derivePoolStatus(0.0, false)).toBe("critical");
+  });
+
+  it("returns 'critical' when circuit breaker is open regardless of capacity", () => {
+    expect(derivePoolStatus(1.0, true)).toBe("critical");
+    expect(derivePoolStatus(0.6, true)).toBe("critical");
+    expect(derivePoolStatus(0.3, true)).toBe("critical");
+    expect(derivePoolStatus(0.0, true)).toBe("critical");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// top-level status derivation
+// ---------------------------------------------------------------------------
+
+describe("top-level status derivation", () => {
+  it("returns 'ok' when poolStatus is 'healthy'", () => {
+    expect(deriveTopLevelStatus("healthy")).toBe("ok");
+  });
+
+  it("returns 'degraded' when poolStatus is 'degraded'", () => {
+    expect(deriveTopLevelStatus("degraded")).toBe("degraded");
+  });
+
+  it("returns 'degraded' when poolStatus is 'critical'", () => {
+    // Both 'degraded' and 'critical' pool states map to top-level "degraded"
+    // so consumers checking status === "ok" correctly detect any degradation.
+    expect(deriveTopLevelStatus("critical")).toBe("degraded");
+  });
+
+  it("returns 'ok' when nonce state is unavailable (null)", () => {
+    // When the NonceDO coordinator is unreachable, we stay 'ok' and degrade
+    // gracefully — coordinator unavailability is logged separately.
+    expect(deriveTopLevelStatus(null)).toBe("ok");
+  });
+});

--- a/src/endpoints/health.ts
+++ b/src/endpoints/health.ts
@@ -18,6 +18,7 @@ type PoolStatus = "healthy" | "degraded" | "critical";
  * - "critical": circuit breaker open OR capacity < 20%
  * - "degraded": capacity < 60% (but not critical)
  * - "healthy": capacity ≥ 60% and circuit breaker closed
+ *
  */
 function derivePoolStatus(effectiveCapacity: number, circuitBreakerOpen: boolean): PoolStatus {
   if (circuitBreakerOpen || effectiveCapacity < CAPACITY_CRITICAL_THRESHOLD) {
@@ -93,7 +94,15 @@ export class Health extends BaseEndpoint {
                   format: "uuid",
                   description: "Unique request identifier for tracking",
                 },
-                status: { type: "string" as const, example: "ok" },
+                status: {
+                  type: "string" as const,
+                  enum: ["ok", "degraded"],
+                  description:
+                    "'ok' when the nonce pool is healthy, 'degraded' when poolStatus is non-healthy " +
+                    "(circuit breaker open, capacity <60%, or capacity <20%). " +
+                    "Consumers should treat any non-'ok' value as unhealthy.",
+                  example: "ok",
+                },
                 network: { type: "string" as const, example: "testnet" },
                 version: { type: "string" as const, example: VERSION },
                 nonce: {
@@ -170,8 +179,14 @@ export class Health extends BaseEndpoint {
     const logger = this.getLogger(c);
     const nonceState = await this.fetchNonceState(c, logger);
 
+    // Reflect pool degradation in the top-level status so consumers that only
+    // check `status === "ok"` correctly detect an unhealthy relay without having
+    // to dig into nonce.* fields. When nonce state is unavailable (null) we
+    // stay "ok" — the coordinator being unreachable is logged separately.
+    const status = nonceState !== null && nonceState.poolStatus !== "healthy" ? "degraded" : "ok";
+
     return this.ok(c, {
-      status: "ok",
+      status,
       network: c.env.STACKS_NETWORK,
       version: VERSION,
       nonce: nonceState,


### PR DESCRIPTION
## Problem

`GET /health` returned `status: "ok"` even when `nonce.poolStatus` was `"degraded"` or `"critical"`. All consumers check the top-level `status` field — they concluded the relay was healthy when it wasn't.

Closes #263.

## Change

In `Health.handle()`, derive `status` from `nonceState.poolStatus` instead of hardcoding `"ok"`:

```
poolStatus "healthy"               → status "ok"
poolStatus "degraded" / "critical" → status "degraded"
nonce state unavailable (null)     → status "ok"  (graceful — coordinator unreachable logged separately)
```

OpenAPI schema updated: `status` is now `enum: ["ok", "degraded"]`.

This is Option A from the issue — the one-line fix that unblocks all consumers without requiring each one to learn the `nonce.*` schema.

## Consumer impact

All downstream consumers (`aibtc-mcp-server` `isRelayHealthy()` / `checkRelayHealth()`, `skills` `relay-diagnostic.ts` / `settings.ts`, `arc-starter` `isRelayHealthy()`) already check `status === "ok"` and will now correctly report unhealthy when the pool is degraded or circuit breaker is open.

The consumer-side fix in aibtcdev/skills#263 (already approved) becomes defense-in-depth rather than the primary detection path.

## Tests

New test file `src/__tests__/health-status.test.ts` covers:
- `derivePoolStatus` thresholds (healthy ≥60%, degraded <60%, critical <20% or CB open)
- top-level status mapping for all four cases (healthy, degraded, critical, null)

All 31 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)