### PR TITLE
fix(nonce): return existing paymentId for idempotent sender-nonce duplicates (closes #277)

### DIFF
--- a/src/__tests__/sender-nonce-idempotency.test.ts
+++ b/src/__tests__/sender-nonce-idempotency.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for sender-nonce in-flight idempotency.
+ *
+ * Covers:
+ * - markInFlight stores structured SenderInflightRecord in KV
+ * - getInFlight returns the record on a hit
+ * - getInFlight returns null for missing keys and for legacy bare "1" markers
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  markInFlight,
+  getInFlight,
+  clearInFlight,
+  type SenderInflightRecord,
+} from "../services/sender-nonce";
+
+// ---------------------------------------------------------------------------
+// Minimal KV mock
+// ---------------------------------------------------------------------------
+
+function makeMockKV(): KVNamespace {
+  const store = new Map<string, { value: string; ttl?: number }>();
+  return {
+    async get(key: string) {
+      return store.get(key)?.value ?? null;
+    },
+    async put(key: string, value: string, opts?: { expirationTtl?: number }) {
+      store.set(key, { value, ttl: opts?.expirationTtl });
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    // Unused methods — type-safe no-ops
+    async getWithMetadata() {
+      return { value: null, metadata: null };
+    },
+    async list() {
+      return { keys: [], list_complete: true, cursor: "" };
+    },
+  } as unknown as KVNamespace;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("sender-nonce in-flight idempotency", () => {
+  const SIGNER_HASH = "abcdef1234567890abcdef1234567890abcdef12";
+  const NONCE = 42;
+  const PAYMENT_ID = "pay_test_12345";
+  const TX_HASH = "a".repeat(64); // fake SHA-256 hex
+
+  let kv: KVNamespace;
+
+  beforeEach(() => {
+    kv = makeMockKV();
+  });
+
+  it("getInFlight returns null when no marker exists", async () => {
+    const record = await getInFlight(kv, SIGNER_HASH, NONCE);
+    expect(record).toBeNull();
+  });
+
+  it("getInFlight returns null for legacy bare '1' marker (backward compat)", async () => {
+    await (kv as unknown as { put: (k: string, v: string) => Promise<void> }).put(
+      `sender_inflight:${SIGNER_HASH}:${NONCE}`,
+      "1"
+    );
+    const record = await getInFlight(kv, SIGNER_HASH, NONCE);
+    expect(record).toBeNull();
+  });
+
+  it("markInFlight stores a structured record with paymentId and txHash", async () => {
+    await markInFlight(kv, SIGNER_HASH, NONCE, PAYMENT_ID, TX_HASH);
+    const record = await getInFlight(kv, SIGNER_HASH, NONCE);
+    expect(record).not.toBeNull();
+    expect(record!.paymentId).toBe(PAYMENT_ID);
+    expect(record!.txHash).toBe(TX_HASH);
+    expect(record!.submittedAt).toBeTruthy();
+  });
+
+  it("getInFlight returns null after clearInFlight removes the marker", async () => {
+    await markInFlight(kv, SIGNER_HASH, NONCE, PAYMENT_ID, TX_HASH);
+    await clearInFlight(kv, SIGNER_HASH, NONCE);
+    const record = await getInFlight(kv, SIGNER_HASH, NONCE);
+    expect(record).toBeNull();
+  });
+
+  it("getInFlight returns null for malformed JSON in the KV value", async () => {
+    await (kv as unknown as { put: (k: string, v: string) => Promise<void> }).put(
+      `sender_inflight:${SIGNER_HASH}:${NONCE}`,
+      "not-json"
+    );
+    const record = await getInFlight(kv, SIGNER_HASH, NONCE);
+    expect(record).toBeNull();
+  });
+
+  it("records for different signer/nonce combos are independent", async () => {
+    await markInFlight(kv, SIGNER_HASH, NONCE, PAYMENT_ID, TX_HASH);
+    await markInFlight(kv, SIGNER_HASH, NONCE + 1, "pay_other", "b".repeat(64));
+
+    const r1 = await getInFlight(kv, SIGNER_HASH, NONCE);
+    const r2 = await getInFlight(kv, SIGNER_HASH, NONCE + 1);
+
+    expect(r1!.paymentId).toBe(PAYMENT_ID);
+    expect(r2!.paymentId).toBe("pay_other");
+  });
+
+  it("markInFlight records a submittedAt ISO timestamp", async () => {
+    const before = new Date().toISOString();
+    await markInFlight(kv, SIGNER_HASH, NONCE, PAYMENT_ID, TX_HASH);
+    const after = new Date().toISOString();
+
+    const record = await getInFlight(kv, SIGNER_HASH, NONCE);
+    expect(record).not.toBeNull();
+    expect(record!.submittedAt >= before).toBe(true);
+    expect(record!.submittedAt <= after).toBe(true);
+  });
+});

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -34,9 +34,22 @@ import {
 import {
   checkSenderNonce,
   clearInFlight,
+  getInFlight,
   markInFlight,
   seedSenderNonceFromHiro,
 } from "./services/sender-nonce";
+
+/**
+ * Compute a SHA-256 hex digest of a normalized tx hex string.
+ * Used to distinguish exact-same-tx retries from different txs with the same sender nonce.
+ */
+async function computeTxHash(cleanHex: string): Promise<string> {
+  const data = new TextEncoder().encode(cleanHex);
+  const buf = await crypto.subtle.digest("SHA-256", data);
+  return [...new Uint8Array(buf)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
 
 /**
  * Result returned by submitPayment.
@@ -219,8 +232,32 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
       };
     }
 
-    // Duplicate nonce — reject to avoid wasting a sponsor slot
+    // Duplicate nonce — check if exact same tx for idempotent recovery
     if (nonceCheck.outcome === "duplicate") {
+      const inFlightRecord = await getInFlight(kv, signerHash, senderNonce);
+      if (inFlightRecord) {
+        const incomingHash = await computeTxHash(cleanHex);
+        if (incomingHash === inFlightRecord.txHash) {
+          // Exact same tx resubmitted — return existing paymentId (idempotent)
+          const baseUrl =
+            this.env.RELAY_BASE_URL ??
+            (network === "mainnet"
+              ? "https://x402-relay.aibtc.com"
+              : "https://x402-relay.aibtc.dev");
+          return {
+            accepted: true,
+            paymentId: inFlightRecord.paymentId,
+            status: "queued",
+            senderNonce: {
+              provided: nonceCheck.provided,
+              expected: nonceCheck.lastSeen + 1,
+              healthy: false,
+            },
+            checkStatusUrl: `${baseUrl}/payment/${inFlightRecord.paymentId}`,
+          };
+        }
+      }
+      // Different tx with same sender nonce — reject to avoid wasting a sponsor slot
       return {
         accepted: false,
         error: `Your transaction uses nonce ${nonceCheck.provided}, which is already in-flight (last seen: ${nonceCheck.lastSeen}). Wait for the previous transaction to confirm or expire before resubmitting.`,
@@ -271,13 +308,15 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
       };
     }
 
+    // Generate paymentId and compute tx hash before writing the in-flight marker
+    // so the marker carries idempotency metadata for exact-tx duplicate detection.
+    const paymentId = generatePaymentId();
+    const txHashStr = await computeTxHash(cleanHex);
+
     // Write in-flight marker before enqueuing so concurrent requests for the
     // same sender/nonce are rejected by checkSenderNonce() (#234).
     // TTL of 5 minutes is self-healing if the consumer crashes.
-    await markInFlight(kv, signerHash, senderNonce);
-
-    // Generate paymentId and write initial status
-    const paymentId = generatePaymentId();
+    await markInFlight(kv, signerHash, senderNonce, paymentId, txHashStr);
     let record = createPaymentRecord(paymentId, network, senderNonceInfo);
     record.senderAddress = senderAddress;
     record.senderNonce = senderNonce;

--- a/src/services/sender-nonce.ts
+++ b/src/services/sender-nonce.ts
@@ -20,6 +20,20 @@ const SENDER_NONCE_TTL_SECONDS = 86_400; // 24 hours
 const SENDER_INFLIGHT_KEY_PREFIX = "sender_inflight:";
 const SENDER_INFLIGHT_TTL_SECONDS = 300; // 5 minutes — self-healing if consumer crashes
 
+/**
+ * Structured in-flight marker stored in KV for idempotent duplicate detection.
+ * Replaces the bare "1" marker so callers can distinguish exact-same-tx retries
+ * from different txs competing for the same sender nonce.
+ */
+export interface SenderInflightRecord {
+  /** Payment ID assigned at acceptance time */
+  paymentId: string;
+  /** SHA-256 of the normalized (0x-stripped) tx hex */
+  txHash: string;
+  /** ISO timestamp of when the in-flight marker was written */
+  submittedAt: string;
+}
+
 /** Timeout for Hiro nonce seed query (ms) */
 const HIRO_NONCE_SEED_TIMEOUT_MS = 8_000;
 
@@ -90,18 +104,47 @@ function inFlightKey(signerHash: string, nonce: number): string {
 
 /**
  * Write a short-lived KV marker indicating this sender/nonce is in-flight.
- * Called at RPC acceptance time, before the payment is enqueued.
+ * Stores structured metadata so callers can perform exact-tx idempotency checks.
  * TTL of 5 minutes is self-healing: if the queue consumer crashes without
  * calling clearInFlight, the marker expires automatically.
+ *
+ * @param paymentId - The payment ID assigned to this submission
+ * @param txHash - SHA-256 of the normalized tx hex, for idempotency checks
  */
 export async function markInFlight(
   kv: KVNamespace,
   signerHash: string,
-  nonce: number
+  nonce: number,
+  paymentId: string,
+  txHash: string
 ): Promise<void> {
-  await kv.put(inFlightKey(signerHash, nonce), "1", {
+  const record: SenderInflightRecord = {
+    paymentId,
+    txHash,
+    submittedAt: new Date().toISOString(),
+  };
+  await kv.put(inFlightKey(signerHash, nonce), JSON.stringify(record), {
     expirationTtl: SENDER_INFLIGHT_TTL_SECONDS,
   });
+}
+
+/**
+ * Read the structured in-flight record for a sender/nonce.
+ * Returns null if no marker exists or if the marker is a legacy bare "1".
+ * Used by callers to implement idempotent duplicate handling.
+ */
+export async function getInFlight(
+  kv: KVNamespace,
+  signerHash: string,
+  nonce: number
+): Promise<SenderInflightRecord | null> {
+  const raw = await kv.get(inFlightKey(signerHash, nonce), "text");
+  if (!raw || raw === "1") return null;
+  try {
+    return JSON.parse(raw) as SenderInflightRecord;
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

After #275 landed, `SENDER_NONCE_DUPLICATE` rejections at the relay became the dominant error at the landing-page boundary. The relay correctly rejects concurrent in-flight submissions to protect sponsor slots, but it cannot distinguish between:

1. **Exact same tx being retried** — caller got a network timeout, resubmits the identical signed hex
2. **Different tx with the same sender nonce** — genuine nonce conflict, should stay rejected

Both cases collapse into `SENDER_NONCE_DUPLICATE`, forcing callers to treat a safe idempotent retry as a hard error. This inflates retry noise and makes retry logic more complex.

## Fix

Extends the in-flight KV marker from a bare `"1"` to a structured `SenderInflightRecord`:

```json
{
  "paymentId": "pay_...",
  "txHash": "<SHA-256 of normalized tx hex>",
  "submittedAt": "2026-04-01T15:00:00Z"
}
```

On a duplicate nonce hit, `submitPayment` now:
1. Loads the in-flight record from KV
2. Computes `SHA-256(cleanHex)` of the incoming tx
3. **If hashes match** → return `accepted: true` with the existing `paymentId` (idempotent recovery)
4. **If hashes differ** → keep the `SENDER_NONCE_DUPLICATE` rejection

Legacy `"1"` markers (from pre-patch deployments) return `null` from `getInFlight`, so the mismatched-hash rejection path is followed safely — no regression.

## Acceptance Criteria (from #277)

- [x] Exact same signed tx can be resubmitted while in-flight and returns the existing `paymentId`
- [x] Different tx with same sender nonce is still rejected
- [x] Existing queue/mempool/confirmed flows continue unchanged
- [x] 63/63 tests pass (7 new tests for markInFlight/getInFlight behaviors)

## Test coverage

New: `src/__tests__/sender-nonce-idempotency.test.ts`
- `getInFlight` returns null when no marker exists
- `getInFlight` returns null for legacy bare `"1"` (backward compat)
- `markInFlight` stores structured record with paymentId and txHash
- `clearInFlight` removes the record
- Malformed JSON falls back to null
- Records for different signer/nonce combos are independent
- `submittedAt` is a valid ISO timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)