### PR TITLE
fix(nonce): prevent frontier drift causing stuck nonce gaps

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -2834,7 +2834,11 @@ export class NonceDO {
         value: info.possible_next_nonce,
         expiresAt: Date.now() + HIRO_NONCE_CACHE_TTL_MS,
       });
-      this.advanceChainFrontier(walletIndex, info.possible_next_nonce);
+      // Advance frontier based on confirmed state, not mempool state
+      const confirmedFrontier = info.last_executed_tx_nonce !== null
+        ? info.last_executed_tx_nonce + 1
+        : info.possible_next_nonce;
+      this.advanceChainFrontier(walletIndex, confirmedFrontier);
       return info.possible_next_nonce;
     } catch (_e) {
       this.log("debug", "nonce_lookahead_check_skipped", {
@@ -3410,13 +3414,18 @@ export class NonceDO {
 
   /**
    * Advance the chain frontier for a wallet. Only moves forward (monotonic).
-   * Called on every Hiro observation to absorb the highest confirmed nonce,
-   * filtering out load-balanced inconsistency where a stale node returns a
-   * lower value.
+   *
+   * IMPORTANT: The frontier must reflect *confirmed* state, not mempool state.
+   * Use `last_executed_tx_nonce + 1` (what's actually confirmed on-chain), NOT
+   * `possible_next_nonce` (which includes mempool txs and can leap past gaps).
+   *
+   * Using `possible_next_nonce` caused "frontier drift" — when high-nonce txs
+   * hit the mempool, the frontier advanced past unconfirmed gaps, making them
+   * invisible to headroom calculations and the reconciliation loop.
    */
-  private advanceChainFrontier(walletIndex: number, hiroNextNonce: number): void {
+  private advanceChainFrontier(walletIndex: number, confirmedNextNonce: number): void {
     const current = this.getChainFrontier(walletIndex);
-    const next = current !== null ? Math.max(current, hiroNextNonce) : hiroNextNonce;
+    const next = current !== null ? Math.max(current, confirmedNextNonce) : confirmedNextNonce;
     if (current === next) return; // no change
     this.chainFrontierCache.set(walletIndex, next);
     this.setStateValue(this.chainFrontierKey(walletIndex), next);
@@ -4996,11 +5005,19 @@ export class NonceDO {
       value: nonceInfo.possible_next_nonce,
       expiresAt: Date.now() + HIRO_NONCE_CACHE_TTL_MS,
     });
-    this.advanceChainFrontier(walletIndex, nonceInfo.possible_next_nonce);
+    // Advance frontier based on confirmed state, not mempool state.
+    // This prevents "frontier drift" where the frontier leaps past unconfirmed
+    // gaps when high-nonce txs land in the mempool.
+    const confirmedFrontier = nonceInfo.last_executed_tx_nonce !== null
+      ? nonceInfo.last_executed_tx_nonce + 1
+      : nonceInfo.possible_next_nonce; // fallback for fresh addresses with no confirmed txs
+    this.advanceChainFrontier(walletIndex, confirmedFrontier);
 
     const previousNonce = this.ledgerGetWalletHead(walletIndex);
 
-    // First-time initialization: seed head from Hiro when no local state exists
+    // First-time initialization: seed head from Hiro when no local state exists.
+    // Use possible_next_nonce for the head (need to assign above mempool),
+    // but frontier is already set to confirmed state above.
     if (previousNonce === null) {
       this.ledgerAdvanceWalletHead(walletIndex, nonceInfo.possible_next_nonce);
       return {
@@ -5647,6 +5664,8 @@ export class NonceDO {
     // for one cycle to let the replacement confirm.
     // -------------------------------------------------------------------------
 
+    // Track whether a forward bump occurred — used in the return value below.
+    let forwardBumped = false;
     if (previousNonce !== null && possible_next_nonce > previousNonce) {
       // Chain has advanced past our stored head — forward bump the head.
       this.ledgerAdvanceWalletHead(walletIndex, possible_next_nonce);
@@ -5658,14 +5677,13 @@ export class NonceDO {
         newNonce: possible_next_nonce,
         hiroNextNonce: possible_next_nonce,
         ledgerReserved: this.ledgerReservedCount(walletIndex),
+        gapFillNonces: gapFillNonces.length,
       });
 
-      return {
-        previousNonce,
-        newNonce: possible_next_nonce,
-        changed: true,
-        reason: `FORWARD BUMP: chain advanced to ${possible_next_nonce}`,
-      };
+      // NOTE: Previously this returned early, skipping gap-fill execution.
+      // This caused "frontier drift" — gaps below the head were never filled
+      // because the function exited before reaching the gap-fill broadcast loop.
+      forwardBumped = true;
     }
 
     const lastAssignedAtMs = this.getStateValue(STATE_KEYS.lastAssignedAt);
@@ -5741,11 +5759,15 @@ export class NonceDO {
     const headBumpSummary = headBumpNonce !== null
       ? ` head_bump [${headBumpNonce}]`
       : "";
+    const forwardBumpSummary = forwardBumped
+      ? ` forward_bump [${previousNonce} → ${possible_next_nonce}]`
+      : "";
+    const effectiveNewNonce = forwardBumped ? possible_next_nonce : previousNonce;
     return {
       previousNonce,
-      newNonce: previousNonce,
-      changed: gapFillFilled.length > 0 || rbfAttempted.length > 0 || headBumpNonce !== null,
-      reason: `nonce is consistent with chain state${gapFilledSummary}${rbfSummary}${headBumpSummary}`,
+      newNonce: effectiveNewNonce,
+      changed: forwardBumped || gapFillFilled.length > 0 || rbfAttempted.length > 0 || headBumpNonce !== null,
+      reason: `nonce is consistent with chain state${forwardBumpSummary}${gapFilledSummary}${rbfSummary}${headBumpSummary}`,
     };
   }
 


### PR DESCRIPTION
## Summary

- Fix "frontier drift" bug where `advanceChainFrontier` used Hiro's `possible_next_nonce` (mempool-aware) instead of `last_executed_tx_nonce + 1` (confirmed), causing the frontier to leap past unconfirmed gaps and making them invisible to the self-healing alarm
- Remove early return in `reconcileNonceForWallet` forward-bump branch so gap-fill detection and broadcast still execute when `possible_next_nonce > head`
- Update reconciliation return value to reflect combined forward bump + gap-fill outcomes

## Problem

Observed on mainnet wallet 0 (`SP1PMPPVCMVW96FSWFV30KJQ4MNBMZ8MRWR3JWQ7`):

| Source | Value |
|--------|-------|
| Hiro `last_executed_tx_nonce` | 1548 |
| Hiro `possible_next_nonce` | 1575 |
| Hiro `detected_missing_nonces` | [1549, 1553, 1555, 1559, 1561, 1567, 1569] |
| Relay `chainFrontier` | 1575 |
| Relay `assignmentHead` | 1575 |
| Relay `headroom` | 20 |
| Relay `healthy` | true |

The relay reported fully healthy with zero gaps while 18 mempool txs were stuck behind 7 unfilled nonce gaps. The relay read the missing nonces from Hiro during reconciliation but then immediately advanced its frontier past them, forgetting what it just learned.

### Root cause (two compounding issues)

1. **`advanceChainFrontier` fed mempool state**: `possible_next_nonce` includes mempool txs. When a tx at nonce 1574 hits the mempool, `possible_next_nonce` jumps to 1575 — but `last_executed_tx_nonce` is still 1548. The frontier leapt 27 nonces ahead of actual confirmations.

2. **Forward bump early return**: When `possible_next_nonce > head`, `reconcileNonceForWallet` returned immediately after bumping the head, skipping the gap-fill broadcast loop entirely. Even if gap-fill nonces were detected, they were never acted on.

## Fix

1. All `advanceChainFrontier` call sites now compute `last_executed_tx_nonce + 1` (falls back to `possible_next_nonce` for fresh addresses with no confirmed txs)
2. Forward bump sets a `forwardBumped` flag instead of returning — execution falls through to gap-fill detection and broadcast
3. Return value merges forward bump + gap-fill state for accurate diagnostics

## Limitations

This fix prevents frontier drift going forward but **does not repair existing stuck state**. The current frontier (1575) is stored in DO persistent storage and `advanceChainFrontier` is monotonic (only moves forward). To fix the current mainnet gaps, either:
- Use the admin `POST /fill-gaps/0` endpoint (fetches live Hiro data, bypasses frontier)
- Or add a one-time frontier regression when `chainFrontier > last_executed_tx_nonce + 1`

## Test plan

- [ ] Verify `npm run check` passes (pre-existing `@aibtc/tx-schemas` errors unrelated)
- [ ] Deploy to staging, trigger nonce gaps, confirm alarm fills them within 1-2 cycles
- [ ] Verify `/nonce/state` shows frontier tracking `last_executed_tx_nonce + 1` not `possible_next_nonce`
- [ ] After deploy to mainnet, use `POST /fill-gaps/0` to clear existing stuck gaps
- [ ] Monitor that new gaps are self-healed by the alarm without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)