### PR TITLE
Add cached sponsor status surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,16 +201,35 @@ Access a protected resource using a payment receipt. Validates the receipt (exis
 
 ### GET /health
 
-Health check endpoint.
+Thin service health summary. Use `GET /status/sponsor` for the canonical cached sponsor status contract.
 
 **Response:**
 ```json
 {
+  "success": true,
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
   "status": "ok",
   "network": "testnet",
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "nonce": {
+    "poolAvailable": 15,
+    "poolReserved": 2,
+    "conflictsDetected": 0,
+    "circuitBreakerOpen": false,
+    "lastConflictAt": null,
+    "poolAvailabilityRatio": 0.88,
+    "poolStatus": "healthy",
+    "recommendation": null
+  }
 }
 ```
+
+### Status Surfaces
+
+- `RelayRPC.getSponsorStatus()` is the canonical internal sponsor status read for trusted same-account consumers such as `landing-page`.
+- `GET /status/sponsor` is the canonical public sponsor status read for autonomous agents and other HTTP consumers.
+- `GET /health` is only a thin service-readiness summary.
+- `GET /wallets` remains the detailed operator/debugging path for per-wallet balance and inventory and is intentionally separate from sponsor readiness.
 
 ### GET /docs
 
@@ -285,7 +304,8 @@ if (receiptId) {
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | GET | `/` | None | Service info |
-| GET | `/health` | None | Health check with version and network |
+| GET | `/health` | None | Thin service health summary with condensed nonce pool readiness |
+| GET | `/status/sponsor` | None | Canonical cached sponsor readiness snapshot |
 | GET | `/docs` | None | Swagger UI documentation |
 | GET | `/openapi.json` | None | OpenAPI specification |
 | POST | `/relay` | None | Submit transaction via x402 facilitator |

--- a/src/__tests__/health.test.ts
+++ b/src/__tests__/health.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { Health, buildNonceHealthState } from "../endpoints/health";
+
+describe("buildNonceHealthState", () => {
+  it("reports poolAvailabilityRatio instead of effectiveCapacity", () => {
+    const state = buildNonceHealthState(
+      {
+        poolAvailable: 15,
+        poolReserved: 2,
+        conflictsDetected: 0,
+        lastGapDetected: null,
+      },
+      Date.parse("2026-03-30T18:20:10.000Z")
+    );
+
+    expect(state.poolAvailabilityRatio).toBe(0.88);
+    expect(state.poolStatus).toBe("healthy");
+    expect(state).not.toHaveProperty("effectiveCapacity");
+  });
+
+  it("opens the circuit breaker when a recent conflict drained the pool", () => {
+    const state = buildNonceHealthState(
+      {
+        poolAvailable: 0,
+        poolReserved: 0,
+        conflictsDetected: 2,
+        lastGapDetected: "2026-03-30T18:19:55.000Z",
+      },
+      Date.parse("2026-03-30T18:20:10.000Z")
+    );
+
+    expect(state.poolAvailabilityRatio).toBe(1);
+    expect(state.circuitBreakerOpen).toBe(true);
+    expect(state.poolStatus).toBe("critical");
+  });
+});
+
+describe("Health schema", () => {
+  it("documents poolAvailabilityRatio on the thin nonce summary", () => {
+    const endpoint = new Health();
+    const nonceProperties =
+      endpoint.schema.responses["200"].content["application/json"].schema.properties.nonce.properties;
+
+    expect(nonceProperties).toHaveProperty("poolAvailabilityRatio");
+    expect(nonceProperties).not.toHaveProperty("effectiveCapacity");
+  });
+});

--- a/src/__tests__/sponsor-status.test.ts
+++ b/src/__tests__/sponsor-status.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSponsorReconciliationFreshness,
+  getSponsorSnapshotFreshness,
+  toSponsorStatusResult,
+  type StoredSponsorStatusSnapshot,
+} from "../services/sponsor-status";
+import { SponsorStatus } from "../endpoints/sponsor-status";
+
+function makeSnapshot(overrides: Partial<StoredSponsorStatusSnapshot> = {}): StoredSponsorStatusSnapshot {
+  return {
+    asOf: "2026-03-30T18:20:00.000Z",
+    walletCount: 4,
+    allWalletsDegraded: false,
+    recommendation: null,
+    noncePool: {
+      totalAvailable: 72,
+      totalReserved: 8,
+      totalCapacity: 80,
+      poolAvailabilityRatio: 0.9,
+      conflictsDetected: 0,
+      lastConflictAt: null,
+      healInProgress: false,
+    },
+    reconciliation: {
+      lastSuccessfulAt: "2026-03-30T18:19:30.000Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("toSponsorStatusResult", () => {
+  it("returns healthy when snapshot and reconciliation are fresh", () => {
+    const result = toSponsorStatusResult(
+      makeSnapshot(),
+      Date.parse("2026-03-30T18:20:10.000Z")
+    );
+
+    expect(result.status).toBe("healthy");
+    expect(result.canSponsor).toBe(true);
+    expect(result.reasons).toEqual([]);
+    expect(result.snapshot.freshness).toBe("fresh");
+    expect(result.reconciliation.freshness).toBe("fresh");
+  });
+
+  it("degrades stale snapshots without marking them unavailable", () => {
+    const result = toSponsorStatusResult(
+      makeSnapshot(),
+      Date.parse("2026-03-30T18:21:00.000Z")
+    );
+
+    expect(result.status).toBe("degraded");
+    expect(result.canSponsor).toBe(false);
+    expect(result.reasons).toContain("SNAPSHOT_STALE");
+    expect(result.snapshot.freshness).toBe("stale");
+  });
+
+  it("marks expired snapshots unavailable", () => {
+    const result = toSponsorStatusResult(
+      makeSnapshot(),
+      Date.parse("2026-03-30T18:30:30.000Z")
+    );
+
+    expect(result.status).toBe("unavailable");
+    expect(result.canSponsor).toBe(false);
+    expect(result.reasons).toContain("SNAPSHOT_STALE");
+    expect(result.snapshot.freshness).toBe("expired");
+  });
+
+  it("marks missing reconciliation metadata unavailable and degrades status", () => {
+    const result = toSponsorStatusResult(
+      makeSnapshot({
+        reconciliation: {
+          lastSuccessfulAt: null,
+        },
+      }),
+      Date.parse("2026-03-30T18:20:10.000Z")
+    );
+
+    expect(result.status).toBe("degraded");
+    expect(result.canSponsor).toBe(false);
+    expect(result.reconciliation.freshness).toBe("unavailable");
+    expect(result.reasons).toContain("RECONCILIATION_STALE");
+  });
+
+  it("adds pool and reconciliation degradation reasons", () => {
+    const result = toSponsorStatusResult(
+      makeSnapshot({
+        allWalletsDegraded: true,
+        recommendation: "fallback_to_direct",
+        noncePool: {
+          totalAvailable: 0,
+          totalReserved: 80,
+          totalCapacity: 80,
+          poolAvailabilityRatio: 0,
+          conflictsDetected: 3,
+          lastConflictAt: "2026-03-30T18:19:55.000Z",
+          healInProgress: true,
+        },
+        reconciliation: {
+          lastSuccessfulAt: "2026-03-30T18:15:00.000Z",
+        },
+      }),
+      Date.parse("2026-03-30T18:20:10.000Z")
+    );
+
+    expect(result.status).toBe("degraded");
+    expect(result.recommendation).toBe("fallback_to_direct");
+    expect(result.reasons).toEqual(
+      expect.arrayContaining([
+        "NO_AVAILABLE_NONCES",
+        "ALL_WALLETS_DEGRADED",
+        "RECENT_CONFLICT",
+        "HEAL_IN_PROGRESS",
+        "RECONCILIATION_STALE",
+      ])
+    );
+  });
+});
+
+describe("sponsor status freshness helpers", () => {
+  it("treats snapshot freshness windows as fresh, stale, then expired", () => {
+    expect(
+      getSponsorSnapshotFreshness(
+        "2026-03-30T18:20:00.000Z",
+        Date.parse("2026-03-30T18:20:20.000Z")
+      )
+    ).toBe("fresh");
+    expect(
+      getSponsorSnapshotFreshness(
+        "2026-03-30T18:20:00.000Z",
+        Date.parse("2026-03-30T18:21:00.000Z")
+      )
+    ).toBe("stale");
+    expect(
+      getSponsorSnapshotFreshness(
+        "2026-03-30T18:20:00.000Z",
+        Date.parse("2026-03-30T18:26:00.000Z")
+      )
+    ).toBe("expired");
+  });
+
+  it("treats reconciliation freshness windows as fresh, stale, or unavailable", () => {
+    expect(
+      getSponsorReconciliationFreshness(
+        "2026-03-30T18:19:30.000Z",
+        Date.parse("2026-03-30T18:20:10.000Z")
+      )
+    ).toBe("fresh");
+    expect(
+      getSponsorReconciliationFreshness(
+        "2026-03-30T18:15:00.000Z",
+        Date.parse("2026-03-30T18:20:10.000Z")
+      )
+    ).toBe("stale");
+    expect(getSponsorReconciliationFreshness(null)).toBe("unavailable");
+  });
+});
+
+describe("SponsorStatus schema", () => {
+  it("documents the canonical cached sponsor status shape", () => {
+    const endpoint = new SponsorStatus();
+    const properties =
+      endpoint.schema.responses["200"].content["application/json"].schema.properties;
+
+    expect(properties).toHaveProperty("noncePool");
+    expect(properties).toHaveProperty("reconciliation");
+    expect(properties).toHaveProperty("snapshot");
+    expect(properties.noncePool.properties).toHaveProperty("poolAvailabilityRatio");
+  });
+});

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -8,13 +8,26 @@ import type { StacksTransactionWire } from "@stacks/transactions";
 import { hexToBytes } from "@stacks/common";
 import { STACKS_MAINNET, STACKS_TESTNET } from "@stacks/network";
 import { generateNewAccount, generateWallet } from "@stacks/wallet-sdk";
-import type { Env, LogsRPC, PoolHealthResponse, WalletHealthSnapshot, HandSubmitResult, RunDispatchResult } from "../types";
+import type {
+  Env,
+  LogsRPC,
+  PoolHealthResponse,
+  SponsorStatusResult,
+  WalletHealthSnapshot,
+  HandSubmitResult,
+  RunDispatchResult,
+} from "../types";
 import { getHiroBaseUrl, getHiroHeaders } from "../utils";
 import {
   getPaymentRecord,
   putPaymentRecord,
   transitionPayment,
 } from "../services/payment-status";
+import {
+  SPONSOR_STATUS_RECENT_CONFLICT_WINDOW_MS,
+  toSponsorStatusResult,
+  type StoredSponsorStatusSnapshot,
+} from "../services/sponsor-status";
 
 const APP_ID = "x402-relay";
 
@@ -531,6 +544,7 @@ const STATE_KEYS = {
 
 /** Round-robin wallet index storage key */
 const NEXT_WALLET_INDEX_KEY = "next_wallet_index";
+const SPONSOR_STATUS_SNAPSHOT_STORAGE_KEY = "sponsor_status_snapshot";
 
 /**
  * Structured error thrown when all sponsor wallets are at the chaining limit.
@@ -2883,6 +2897,7 @@ export class NonceDO {
     errorReason: string | undefined
   ): Promise<void> {
     this.ledgerBroadcastOutcome(walletIndex, nonce, txid, httpStatus, nodeUrl, errorReason);
+    await this.refreshSponsorStatusSnapshot();
   }
 
   // ---------------------------------------------------------------------------
@@ -3519,6 +3534,8 @@ export class NonceDO {
         poolCapacity: effectiveWalletCount * CHAINING_LIMIT,
       });
 
+      await this.refreshSponsorStatusSnapshot();
+
       return { nonce: assignedNonce, walletIndex, totalReserved };
     });
   }
@@ -3615,6 +3632,8 @@ export class NonceDO {
       if (failureQuarantined) {
         await this.recordQuarantineEvent(walletIndex);
       }
+
+      await this.refreshSponsorStatusSnapshot();
     });
   }
 
@@ -3708,6 +3727,91 @@ export class NonceDO {
       initializedWallets.length > 0 && degradedCount === initializedWallets.length;
 
     return { allWalletsDegraded, totalReserved, totalCapacity, wallets };
+  }
+
+  private async buildSponsorStatusSnapshot(): Promise<StoredSponsorStatusSnapshot> {
+    const initializedWallets = await this.getInitializedWallets();
+    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
+    const walletSnapshots = await Promise.all(
+      initializedWallets.map(async ({ walletIndex }) => {
+        const recentQuarantines =
+          (await this.state.storage.get<string[]>(
+            this.walletQuarantineRecentKey(walletIndex)
+          )) ?? [];
+        const activeQuarantines = recentQuarantines.filter(
+          (ts) => new Date(ts).getTime() >= cutoff
+        );
+        const available = this.walletHeadroom(walletIndex);
+        return {
+          circuitBreakerOpen:
+            activeQuarantines.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD,
+          available,
+          reserved: CHAINING_LIMIT - available,
+        };
+      })
+    );
+    const walletCount = walletSnapshots.length;
+    const totalAvailable = walletSnapshots.reduce((sum, wallet) => sum + wallet.available, 0);
+    const totalReserved = walletSnapshots.reduce((sum, wallet) => sum + wallet.reserved, 0);
+    const totalCapacity = walletCount * CHAINING_LIMIT;
+    const allWalletsDegraded =
+      walletCount > 0 && walletSnapshots.every((wallet) => wallet.circuitBreakerOpen);
+    const lastGapDetectedMs = this.getStateValue(STATE_KEYS.lastGapDetected);
+    const lastHiroSyncMs = this.getStateValue(STATE_KEYS.lastHiroSync);
+    const healInProgress =
+      lastGapDetectedMs !== null &&
+      Date.now() - lastGapDetectedMs < ALARM_INTERVAL_ACTIVE_MS * 2;
+    const recentConflict =
+      lastGapDetectedMs !== null &&
+      Date.now() - lastGapDetectedMs <= SPONSOR_STATUS_RECENT_CONFLICT_WINDOW_MS;
+    const poolAvailabilityRatio =
+      totalCapacity === 0
+        ? 0
+        : Math.round((totalAvailable / totalCapacity) * 100) / 100;
+
+    return {
+      asOf: new Date().toISOString(),
+      walletCount,
+      allWalletsDegraded,
+      recommendation:
+        totalAvailable === 0 ||
+        allWalletsDegraded ||
+        recentConflict ||
+        healInProgress
+          ? "fallback_to_direct"
+          : null,
+      noncePool: {
+        totalAvailable,
+        totalReserved,
+        totalCapacity,
+        poolAvailabilityRatio,
+        conflictsDetected: this.getStoredCount(STATE_KEYS.conflictsDetected),
+        lastConflictAt: lastGapDetectedMs ? new Date(lastGapDetectedMs).toISOString() : null,
+        healInProgress,
+      },
+      reconciliation: {
+        lastSuccessfulAt: lastHiroSyncMs ? new Date(lastHiroSyncMs).toISOString() : null,
+      },
+    };
+  }
+
+  private async refreshSponsorStatusSnapshot(): Promise<StoredSponsorStatusSnapshot> {
+    const snapshot = await this.buildSponsorStatusSnapshot();
+    await this.state.storage.put(SPONSOR_STATUS_SNAPSHOT_STORAGE_KEY, snapshot);
+    return snapshot;
+  }
+
+  async getSponsorStatus(): Promise<SponsorStatusResult> {
+    let snapshot =
+      await this.state.storage.get<StoredSponsorStatusSnapshot>(
+        SPONSOR_STATUS_SNAPSHOT_STORAGE_KEY
+      );
+
+    if (!snapshot) {
+      snapshot = await this.refreshSponsorStatusSnapshot();
+    }
+
+    return toSponsorStatusResult(snapshot);
   }
 
   async getStats(): Promise<NonceStatsResponse> {
@@ -6288,6 +6392,8 @@ export class NonceDO {
           this.log("info", "probe_queue_cycle_complete", probeResult);
         }
 
+        await this.refreshSponsorStatusSnapshot();
+
         // Dynamic alarm interval: use cascade (20s) when cascade is active + in-flight nonces,
         // active (60s) when in-flight nonces present, idle (5min) when all wallets are drained.
         const totalReservedAfterCycle = this.ledgerTotalAssigned();
@@ -6332,6 +6438,7 @@ export class NonceDO {
       const result = action === "reset"
         ? await this.state.blockConcurrencyWhile(() => this.performReset())
         : await this.state.blockConcurrencyWhile(() => this.performResync());
+      await this.refreshSponsorStatusSnapshot();
       return this.jsonResponse(result);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
@@ -6369,8 +6476,9 @@ export class NonceDO {
    * without touching any nonce pool state. Used when auto-clear hasn't fired yet
    * and operators need to unblock the health circuit breaker immediately.
    */
-  private handleClearConflicts(): Response {
+  private async handleClearConflicts(): Promise<Response> {
     const previousConflicts = this.clearConflictCounters("manual_operator_clear");
+    await this.refreshSponsorStatusSnapshot();
     return this.jsonResponse({ cleared: true, previousConflicts });
   }
 
@@ -6429,6 +6537,7 @@ export class NonceDO {
         reason,
       };
       this.log("info", "clear_pools", { action: result.action, changed: result.changed, reason: result.reason });
+      await this.refreshSponsorStatusSnapshot();
       return this.jsonResponse(result);
     });
   }
@@ -6992,6 +7101,18 @@ export class NonceDO {
       }
     }
 
+    if (request.method === "GET" && url.pathname === "/sponsor-status") {
+      try {
+        const sponsorStatus = await this.getSponsorStatus();
+        return this.jsonResponse(
+          sponsorStatus,
+          sponsorStatus.status === "unavailable" ? 503 : 200
+        );
+      } catch (error) {
+        return this.internalError(error);
+      }
+    }
+
     // GET /wallet-fees/:walletIndex — returns fee stats for a specific wallet
     const walletFeesMatch = url.pathname.match(/^\/wallet-fees\/(\d+)$/);
     if (request.method === "GET" && walletFeesMatch) {
@@ -7083,7 +7204,11 @@ export class NonceDO {
     const fillGapsMatch = url.pathname.match(/^\/fill-gaps\/(\d+)$/);
     if (request.method === "POST" && fillGapsMatch) {
       const walletIdx = parseInt(fillGapsMatch[1], 10);
-      return this.state.blockConcurrencyWhile(() => this.handleFillGaps(walletIdx));
+      const response = await this.state.blockConcurrencyWhile(() => this.handleFillGaps(walletIdx));
+      if (response.ok) {
+        await this.refreshSponsorStatusSnapshot();
+      }
+      return response;
     }
 
     // POST /flush-wallet/:walletIndex — admin: full wallet flush when surgical gap-filling fails.
@@ -7106,9 +7231,13 @@ export class NonceDO {
       // (both mutate SQLite). When probeDepth is set and the forward range is
       // empty, handleFlushWallet enqueues nonces into probe_queue and returns
       // immediately — the alarm processes them in batches (5/tick, RBF_FEE).
-      return this.state.blockConcurrencyWhile(
+      const response = await this.state.blockConcurrencyWhile(
         () => this.handleFlushWallet(walletIdx, probeDepth)
       );
+      if (response.ok) {
+        await this.refreshSponsorStatusSnapshot();
+      }
+      return response;
     }
 
     // GET /history/:wallet/:nonce — diagnostic endpoint for full nonce event trail.

--- a/src/endpoints/health.ts
+++ b/src/endpoints/health.ts
@@ -11,19 +11,22 @@ const CAPACITY_HEALTHY_THRESHOLD = 0.6;
 const CAPACITY_CRITICAL_THRESHOLD = 0.2;
 
 /** Machine-readable pool health status for agent circuit-breaker gating */
-type PoolStatus = "healthy" | "degraded" | "critical";
+export type PoolStatus = "healthy" | "degraded" | "critical";
 
 /**
- * Derive a PoolStatus from effective capacity and circuit-breaker state.
- * - "critical": circuit breaker open OR capacity < 20%
- * - "degraded": capacity < 60% (but not critical)
- * - "healthy": capacity ≥ 60% and circuit breaker closed
+ * Derive a PoolStatus from the available share of the nonce pool and circuit-breaker state.
+ * - "critical": circuit breaker open OR available ratio < 20%
+ * - "degraded": available ratio < 60% (but not critical)
+ * - "healthy": available ratio ≥ 60% and circuit breaker closed
  */
-function derivePoolStatus(effectiveCapacity: number, circuitBreakerOpen: boolean): PoolStatus {
-  if (circuitBreakerOpen || effectiveCapacity < CAPACITY_CRITICAL_THRESHOLD) {
+export function derivePoolStatus(
+  poolAvailabilityRatio: number,
+  circuitBreakerOpen: boolean
+): PoolStatus {
+  if (circuitBreakerOpen || poolAvailabilityRatio < CAPACITY_CRITICAL_THRESHOLD) {
     return "critical";
   }
-  if (effectiveCapacity < CAPACITY_HEALTHY_THRESHOLD) {
+  if (poolAvailabilityRatio < CAPACITY_HEALTHY_THRESHOLD) {
     return "degraded";
   }
   return "healthy";
@@ -33,7 +36,7 @@ function derivePoolStatus(effectiveCapacity: number, circuitBreakerOpen: boolean
  * Condensed nonce pool state surfaced by /health.
  * Derived from the full NonceStatsResponse returned by NonceDO GET /stats.
  */
-interface NonceHealthState {
+export interface NonceHealthState {
   /** Number of nonces available in the pool (wallet 0, backward compat) */
   poolAvailable: number;
   /** Number of nonces currently in-flight across all wallets */
@@ -48,12 +51,8 @@ interface NonceHealthState {
   circuitBreakerOpen: boolean;
   /** ISO timestamp of last gap/conflict detection, or null if none */
   lastConflictAt: string | null;
-  /**
-   * Fraction of total pool capacity currently available (0.0–1.0).
-   * Computed as poolAvailable / (poolAvailable + poolReserved).
-   * 1.0 when pool is empty (no reserved nonces) — idle is healthy.
-   */
-  effectiveCapacity: number;
+  /** Fraction of total pool capacity currently available (0.0-1.0). */
+  poolAvailabilityRatio: number;
   /**
    * Machine-readable pool health for agent circuit-breaker gating.
    * "healthy" ≥60% capacity, "degraded" <60%, "critical" <20% or circuit open.
@@ -69,6 +68,54 @@ interface NonceHealthState {
   recommendation?: "fallback_to_direct" | null;
 }
 
+interface RawNonceStats {
+  poolAvailable: number;
+  poolReserved: number;
+  conflictsDetected: number;
+  lastGapDetected: string | null;
+}
+
+export function buildNonceHealthState(
+  raw: RawNonceStats,
+  now = Date.now(),
+  recommendation: "fallback_to_direct" | null = null
+): NonceHealthState {
+  const lastConflictAt = raw.lastGapDetected ?? null;
+  const recentConflict =
+    lastConflictAt !== null &&
+    now - new Date(lastConflictAt).getTime() <= RECENT_CONFLICT_WINDOW_MS;
+
+  // Pool exhausted by conflicts: both available and reserved are 0 but conflicts
+  // were detected — this means the pool drained without recovering (e.g. all
+  // wallets hit conflict state and nonces flushed). Phase 1 auto-resets
+  // conflictsDetected when resync finds all wallets consistent, so this
+  // condition only fires during genuinely unresolved conflict windows.
+  const poolExhaustedByConflicts =
+    raw.poolAvailable === 0 && raw.poolReserved === 0 && raw.conflictsDetected > 0;
+
+  const circuitBreakerOpen =
+    recentConflict ||
+    (raw.poolAvailable === 0 && raw.poolReserved > 0) ||
+    poolExhaustedByConflicts;
+
+  const totalPool = raw.poolAvailable + raw.poolReserved;
+  // When pool is idle (nothing reserved), treat as fully available
+  const poolAvailabilityRatio =
+    totalPool === 0 ? 1.0 : Math.round((raw.poolAvailable / totalPool) * 100) / 100;
+  const poolStatus = derivePoolStatus(poolAvailabilityRatio, circuitBreakerOpen);
+
+  return {
+    poolAvailable: raw.poolAvailable,
+    poolReserved: raw.poolReserved,
+    conflictsDetected: raw.conflictsDetected,
+    circuitBreakerOpen,
+    lastConflictAt,
+    poolAvailabilityRatio,
+    poolStatus,
+    recommendation,
+  };
+}
+
 /**
  * Health check endpoint
  * GET /health
@@ -76,9 +123,9 @@ interface NonceHealthState {
 export class Health extends BaseEndpoint {
   schema = {
     tags: ["Health"],
-    summary: "Health check with network info and nonce pool state",
+    summary: "Thin service health summary with condensed nonce pool state",
     description:
-      "Returns service status, network, version, and a condensed view of the nonce pool state from the NonceDO coordinator. The `nonce` field is null when the coordinator is unavailable.",
+      "Returns service status, network, version, and a condensed nonce pool readiness summary from the NonceDO coordinator. Use GET /status/sponsor for the full cached sponsor status contract. The `nonce` field is null when the coordinator is unavailable.",
     responses: {
       "200": {
         description: "Service health status",
@@ -130,10 +177,10 @@ export class Health extends BaseEndpoint {
                         "ISO timestamp of the most recent nonce gap/conflict detection, or null",
                       example: null,
                     },
-                    effectiveCapacity: {
+                    poolAvailabilityRatio: {
                       type: "number" as const,
                       description:
-                        "Fraction of pool capacity currently available (0.0–1.0). " +
+                        "Fraction of pool capacity currently available (0.0-1.0). " +
                         "Computed as poolAvailable / (poolAvailable + poolReserved). " +
                         "1.0 when pool is idle (no reserved nonces).",
                       example: 0.88,
@@ -201,64 +248,31 @@ export class Health extends BaseEndpoint {
         return null;
       }
 
-      const raw = (await statsResponse.json()) as {
-        poolAvailable: number;
-        poolReserved: number;
-        conflictsDetected: number;
-        lastGapDetected: string | null;
-      };
-
-      const lastConflictAt = raw.lastGapDetected ?? null;
-      const recentConflict =
-        lastConflictAt !== null &&
-        Date.now() - new Date(lastConflictAt).getTime() <= RECENT_CONFLICT_WINDOW_MS;
-
-      // Pool exhausted by conflicts: both available and reserved are 0 but conflicts
-      // were detected — this means the pool drained without recovering (e.g. all
-      // wallets hit conflict state and nonces flushed). Phase 1 auto-resets
-      // conflictsDetected when resync finds all wallets consistent, so this
-      // condition only fires during genuinely unresolved conflict windows.
-      const poolExhaustedByConflicts =
-        raw.poolAvailable === 0 && raw.poolReserved === 0 && raw.conflictsDetected > 0;
-
-      const circuitBreakerOpen =
-        recentConflict || (raw.poolAvailable === 0 && raw.poolReserved > 0) || poolExhaustedByConflicts;
-
-      const totalPool = raw.poolAvailable + raw.poolReserved;
-      // When pool is idle (nothing reserved), treat as fully available
-      const effectiveCapacity =
-        totalPool === 0 ? 1.0 : Math.round((raw.poolAvailable / totalPool) * 100) / 100;
-      const poolStatus = derivePoolStatus(effectiveCapacity, circuitBreakerOpen);
+      const raw = (await statsResponse.json()) as RawNonceStats;
+      const now = Date.now();
+      const baseState = buildNonceHealthState(raw, now);
 
       // Only fetch nonce-state when pool looks unhealthy — avoids adding
       // two SQL queries + Promise.all to every pre-flight health check.
       // recommendation is derived inside the DO (single source of truth).
-      let recommendation: "fallback_to_direct" | null = null;
-
-      if (poolStatus !== "healthy") {
+      if (baseState.poolStatus !== "healthy") {
         try {
           const nonceStateResponse = await stub.fetch("https://nonce-do/nonce-state");
           if (nonceStateResponse.ok) {
             const nonceState = (await nonceStateResponse.json()) as {
               recommendation: "fallback_to_direct" | null;
             };
-            recommendation = nonceState.recommendation;
+            return {
+              ...baseState,
+              recommendation: nonceState.recommendation,
+            };
           }
         } catch {
           // best-effort — don't block health response
         }
       }
 
-      return {
-        poolAvailable: raw.poolAvailable,
-        poolReserved: raw.poolReserved,
-        conflictsDetected: raw.conflictsDetected,
-        circuitBreakerOpen,
-        lastConflictAt,
-        effectiveCapacity,
-        poolStatus,
-        recommendation,
-      };
+      return baseState;
     } catch (e) {
       logger.warn("Failed to fetch nonce state for health check", {
         error: e instanceof Error ? e.message : "Unknown error",

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,4 +1,5 @@
 export { Health } from "./health";
+export { SponsorStatus } from "./sponsor-status";
 export { Relay } from "./relay";
 export { Sponsor } from "./sponsor";
 export { DashboardStats } from "./DashboardStats";

--- a/src/endpoints/sponsor-status.ts
+++ b/src/endpoints/sponsor-status.ts
@@ -1,0 +1,155 @@
+import { BaseEndpoint } from "./BaseEndpoint";
+import type { AppContext } from "../types";
+import { Error500Response } from "../schemas";
+
+/**
+ * Public cached sponsor status endpoint.
+ * Returns the same SponsorStatusResult contract used by RelayRPC.getSponsorStatus().
+ *
+ * GET /status/sponsor
+ */
+export class SponsorStatus extends BaseEndpoint {
+  schema = {
+    tags: ["Health"],
+    summary: "Cached sponsor readiness snapshot",
+    description:
+      "Returns the relay-owned cached sponsor readiness snapshot. Reads never fan out to Hiro on the request path.",
+    responses: {
+      "200": {
+        description: "Fresh or stale sponsor status snapshot",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object" as const,
+              properties: {
+                status: {
+                  type: "string" as const,
+                  enum: ["healthy", "degraded", "unavailable"],
+                },
+                canSponsor: { type: "boolean" as const },
+                walletCount: { type: "number" as const },
+                recommendation: {
+                  type: "string" as const,
+                  nullable: true,
+                  enum: ["fallback_to_direct"],
+                },
+                reasons: {
+                  type: "array" as const,
+                  items: {
+                    type: "string" as const,
+                    enum: [
+                      "NO_AVAILABLE_NONCES",
+                      "ALL_WALLETS_DEGRADED",
+                      "RECENT_CONFLICT",
+                      "HEAL_IN_PROGRESS",
+                      "RECONCILIATION_STALE",
+                      "SNAPSHOT_STALE",
+                    ],
+                  },
+                },
+                noncePool: {
+                  type: "object" as const,
+                  properties: {
+                    totalAvailable: { type: "number" as const },
+                    totalReserved: { type: "number" as const },
+                    totalCapacity: { type: "number" as const },
+                    poolAvailabilityRatio: { type: "number" as const },
+                    conflictsDetected: { type: "number" as const },
+                    lastConflictAt: { type: "string" as const, nullable: true },
+                    healInProgress: { type: "boolean" as const },
+                  },
+                },
+                reconciliation: {
+                  type: "object" as const,
+                  properties: {
+                    source: { type: "string" as const, enum: ["hiro"] },
+                    lastSuccessfulAt: { type: "string" as const, nullable: true },
+                    freshness: {
+                      type: "string" as const,
+                      enum: ["fresh", "stale", "unavailable"],
+                    },
+                  },
+                },
+                snapshot: {
+                  type: "object" as const,
+                  properties: {
+                    asOf: { type: "string" as const },
+                    ageMs: { type: "number" as const },
+                    freshness: {
+                      type: "string" as const,
+                      enum: ["fresh", "stale", "expired"],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "503": {
+        description: "Expired sponsor status snapshot",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object" as const,
+              properties: {
+                status: { type: "string" as const, enum: ["unavailable"] },
+              },
+            },
+          },
+        },
+      },
+      "500": Error500Response,
+    },
+  };
+
+  async handle(c: AppContext) {
+    const logger = this.getLogger(c);
+
+    if (!c.env.NONCE_DO) {
+      return this.err(c, {
+        error: "Nonce coordinator unavailable",
+        code: "INTERNAL_ERROR",
+        status: 500,
+        details: "NONCE_DO binding not configured",
+        retryable: true,
+        retryAfter: 5,
+      });
+    }
+
+    try {
+      const stub = c.env.NONCE_DO.get(c.env.NONCE_DO.idFromName("sponsor"));
+      const response = await stub.fetch("https://nonce-do/sponsor-status");
+
+      const body = await response.text();
+      if (!response.ok && response.status !== 503) {
+        logger.warn("Nonce DO sponsor-status request failed", {
+          status: response.status,
+          body,
+        });
+        return this.err(c, {
+          error: "Failed to fetch sponsor status",
+          code: "INTERNAL_ERROR",
+          status: 500,
+          details: body || "Nonce DO responded with error",
+          retryable: true,
+          retryAfter: 5,
+        });
+      }
+
+      return c.json(JSON.parse(body), response.status as 200 | 503);
+    } catch (e) {
+      logger.error("Sponsor status request failed", {
+        error: e instanceof Error ? e.message : "Unknown error",
+      });
+      return this.err(c, {
+        error: "Failed to fetch sponsor status",
+        code: "INTERNAL_ERROR",
+        status: 500,
+        details: e instanceof Error ? e.message : "Unknown error",
+        retryable: true,
+        retryAfter: 5,
+      });
+    }
+  }
+}

--- a/src/endpoints/wallets.ts
+++ b/src/endpoints/wallets.ts
@@ -15,7 +15,8 @@ export class Wallets extends BaseEndpoint {
       "Returns current STX balance, cumulative fees spent, transaction counts, live nonce pool state, " +
       "and health status for each configured sponsor wallet. " +
       "Balances are cached for 60 seconds. " +
-      "Use this endpoint to identify wallets that need funding.",
+      "Use this endpoint to identify wallets that need funding. " +
+      "This is the detailed operator/debugging path; use GET /status/sponsor for the canonical cached sponsor readiness surface.",
     responses: {
       "200": {
         description: "Wallet statuses retrieved successfully",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { fromHono } from "chanfana";
 import type { Env, AppVariables, Logger } from "./types";
 import { loggerMiddleware, authMiddleware, requireAuthMiddleware } from "./middleware";
-import { Health, Relay, Sponsor, DashboardStats, TransactionLog, Verify, Access, Provision, ProvisionStx, Fees, FeesConfig, NonceStatsEndpoint, NonceState, NonceReset, NonceFillGaps, NonceHistory, NonceSurgeHistory, Settle, SettleStatus, VerifyV2, Supported, Wallets, PaymentStatus, Chainhook, QueueRead, QueueCancel } from "./endpoints";
+import { Health, SponsorStatus, Relay, Sponsor, DashboardStats, TransactionLog, Verify, Access, Provision, ProvisionStx, Fees, FeesConfig, NonceStatsEndpoint, NonceState, NonceReset, NonceFillGaps, NonceHistory, NonceSurgeHistory, Settle, SettleStatus, VerifyV2, Supported, Wallets, PaymentStatus, Chainhook, QueueRead, QueueCancel } from "./endpoints";
 import { dashboard } from "./dashboard";
 import { discovery } from "./routes/discovery";
 import { VERSION } from "./version";
@@ -86,6 +86,7 @@ const openapi = fromHono(app, {
 
 // Register endpoints with Chanfana (casts needed for extended endpoint classes)
 openapi.get("/health", Health as unknown as typeof Health);
+openapi.get("/status/sponsor", SponsorStatus as unknown as typeof SponsorStatus);
 openapi.post("/relay", Relay as unknown as typeof Relay);
 openapi.post("/sponsor", Sponsor as unknown as typeof Sponsor);
 openapi.get("/verify/:receiptId", Verify as unknown as typeof Verify);
@@ -141,7 +142,8 @@ app.get("/", (c) => {
       provisionStx: "POST /keys/provision-stx - Provision API key via Stacks signature",
       fees: "GET /fees - Get clamped fee estimates",
       feesConfig: "POST /fees/config - Update fee clamps (admin, requires API key)",
-      health: "GET /health - Health check with network info",
+      health: "GET /health - Thin service health summary with condensed nonce pool readiness",
+      sponsorStatus: "GET /status/sponsor - Cached sponsor readiness snapshot",
       stats: "GET /stats - Relay statistics (JSON)",
       transactionLog: "GET /stats/transactions - Recent individual transactions",
       nonceStats: "GET /nonce/stats - Nonce coordinator stats",

--- a/src/routes/discovery.ts
+++ b/src/routes/discovery.ts
@@ -161,7 +161,8 @@ Full V2 facilitator docs: https://x402-relay.aibtc.com/topics/x402-v2-facilitato
 
 ## Other Endpoints
 
-- GET  /health              — Health check with network info
+- GET  /health              — Thin service health summary
+- GET  /status/sponsor      — Cached sponsor readiness snapshot
 - GET  /fees                — Clamped fee estimates (no auth required)
 - GET  /verify/:receiptId   — Verify a payment receipt
 - POST /access              — Access a receipt-gated resource
@@ -737,16 +738,41 @@ See https://x402-relay.aibtc.com/topics/x402-v2-facilitator for full details.
 
 ## GET /health — Health Check
 
-Returns service health, Stacks network connectivity, and sponsor wallet info.
+Returns a thin service-readiness summary with network, version, and condensed nonce pool readiness.
+This is not the canonical sponsor status contract and does not include sponsor wallet inventory or balances.
+
+## GET /status/sponsor — Cached Sponsor Status
+
+Returns the relay-owned cached sponsor readiness snapshot used by public and internal consumers.
+This is the canonical sponsor status surface. Reads do not trigger live Hiro fan-out.
 
 ### Response
 
 {
-  "success": true,
-  "requestId": "uuid",
-  "status": "ok",
-  "version": "1.4.0",
-  "network": "mainnet"
+  "status": "healthy",
+  "canSponsor": true,
+  "walletCount": 4,
+  "recommendation": null,
+  "reasons": [],
+  "noncePool": {
+    "totalAvailable": 72,
+    "totalReserved": 8,
+    "totalCapacity": 80,
+    "poolAvailabilityRatio": 0.9,
+    "conflictsDetected": 0,
+    "lastConflictAt": null,
+    "healInProgress": false
+  },
+  "reconciliation": {
+    "source": "hiro",
+    "lastSuccessfulAt": "2026-03-30T18:20:00.000Z",
+    "freshness": "fresh"
+  },
+  "snapshot": {
+    "asOf": "2026-03-30T18:20:05.000Z",
+    "ageMs": 412,
+    "freshness": "fresh"
+  }
 }
 
 ---
@@ -2183,8 +2209,8 @@ discovery.get("/.well-known/agent.json", (c) => {
         id: "health-check",
         name: "Service Health Check",
         description:
-          "Check relay health, network, and sponsor wallet status. " +
-          "GET /health returns status, version, network, and sponsorAddress. " +
+          "Check relay health and cached sponsor readiness. " +
+          "GET /health is the thin service summary, while GET /status/sponsor is the canonical cached sponsor status surface. " +
           "Use before sending transactions to verify the relay is operational.",
         tags: ["health", "monitoring", "status"],
         examples: [

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -4,9 +4,10 @@
  * Provides type-safe RPC methods for same-account workers (landing-page, agent-news).
  * No auth required — service binding = trusted caller.
  *
- * Two public methods:
+ * Public methods:
  * - submitPayment(txHex, settle) — validate tx, check sender nonce, enqueue, return paymentId
  * - checkPayment(paymentId)      — return current payment status from KV
+ * - getSponsorStatus()           — return the cached relay-owned sponsor status snapshot
  */
 
 import { WorkerEntrypoint } from "cloudflare:workers";
@@ -19,7 +20,7 @@ import {
   addressToString,
 } from "@stacks/transactions";
 import { STACKS_MAINNET, STACKS_TESTNET } from "@stacks/network";
-import type { Env, SettleOptions } from "./types";
+import type { Env, SettleOptions, SponsorStatusResult } from "./types";
 import { stripHexPrefix } from "./utils";
 import {
   generatePaymentId,
@@ -95,6 +96,7 @@ export interface CheckPaymentResult {
  * // wrangler.jsonc: "services": [{ "binding": "X402_RELAY", "service": "x402-sponsor-relay", "entrypoint": "RelayRPC" }]
  * const result = await env.X402_RELAY.submitPayment(txHex, settle);
  * const status = await env.X402_RELAY.checkPayment(result.paymentId);
+ * const sponsorStatus = await env.X402_RELAY.getSponsorStatus();
  * ```
  */
 export class RelayRPC extends WorkerEntrypoint<Env> {
@@ -387,5 +389,25 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
       retryable: record.retryable,
       senderNonceInfo: record.senderNonceInfo,
     };
+  }
+
+  /**
+   * Return the cached relay-owned sponsor status snapshot.
+   * Reads from NonceDO cached state only and never triggers live Hiro fan-out.
+   */
+  async getSponsorStatus(): Promise<SponsorStatusResult> {
+    if (!this.env.NONCE_DO) {
+      throw new Error("Nonce coordinator unavailable");
+    }
+
+    const stub = this.env.NONCE_DO.get(this.env.NONCE_DO.idFromName("sponsor"));
+    const response = await stub.fetch("https://nonce-do/sponsor-status");
+
+    if (!response.ok && response.status !== 503) {
+      const body = await response.text();
+      throw new Error(body || `NonceDO sponsor status failed with ${response.status}`);
+    }
+
+    return (await response.json()) as SponsorStatusResult;
   }
 }

--- a/src/services/sponsor-status.ts
+++ b/src/services/sponsor-status.ts
@@ -1,0 +1,126 @@
+import type {
+  SponsorReconciliationFreshness,
+  SponsorSnapshotFreshness,
+  SponsorStatusReason,
+  SponsorStatusResult,
+} from "../types";
+
+export const SPONSOR_STATUS_SNAPSHOT_FRESH_MS = 30 * 1000;
+export const SPONSOR_STATUS_SNAPSHOT_EXPIRED_MS = 5 * 60 * 1000;
+export const SPONSOR_STATUS_RECONCILIATION_FRESH_MS = 2 * 60 * 1000;
+export const SPONSOR_STATUS_RECENT_CONFLICT_WINDOW_MS = 10 * 60 * 1000;
+
+export interface StoredSponsorStatusSnapshot {
+  asOf: string;
+  walletCount: number;
+  allWalletsDegraded: boolean;
+  recommendation: "fallback_to_direct" | null;
+  noncePool: {
+    totalAvailable: number;
+    totalReserved: number;
+    totalCapacity: number;
+    poolAvailabilityRatio: number;
+    conflictsDetected: number;
+    lastConflictAt: string | null;
+    healInProgress: boolean;
+  };
+  reconciliation: {
+    lastSuccessfulAt: string | null;
+  };
+}
+
+export function getSponsorSnapshotFreshness(
+  asOf: string,
+  nowMs = Date.now()
+): SponsorSnapshotFreshness {
+  const ageMs = Math.max(0, nowMs - new Date(asOf).getTime());
+  if (ageMs <= SPONSOR_STATUS_SNAPSHOT_FRESH_MS) {
+    return "fresh";
+  }
+  if (ageMs <= SPONSOR_STATUS_SNAPSHOT_EXPIRED_MS) {
+    return "stale";
+  }
+  return "expired";
+}
+
+export function getSponsorReconciliationFreshness(
+  lastSuccessfulAt: string | null,
+  nowMs = Date.now()
+): SponsorReconciliationFreshness {
+  if (!lastSuccessfulAt) {
+    return "unavailable";
+  }
+  const ageMs = Math.max(0, nowMs - new Date(lastSuccessfulAt).getTime());
+  return ageMs <= SPONSOR_STATUS_RECONCILIATION_FRESH_MS ? "fresh" : "stale";
+}
+
+export function toSponsorStatusResult(
+  snapshot: StoredSponsorStatusSnapshot,
+  nowMs = Date.now()
+): SponsorStatusResult {
+  const snapshotAgeMs = Math.max(0, nowMs - new Date(snapshot.asOf).getTime());
+  const snapshotFreshness = getSponsorSnapshotFreshness(snapshot.asOf, nowMs);
+  const reconciliationFreshness = getSponsorReconciliationFreshness(
+    snapshot.reconciliation.lastSuccessfulAt,
+    nowMs
+  );
+
+  const reasons: SponsorStatusReason[] = [];
+
+  if (snapshot.noncePool.totalAvailable === 0) {
+    reasons.push("NO_AVAILABLE_NONCES");
+  }
+  if (snapshot.allWalletsDegraded) {
+    reasons.push("ALL_WALLETS_DEGRADED");
+  }
+  if (
+    snapshot.noncePool.lastConflictAt &&
+    nowMs - new Date(snapshot.noncePool.lastConflictAt).getTime() <=
+      SPONSOR_STATUS_RECENT_CONFLICT_WINDOW_MS
+  ) {
+    reasons.push("RECENT_CONFLICT");
+  }
+  if (snapshot.noncePool.healInProgress) {
+    reasons.push("HEAL_IN_PROGRESS");
+  }
+  if (reconciliationFreshness !== "fresh") {
+    reasons.push("RECONCILIATION_STALE");
+  }
+  if (snapshotFreshness !== "fresh") {
+    reasons.push("SNAPSHOT_STALE");
+  }
+
+  let status: SponsorStatusResult["status"] = "healthy";
+  if (snapshotFreshness === "expired") {
+    status = "unavailable";
+  } else if (reasons.length > 0) {
+    status = "degraded";
+  }
+
+  return {
+    status,
+    canSponsor: status === "healthy",
+    walletCount: snapshot.walletCount,
+    recommendation: snapshot.recommendation,
+    reasons,
+    noncePool: {
+      totalAvailable: snapshot.noncePool.totalAvailable,
+      totalReserved: snapshot.noncePool.totalReserved,
+      totalCapacity: snapshot.noncePool.totalCapacity,
+      poolAvailabilityRatio: snapshot.noncePool.poolAvailabilityRatio,
+      conflictsDetected: snapshot.noncePool.conflictsDetected,
+      lastConflictAt: snapshot.noncePool.lastConflictAt,
+      healInProgress: snapshot.noncePool.healInProgress,
+    },
+    reconciliation: {
+      source: "hiro",
+      lastSuccessfulAt: snapshot.reconciliation.lastSuccessfulAt,
+      freshness: reconciliationFreshness,
+    },
+    snapshot: {
+      asOf: snapshot.asOf,
+      ageMs: snapshotAgeMs,
+      freshness: snapshotFreshness,
+    },
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -647,6 +647,44 @@ export interface PoolHealthResponse {
   wallets: WalletHealthSnapshot[];
 }
 
+export type SponsorStatusLevel = "healthy" | "degraded" | "unavailable";
+export type SponsorSnapshotFreshness = "fresh" | "stale" | "expired";
+export type SponsorReconciliationFreshness = "fresh" | "stale" | "unavailable";
+export type SponsorStatusReason =
+  | "NO_AVAILABLE_NONCES"
+  | "ALL_WALLETS_DEGRADED"
+  | "RECENT_CONFLICT"
+  | "HEAL_IN_PROGRESS"
+  | "RECONCILIATION_STALE"
+  | "SNAPSHOT_STALE";
+
+export interface SponsorStatusResult {
+  status: SponsorStatusLevel;
+  canSponsor: boolean;
+  walletCount: number;
+  recommendation: "fallback_to_direct" | null;
+  reasons: SponsorStatusReason[];
+  noncePool: {
+    totalAvailable: number;
+    totalReserved: number;
+    totalCapacity: number;
+    poolAvailabilityRatio: number;
+    conflictsDetected: number;
+    lastConflictAt: string | null;
+    healInProgress: boolean;
+  };
+  reconciliation: {
+    source: "hiro";
+    lastSuccessfulAt: string | null;
+    freshness: SponsorReconciliationFreshness;
+  };
+  snapshot: {
+    asOf: string;
+    ageMs: number;
+    freshness: SponsorSnapshotFreshness;
+  };
+}
+
 /**
  * Structured error response with retry guidance
  */


### PR DESCRIPTION
## Summary
- add a cached sponsor status snapshot service and expose it through `RelayRPC.getSponsorStatus()` and public `GET /status/sponsor`
- tighten `GET /health` so it stays a thin readiness summary, replacing `effectiveCapacity` with `poolAvailabilityRatio`
- update docs/discovery to steer consumers to the canonical status surfaces and keep `/wallets` as the operator/debugging path
- add focused tests for sponsor status freshness/degradation semantics and `/health` shape

## Verification
- `npm test -- src/__tests__/health.test.ts src/__tests__/sponsor-status.test.ts`
- `npm run check`

Closes #276
Related: #278, aibtcdev/landing-page#544