### PR TITLE
refactor(nonce): replace degradation state machines with per-nonce tracking and isOrigin routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "x402-sponsor-relay",
       "version": "1.27.2",
       "dependencies": {
-        "@aibtc/tx-schemas": "^0.3.0",
+        "@aibtc/tx-schemas": "^0.4.0",
         "@noble/curves": "^2.0.1",
         "@scure/btc-signer": "^2.0.1",
         "@stacks/common": "^7.3.1",
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@aibtc/tx-schemas": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.3.0.tgz",
-      "integrity": "sha512-pXzW9TnmFR3uJMfajbUdAYiPKRkNlzWWL2WGZ554NAeVIPq9vWyL6x8nrYtaDohuHlZRmMj1tSVeFap9AA+adw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.4.0.tgz",
+      "integrity": "sha512-51z8O+mNGnqwoisKZCvvC8ZNBv0Z+RIfSTQ2CV99NFk4Z4ySp+KX+kPEpwlbLLul3AySn/AD9EHWXrjcGaAYAg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "wrangler": "^4.75.0"
   },
   "dependencies": {
-    "@aibtc/tx-schemas": "^0.3.0",
+    "@aibtc/tx-schemas": "^0.4.0",
     "@noble/curves": "^2.0.1",
     "@scure/btc-signer": "^2.0.1",
     "@stacks/common": "^7.3.1",

--- a/src/__tests__/ghost-wallet-fee-escalation.test.ts
+++ b/src/__tests__/ghost-wallet-fee-escalation.test.ts
@@ -8,169 +8,56 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 // Constants (mirrored from nonce-do.ts internals)
 // ---------------------------------------------------------------------------
-const GHOST_FAILURE_THRESHOLD = 5;
 const GAP_FILL_FEE = 30_000n;
 const MAX_BROADCAST_FEE = 90_000n;
 const CHAINING_LIMIT = 20;
 
 // ---------------------------------------------------------------------------
-// Helpers
+// buildSponsorStatusSnapshot: available math (no ghost-degraded flags)
 // ---------------------------------------------------------------------------
 
-/** Minimal nonce_state KV store for ghost counter tests */
-function makeStateStore(initial: Record<string, number> = {}) {
-  const store = new Map<string, number | null>();
-  for (const [k, v] of Object.entries(initial)) {
-    store.set(k, v);
-  }
-  return {
-    getStateValue: (key: string) => store.get(key) ?? null,
-    setStateValue: (key: string, value: number) => store.set(key, value),
-    walletGhostFailuresKey: (NonceDO as any).prototype.walletGhostFailuresKey,
-    walletGhostDegradedKey: (NonceDO as any).prototype.walletGhostDegradedKey,
-    _store: store,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Ghost counter semantics
-// ---------------------------------------------------------------------------
-
-describe("ghost wallet counter semantics", () => {
-  const incrementGhostFailures = (NonceDO as any).prototype.incrementGhostFailures;
-  const resetGhostState = (NonceDO as any).prototype.resetGhostState;
-  const walletGhostFailuresKey = (NonceDO as any).prototype.walletGhostFailuresKey;
-  const walletGhostDegradedKey = (NonceDO as any).prototype.walletGhostDegradedKey;
-
-  it("increments ghost failures and marks degraded at threshold", () => {
-    const ctx = { ...makeStateStore(), log: vi.fn() };
-
-    // Increment up to threshold - 1: NOT degraded yet
-    for (let i = 1; i < GHOST_FAILURE_THRESHOLD; i++) {
-      const becameDegraded = incrementGhostFailures.call(ctx, 0);
-      expect(becameDegraded).toBe(false);
-      expect(ctx.getStateValue(walletGhostFailuresKey.call(ctx, 0))).toBe(i);
-      expect(ctx.getStateValue(walletGhostDegradedKey.call(ctx, 0))).toBeNull();
-    }
-
-    // One more push reaches threshold → degraded
-    const becameDegraded = incrementGhostFailures.call(ctx, 0);
-    expect(becameDegraded).toBe(true);
-    expect(ctx.getStateValue(walletGhostFailuresKey.call(ctx, 0))).toBe(GHOST_FAILURE_THRESHOLD);
-    expect(ctx.getStateValue(walletGhostDegradedKey.call(ctx, 0))).toBe(1);
-    expect(ctx.log).toHaveBeenCalledWith("warn", "ghost_wallet_degraded", expect.objectContaining({
-      walletIndex: 0,
-      ghostFailures: GHOST_FAILURE_THRESHOLD,
-      threshold: GHOST_FAILURE_THRESHOLD,
-    }));
-  });
-
-  it("does not re-log degraded on subsequent increments past threshold", () => {
-    const ctx = { ...makeStateStore(), log: vi.fn() };
-
-    // Push past threshold
-    for (let i = 0; i <= GHOST_FAILURE_THRESHOLD; i++) {
-      incrementGhostFailures.call(ctx, 0);
-    }
-    expect(ctx.log).toHaveBeenCalledTimes(1); // only the first crossing
-
-    // One more: already degraded, no new log
-    const becameDegraded = incrementGhostFailures.call(ctx, 0);
-    expect(becameDegraded).toBe(false);
-    expect(ctx.log).toHaveBeenCalledTimes(1);
-  });
-
-  it("resetGhostState clears counter and degraded flag", () => {
-    const ctx = {
-      ...makeStateStore({
-        "wallet_ghost_failures:2": GHOST_FAILURE_THRESHOLD + 3,
-        "wallet_ghost_degraded:2": 1,
-      }),
-      log: vi.fn(),
-    };
-
-    resetGhostState.call(ctx, 2);
-
-    expect(ctx.getStateValue(walletGhostFailuresKey.call(ctx, 2))).toBe(0);
-    expect(ctx.getStateValue(walletGhostDegradedKey.call(ctx, 2))).toBe(0);
-    expect(ctx.log).toHaveBeenCalledWith("info", "ghost_wallet_recovered", { walletIndex: 2 });
-  });
-
-  it("resetGhostState does not log recovery when wallet was not degraded", () => {
-    const ctx = {
-      ...makeStateStore({
-        "wallet_ghost_failures:1": 2,
-      }),
-      log: vi.fn(),
-    };
-
-    resetGhostState.call(ctx, 1);
-
-    expect(ctx.getStateValue(walletGhostFailuresKey.call(ctx, 1))).toBe(0);
-    expect(ctx.log).not.toHaveBeenCalled();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildSponsorStatusSnapshot: ghost-degraded wallets report 0 available
-// ---------------------------------------------------------------------------
-
-describe("buildSponsorStatusSnapshot ghost-degraded wallets", () => {
-  function makeSnapshotDouble(opts: { rawAvailabilities: number[]; ghostDegradedWallets?: number[] }) {
-    const ghostSet = new Set(opts.ghostDegradedWallets ?? []);
+describe("buildSponsorStatusSnapshot available math", () => {
+  function makeSnapshotDouble(opts: { rawAvailabilities: number[] }) {
     return {
-      getInitializedWallets: async () => opts.rawAvailabilities.map((_, walletIndex) => ({ walletIndex })),
-      state: {
-        storage: {
-          get: async () => [],
-        },
-      },
-      walletQuarantineRecentKey: (walletIndex: number) => `quarantine:${walletIndex}`,
+      getInitializedWallets: () => opts.rawAvailabilities.map((_, walletIndex) => ({ walletIndex })),
       walletHeadroom: (walletIndex: number) => opts.rawAvailabilities[walletIndex],
-      walletGhostDegradedKey: (walletIndex: number) => `wallet_ghost_degraded:${walletIndex}`,
-      getStateValue: (key: string) => {
-        // Parse wallet index from key like "wallet_ghost_degraded:3"
-        const match = key.match(/wallet_ghost_degraded:(\d+)/);
-        if (match && ghostSet.has(Number(match[1]))) return 1;
-        return null;
-      },
+      getStateValue: () => null,
       getStoredCount: () => 0,
     };
   }
 
-  it("reports available: 0 for ghost-degraded wallet with positive headroom", async () => {
+  it("reports correct available from headroom", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-04-04T12:00:00.000Z"));
 
     const snapshot = await (NonceDO as any).prototype.buildSponsorStatusSnapshot.call(
-      makeSnapshotDouble({ rawAvailabilities: [15], ghostDegradedWallets: [0] })
+      makeSnapshotDouble({ rawAvailabilities: [15] })
     );
 
-    expect(snapshot.noncePool.totalAvailable).toBe(0);
-    expect(snapshot.noncePool.totalReserved).toBe(CHAINING_LIMIT);
+    expect(snapshot.noncePool.totalAvailable).toBe(15);
+    expect(snapshot.noncePool.totalReserved).toBe(CHAINING_LIMIT - 15);
     expect(snapshot.noncePool.totalCapacity).toBe(CHAINING_LIMIT);
+    expect(snapshot.allWalletsDegraded).toBe(false);
   });
 
-  it("includes ghost-degraded in allWalletsDegraded check", async () => {
+  it("allWalletsDegraded only when all wallets at zero available", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-04-04T12:00:00.000Z"));
 
     const snapshot = await (NonceDO as any).prototype.buildSponsorStatusSnapshot.call(
-      makeSnapshotDouble({ rawAvailabilities: [10], ghostDegradedWallets: [0] })
+      makeSnapshotDouble({ rawAvailabilities: [0] })
     );
 
     expect(snapshot.allWalletsDegraded).toBe(true);
   });
 
-  it("healthy wallet unaffected when sibling is ghost-degraded", async () => {
+  it("multi-wallet available sums correctly", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-04-04T12:00:00.000Z"));
 
     const snapshot = await (NonceDO as any).prototype.buildSponsorStatusSnapshot.call(
-      makeSnapshotDouble({ rawAvailabilities: [10, 15], ghostDegradedWallets: [0] })
+      makeSnapshotDouble({ rawAvailabilities: [10, 15] })
     );
 
-    // Wallet 0: ghost-degraded → 0 available, 20 reserved
-    // Wallet 1: healthy → 15 available, 5 reserved
-    expect(snapshot.noncePool.totalAvailable).toBe(15);
-    expect(snapshot.noncePool.totalReserved).toBe(25);
+    expect(snapshot.noncePool.totalAvailable).toBe(25);
+    expect(snapshot.noncePool.totalReserved).toBe(2 * CHAINING_LIMIT - 25);
     expect(snapshot.allWalletsDegraded).toBe(false);
   });
 });

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -246,6 +246,7 @@ interface ObservableWalletState {
   gaps: number[];
   available: number;
   reserved: number;
+  /** @deprecated Always false — circuit breaker removed in favor of per-nonce tracking */
   circuitBreakerOpen: boolean;
   healthy: boolean;
   /** Total non-confirmed dispatch_queue rows (queued + dispatched + replaying) */
@@ -254,10 +255,6 @@ interface ObservableWalletState {
   replayBufferDepth?: number;
   /** Settlement time percentiles for this wallet (last 24h, null if no data) */
   settlementTimes?: SettlementTimeStats;
-  /** True when the wallet has accumulated GHOST_FAILURE_THRESHOLD consecutive ghost failures */
-  ghostDegraded?: boolean;
-  /** Number of consecutive ghost broadcast failures (ConflictingNonceInMempool with no Hiro-visible occupant) */
-  ghostFailures?: number;
 }
 
 /**
@@ -399,12 +396,6 @@ const ALARM_INTERVAL_MS = 5 * 60 * 1000;
 const ALARM_INTERVAL_ACTIVE_MS = 60 * 1000;
 /** Alias for readability: idle wallets revert to the standard 5-minute cadence. */
 const ALARM_INTERVAL_IDLE_MS = ALARM_INTERVAL_MS;
-/**
- * Alarm interval used when a cross-wallet cascade is active AND there are in-flight nonces.
- * 20s fires much more often than the normal 60s active cadence, accelerating RBF and gap-fill
- * cycles during nonce storms so the DO self-heals without waiting for agent retries.
- */
-const ALARM_INTERVAL_CASCADE_MS = 20 * 1000;
 /** Reset to possible_next_nonce if no assignment in this window and we are ahead */
 const STALE_THRESHOLD_MS = 10 * 60 * 1000;
 /** Maximum number of sponsor wallets supported */
@@ -444,10 +435,6 @@ const SENDER_REFRESH_FAILURE_BACKOFF_MS = 2 * 60 * 1000;
  * probability and are candidates for RBF replacement.
  */
 const STUCK_TX_AGE_MS = 15 * 60 * 1000;
-/** Reduced stuck-tx age when a cross-wallet cascade is active (5 min) */
-const STUCK_TX_AGE_CASCADE_MS = 5 * 60 * 1000;
-/** Most aggressive stuck-tx age when a wallet's circuit breaker is open (3 min) */
-const STUCK_TX_AGE_CIRCUIT_OPEN_MS = 3 * 60 * 1000;
 /**
  * Compute the RBF fee for replacing a stuck tx.
  * Stacks only requires original_fee + 1 uSTX to replace. When original_fee is known
@@ -483,22 +470,6 @@ const MAX_RBF_ATTEMPTS = 3;
  * replacement + resubmission window exceeds the call's deadline.
  */
 const HEAD_BUMP_FEE = MIN_FLUSH_FEE * 2n;
-/**
- * Per-wallet circuit breaker: if a wallet accumulates this many quarantines
- * within CIRCUIT_BREAKER_WINDOW_MS, it is skipped during nonce assignment
- * and an eager resync is triggered for that wallet only.
- */
-// Single failure = immediate skip. Wallet recovers naturally when the 10-minute
-// CIRCUIT_BREAKER_WINDOW_MS expires. For a payment relay, every failed broadcast
-// is a user-facing SETTLEMENT_TIMEOUT — aggressive quarantine is correct.
-const CIRCUIT_BREAKER_QUARANTINE_THRESHOLD = 1;
-/**
- * Number of consecutive ghost broadcast failures before a wallet is marked ghost_degraded.
- * A "ghost" failure is a ConflictingNonceInMempool where fetchOccupantFee returns null —
- * the node holds a transaction that Hiro cannot see (invisible mempool entry).
- * Ghost-degraded wallets are skipped during nonce assignment until they self-clear.
- */
-const GHOST_FAILURE_THRESHOLD = 5;
 /** Maximum fee cap for gap-fill escalation and RBF broadcasts (90,000 uSTX) */
 const MAX_BROADCAST_FEE = 90_000n;
 
@@ -544,13 +515,6 @@ const ALARM_WALLET_CURSOR_KEY = "alarm_wallet_cursor";
 
 /** nonce_state key for the round-robin sender sweep cursor */
 const ALARM_SENDER_CURSOR_KEY = "alarm_sender_cursor";
-/** Time window for circuit breaker quarantine counting (10 minutes) */
-const CIRCUIT_BREAKER_WINDOW_MS = 10 * 60 * 1000;
-/**
- * Cross-wallet cascade detection: log a cascade_detected event when quarantine
- * count across all wallets exceeds this threshold within CIRCUIT_BREAKER_WINDOW_MS.
- */
-const CASCADE_DETECTION_THRESHOLD = 3;
 
 /**
  * Pool pressure threshold (0.80 = 80%) above which a surge event is recorded.
@@ -619,26 +583,6 @@ class LowHeadroomError extends Error {
     // Estimate: each confirmed tx frees one nonce slot. ~2 txs/s drain rate.
     // Backoff scales with pool pressure: more reserved nonces → longer wait.
     this.retryAfterSeconds = Math.ceil((CHAINING_LIMIT - maxHeadroom) / 2) + 5;
-  }
-}
-
-/**
- * Thrown when ALL wallets are circuit-broken (degraded) but at least one has
- * headroom. Previously the code fell back to the "least degraded" wallet,
- * which fed transactions into a broken pool and amplified contention.
- * Now we reject immediately with a retry hint.
- */
-class AllWalletsDegradedError extends Error {
-  readonly degradedCount: number;
-  readonly totalReserved: number;
-  readonly totalCapacity: number;
-
-  constructor(degradedCount: number, totalReserved: number, totalCapacity: number) {
-    super("ALL_WALLETS_DEGRADED");
-    this.name = "AllWalletsDegradedError";
-    this.degradedCount = degradedCount;
-    this.totalReserved = totalReserved;
-    this.totalCapacity = totalCapacity;
   }
 }
 
@@ -2432,7 +2376,6 @@ export class NonceDO {
         state.lastRbfTxid = result.txid;
         await this.state.storage.put(key, state);
         this.incrementCounter(STATE_KEYS.stuckTxRbfBroadcast);
-        this.resetGhostState(walletIndex);
         // Update the ledger txid so reconciliation tracks the replacement
         try {
           this.sql.exec(
@@ -2464,7 +2407,6 @@ export class NonceDO {
         // Terminal — delete stuck-tx state entirely to avoid orphaned entries
         state.rbfAttempts = attemptNum;
         await this.state.storage.delete(key);
-        this.resetGhostState(walletIndex);
         this.log("info", "rbf_nonce_consumed", {
           walletIndex,
           nonce,
@@ -2476,28 +2418,21 @@ export class NonceDO {
       }
 
       if (result.reason === "ConflictingNonceInMempool") {
-        // Classify the conflict based on why occupant fee lookup failed:
-        //   no_txid/not_found = true ghost (node holds tx invisible to Hiro)
-        //   hiro_error = transient Hiro failure — don't penalize the wallet
-        //   fee discovered = our fee was too low
+        // Classify the conflict for logging — no per-wallet degradation flags.
         const occupantReason = occupantResult.reason;
         const isGhost = occupantReason === "no_txid" || occupantReason === "not_found";
         const isHiroError = occupantReason === "hiro_error";
 
         if (isGhost) {
-          // True ghost — node holds something invisible to Hiro: increment ghost counter.
-          // Do NOT increment rbfAttempts — this is a guaranteed failure, not a real attempt.
-          this.incrementGhostFailures(walletIndex);
+          // Ghost — node holds tx invisible to Hiro. Log but don't penalize wallet.
           this.log("warn", "rbf_ghost_conflict", {
             walletIndex,
             nonce,
-            ghostFailures: this.getStateValue(this.walletGhostFailuresKey(walletIndex)),
             rbfFee: rbfFee.toString(),
             occupantReason,
           });
         } else if (isHiroError) {
-          // Hiro was unavailable — we can't determine occupant fee, don't blame the wallet.
-          // Do NOT increment rbfAttempts or ghost counter.
+          // Hiro unavailable — can't determine occupant fee, don't blame the wallet.
           this.log("warn", "rbf_conflict_hiro_unavailable", {
             walletIndex,
             nonce,
@@ -2505,10 +2440,8 @@ export class NonceDO {
             attemptNum,
           });
         } else {
-          // Fee too low (occupant fee discovered but our fee wasn't enough) — increment counter.
-          // This is a non-ghost outcome: reset ghost state if accumulated.
+          // Fee too low — occupant fee discovered but ours wasn't enough.
           state.rbfAttempts = attemptNum;
-          this.resetGhostState(walletIndex);
           this.log("warn", "rbf_fee_too_low", {
             walletIndex,
             nonce,
@@ -2836,59 +2769,6 @@ export class NonceDO {
     return `stuck_tx:${walletIndex}:${nonce}`;
   }
 
-  /** KV key for per-wallet recent quarantine timestamps (circuit breaker window) */
-  private walletQuarantineRecentKey(walletIndex: number): string {
-    return `wallet_quarantine_recent:${walletIndex}`;
-  }
-
-  /** nonce_state key for per-wallet ghost failure counter */
-  private walletGhostFailuresKey(walletIndex: number): string {
-    return `wallet_ghost_failures:${walletIndex}`;
-  }
-
-  /** nonce_state key for per-wallet ghost-degraded flag (0 = healthy, 1 = degraded) */
-  private walletGhostDegradedKey(walletIndex: number): string {
-    return `wallet_ghost_degraded:${walletIndex}`;
-  }
-
-  /**
-   * Increment the ghost failure counter for a wallet.
-   * When the counter reaches GHOST_FAILURE_THRESHOLD, marks the wallet as ghost_degraded.
-   * Ghost-degraded wallets are skipped during nonce assignment.
-   * Returns true if the wallet just became ghost_degraded.
-   */
-  private incrementGhostFailures(walletIndex: number): boolean {
-    const count = (this.getStateValue(this.walletGhostFailuresKey(walletIndex)) ?? 0) + 1;
-    this.setStateValue(this.walletGhostFailuresKey(walletIndex), count);
-    if (count >= GHOST_FAILURE_THRESHOLD) {
-      const alreadyDegraded = (this.getStateValue(this.walletGhostDegradedKey(walletIndex)) ?? 0) === 1;
-      this.setStateValue(this.walletGhostDegradedKey(walletIndex), 1);
-      if (!alreadyDegraded) {
-        this.log("warn", "ghost_wallet_degraded", {
-          walletIndex,
-          ghostFailures: count,
-          threshold: GHOST_FAILURE_THRESHOLD,
-        });
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Reset ghost failure state for a wallet on any non-ghost broadcast outcome.
-   * Called after: successful RBF, successful gap-fill, BadNonce (consumed),
-   * or fee-too-low (occupant fee was discovered, so not a ghost).
-   */
-  private resetGhostState(walletIndex: number): void {
-    const wasDegraded = (this.getStateValue(this.walletGhostDegradedKey(walletIndex)) ?? 0) === 1;
-    this.setStateValue(this.walletGhostFailuresKey(walletIndex), 0);
-    this.setStateValue(this.walletGhostDegradedKey(walletIndex), 0);
-    if (wasDegraded) {
-      this.log("info", "ghost_wallet_recovered", { walletIndex });
-    }
-  }
-
   /**
    * Compute the escalated gap-fill fee for a nonce based on prior attempts.
    * Returns baseFee + priorAttempts (capped at MAX_BROADCAST_FEE), or baseFee if no prior attempts.
@@ -2910,100 +2790,6 @@ export class NonceDO {
       }
     } catch { /* fail-open — use base fee */ }
     return baseFee;
-  }
-
-  /** KV key for cross-wallet cascade quarantine tracking */
-  private readonly cascadeQuarantineKey = "cascade_quarantine_window";
-
-  /**
-   * Record a quarantine event for a specific wallet.
-   * Maintains a rolling window of recent quarantine timestamps for the circuit breaker.
-   * Also contributes to cross-wallet cascade detection.
-   * Called from releaseNonce() only for failure quarantines (not normal consumption).
-   */
-  private async recordQuarantineEvent(walletIndex: number): Promise<void> {
-    const now = new Date().toISOString();
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-
-    // Update per-wallet recent quarantine list
-    const recentKey = this.walletQuarantineRecentKey(walletIndex);
-    const existing = (await this.state.storage.get<string[]>(recentKey)) ?? [];
-    const pruned = existing.filter((ts) => new Date(ts).getTime() >= cutoff);
-    pruned.push(now);
-    await this.state.storage.put(recentKey, pruned);
-
-    if (pruned.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD) {
-      this.log("warn", "circuit_breaker_triggered", {
-        walletIndex,
-        quarantineCount: pruned.length,
-        windowMs: CIRCUIT_BREAKER_WINDOW_MS,
-        threshold: CIRCUIT_BREAKER_QUARANTINE_THRESHOLD,
-      });
-    }
-
-    // Update cross-wallet cascade window
-    await this.checkCascadeThreshold(walletIndex, now);
-  }
-
-  /**
-   * Check if cross-wallet quarantines have crossed the cascade detection threshold.
-   * Logs a cascade_detected event when >= CASCADE_DETECTION_THRESHOLD quarantines
-   * have occurred across any wallets within the circuit breaker time window.
-   */
-  private async checkCascadeThreshold(walletIndex: number, ts: string): Promise<void> {
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-    const existing = (await this.state.storage.get<Array<{ walletIndex: number; ts: string }>>(
-      this.cascadeQuarantineKey
-    )) ?? [];
-
-    const pruned = existing.filter((e) => new Date(e.ts).getTime() >= cutoff);
-    pruned.push({ walletIndex, ts });
-    await this.state.storage.put(this.cascadeQuarantineKey, pruned);
-
-    if (pruned.length >= CASCADE_DETECTION_THRESHOLD) {
-      const uniqueWallets = [...new Set(pruned.map((e) => e.walletIndex))];
-      this.log("warn", "cascade_detected", {
-        totalQuarantinesInWindow: pruned.length,
-        affectedWallets: uniqueWallets,
-        windowMs: CIRCUIT_BREAKER_WINDOW_MS,
-        threshold: CASCADE_DETECTION_THRESHOLD,
-        detectedAt: ts,
-      });
-    }
-  }
-
-  /**
-   * Return true when a cross-wallet cascade is currently active.
-   * A cascade is active when >= CASCADE_DETECTION_THRESHOLD quarantine events have
-   * been recorded across any wallets within the CIRCUIT_BREAKER_WINDOW_MS window.
-   * Reads the same KV key that checkCascadeThreshold() writes so the signal is
-   * consistent without adding a separate flag.
-   */
-  private async isCascadeActive(): Promise<boolean> {
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-    const existing = (await this.state.storage.get<Array<{ walletIndex: number; ts: string }>>(
-      this.cascadeQuarantineKey
-    )) ?? [];
-    const pruned = existing.filter((e) => new Date(e.ts).getTime() >= cutoff);
-    if (pruned.length !== existing.length) {
-      await this.state.storage.put(this.cascadeQuarantineKey, pruned);
-    }
-    return pruned.length >= CASCADE_DETECTION_THRESHOLD;
-  }
-
-  /**
-   * Return the effective "stuck tx" age threshold for RBF eligibility.
-   * During a cascade the relay needs to RBF stuck transactions sooner so the
-   * nonce pipeline can drain before the situation worsens.
-   *
-   * - circuitOpen (any wallet): 3 min — most aggressive, wallet already skipped
-   * - cascadeActive:            5 min — multiple wallets affected, speed up RBF
-   * - normal:                  15 min (STUCK_TX_AGE_MS)
-   */
-  private getEffectiveStuckTxAge(cascadeActive: boolean, circuitOpen: boolean): number {
-    if (circuitOpen) return STUCK_TX_AGE_CIRCUIT_OPEN_MS;
-    if (cascadeActive) return STUCK_TX_AGE_CASCADE_MS;
-    return STUCK_TX_AGE_MS;
   }
 
   /**
@@ -3970,76 +3756,28 @@ export class NonceDO {
         )
       );
 
-      // Round-robin: start from stored nextWalletIndex, find a wallet under chaining limit
-      let walletIndex = (await this.getNextWalletIndex()) % effectiveWalletCount;
-
       // Resolve the correct sponsor address for a given wallet index.
       // In multi-wallet mode, each wallet has its own Stacks address for nonce seeding.
       const resolveAddress = (wi: number): string =>
         addresses?.[String(wi)] ?? sponsorAddress;
 
-      // Try each wallet in round-robin order; skip any at chaining limit or degraded (stuck nonce)
-      let attempts = 0;
+      // Scan all wallets and select the one with the most available headroom.
+      // No degradation flags — per-nonce occupied tracking handles conflicts.
       let totalMempoolDepth = 0;
-      // Track degraded wallets for fallback (walletIndex only — no pool state needed)
-      const degradedWallets: Array<{ walletIndex: number; cycleCount: number }> = [];
-      /** Eligible (under chaining limit) wallets with their available headroom */
       const eligibleWallets: Array<{ walletIndex: number; headroom: number }> = [];
-      let selectedWalletIndex: number | null = null;
 
-      while (attempts < effectiveWalletCount) {
-        // Ensure wallet head is initialized before circuit breaker check
-        await this.initWalletHeadFromHiro(walletIndex, resolveAddress(walletIndex));
-
-        // Check per-wallet circuit breaker: skip if too many recent quarantines
-        const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-        const recentQuarantines = (
-          await this.state.storage.get<string[]>(this.walletQuarantineRecentKey(walletIndex))
-        ) ?? [];
-        const activeQuarantines = recentQuarantines.filter(
-          (ts) => new Date(ts).getTime() >= cutoff
-        );
-        if (activeQuarantines.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD) {
-          this.log("warn", "circuit_breaker_skip", {
-            walletIndex,
-            quarantineCount: activeQuarantines.length,
-            windowMs: CIRCUIT_BREAKER_WINDOW_MS,
-            threshold: CIRCUIT_BREAKER_QUARANTINE_THRESHOLD,
-          });
-          degradedWallets.push({ walletIndex, cycleCount: 0 });
-          walletIndex = (walletIndex + 1) % effectiveWalletCount;
-          attempts++;
-          continue;
-        }
-
-        // Check ghost-degraded state: skip wallets where broadcast failures indicate
-        // the node holds transactions invisible to Hiro (ghost mempool entries).
-        const isGhostDegraded = (this.getStateValue(this.walletGhostDegradedKey(walletIndex)) ?? 0) === 1;
-        if (isGhostDegraded) {
-          this.log("warn", "ghost_degraded_skip", {
-            walletIndex,
-            ghostFailures: this.getStateValue(this.walletGhostFailuresKey(walletIndex)) ?? 0,
-          });
-          degradedWallets.push({ walletIndex, cycleCount: 0 });
-          walletIndex = (walletIndex + 1) % effectiveWalletCount;
-          attempts++;
-          continue;
-        }
-
-        const headroom = this.walletHeadroom(walletIndex);
+      for (let i = 0; i < effectiveWalletCount; i++) {
+        await this.initWalletHeadFromHiro(i, resolveAddress(i));
+        const headroom = this.walletHeadroom(i);
         if (headroom > 0) {
-          // Collect all eligible wallets; select by headroom after full scan
-          eligibleWallets.push({ walletIndex, headroom });
+          eligibleWallets.push({ walletIndex: i, headroom });
         } else {
-          // This wallet is at its chaining limit; accumulate depth for error reporting
-          totalMempoolDepth += CHAINING_LIMIT - headroom; // headroom is 0 (or negative on fallback path)
+          totalMempoolDepth += CHAINING_LIMIT - headroom;
         }
-        walletIndex = (walletIndex + 1) % effectiveWalletCount;
-        attempts++;
       }
 
-      // Select wallet with most chain headroom (fewest in-flight nonces).
-      // Prefer a wallet that has more room to absorb additional burst traffic.
+      // Select wallet with most available headroom (fewest in-flight nonces).
+      let selectedWalletIndex: number | null = null;
       if (eligibleWallets.length > 0) {
         eligibleWallets.sort((a, b) => b.headroom - a.headroom);
         const best = eligibleWallets[0];
@@ -4057,35 +3795,10 @@ export class NonceDO {
       }
 
       if (selectedWalletIndex === null) {
-        // No healthy wallet with capacity was found. Remaining wallets are either:
-        // - At chaining limit (healthy but full)
-        // - Circuit-broken (degraded, may have capacity)
-        // Reject instead of falling back to a degraded wallet — feeding transactions
-        // into a broken pool amplifies contention (see #226).
-        const degradedNotFull = degradedWallets.filter(
-          (d) => this.walletHeadroom(d.walletIndex) > 0
-        );
-        if (degradedNotFull.length > 0) {
-          // The only wallets with capacity are circuit-broken — reject so callers
-          // can distinguish this from pure chaining limit exhaustion.
-          const totalReservedAll = this.poolTotalReserved(effectiveWalletCount);
-          this.log("warn", "all_wallets_degraded_rejecting", {
-            degradedCount: degradedWallets.length,
-            degradedNotFullCount: degradedNotFull.length,
-            totalReserved: totalReservedAll,
-            totalCapacity: effectiveWalletCount * CHAINING_LIMIT,
-          });
-          throw new AllWalletsDegradedError(
-            degradedWallets.length,
-            totalReservedAll,
-            effectiveWalletCount * CHAINING_LIMIT,
-          );
-        } else {
-          throw new ChainingLimitError(totalMempoolDepth);
-        }
+        throw new ChainingLimitError(totalMempoolDepth);
       }
 
-      walletIndex = selectedWalletIndex;
+      const walletIndex = selectedWalletIndex;
 
       // Store the per-wallet sponsor address (used by alarm reconciliation)
       await this.setStoredSponsorAddressForWallet(walletIndex, resolveAddress(walletIndex));
@@ -4165,13 +3878,12 @@ export class NonceDO {
    *
    * txid present   → nonce was broadcast successfully; mark as 'confirmed' in ledger.
    * txid absent    → nonce was NOT broadcast (e.g. broadcast failure). Priority order:
-   *   1. errorReason provided → immediate quarantine ('failed' state) + recordQuarantineEvent.
-   *      Use for contention-specific terminal failures (TooMuchChaining, nonce_conflict).
-   *   2. Prior txid in nonce_txids → quarantine (broadcast happened but release has no txid).
+   *   1. errorReason provided → mark as 'failed' with reason recorded.
+   *   2. Prior txid in nonce_txids → mark as 'failed' (broadcast happened but release has no txid).
    *   3. Neither → mark as 'expired' (truly unused nonce, available for gap-fill).
    * walletIndex    → which wallet the nonce belongs to (default: 0)
    * fee            → when provided with txid (broadcast succeeded), recorded in cumulative wallet stats
-   * errorReason    → triggers quarantine when txid is absent (feeds circuit breaker)
+   * errorReason    → recorded in ledger for diagnostics
    */
   async releaseNonce(nonce: number, txid?: string, walletIndex: number = 0, fee?: string, errorReason?: string): Promise<void> {
     return this.state.blockConcurrencyWhile(async () => {
@@ -4190,14 +3902,8 @@ export class NonceDO {
         return;
       }
 
-      // Track whether this is a failure quarantine (for circuit breaker)
-      let failureQuarantined = false;
-
       if (!txid) {
-        // Caller-supplied error reason (e.g. TooMuchChaining, nonce_conflict from queue-consumer)
-        // takes priority — quarantine immediately so the circuit breaker fires.
         if (errorReason) {
-          failureQuarantined = true;
           this.log("warn", "nonce_quarantined", {
             walletIndex,
             nonce,
@@ -4206,7 +3912,6 @@ export class NonceDO {
           this.ledgerRelease(walletIndex, nonce, undefined, errorReason);
         } else {
           // No explicit error reason: check if a txid was previously recorded in nonce_txids.
-          // If so, the nonce was broadcast at some point — quarantine as failure.
           const txidRows = this.sql
             .exec<{ count: number }>(
               "SELECT COUNT(*) as count FROM nonce_txids WHERE nonce = ?",
@@ -4216,8 +3921,6 @@ export class NonceDO {
           const hasPriorTxid = (txidRows[0]?.count ?? 0) > 0;
 
           if (hasPriorTxid) {
-            // Nonce was broadcast at some point — quarantine permanently
-            failureQuarantined = true;
             this.log("warn", "nonce_quarantined", {
               walletIndex,
               nonce,
@@ -4226,15 +3929,12 @@ export class NonceDO {
             this.ledgerRelease(walletIndex, nonce, undefined, "txid_recorded_on_failed_release");
           } else {
             // Truly unused nonce (never broadcast) — mark expired
-            // The ledger head already advanced past this nonce on assignment,
-            // so this creates a gap that reconciliation will fill if needed.
             this.ledgerRelease(walletIndex, nonce, undefined);
           }
         }
       } else {
         // txid provided: nonce was broadcast successfully — consumed
         if (fee && fee !== "0") {
-          // Broadcast succeeded and fee provided — record in wallet stats
           await this.recordWalletFee(walletIndex, fee);
         }
         this.ledgerRelease(walletIndex, nonce, txid);
@@ -4247,11 +3947,6 @@ export class NonceDO {
         txid: txid ?? null,
         ledgerReserved: this.ledgerReservedCount(walletIndex),
       });
-
-      // Circuit breaker: only record failure quarantines (not normal consumption).
-      if (failureQuarantined) {
-        await this.recordQuarantineEvent(walletIndex);
-      }
 
       await this.refreshSponsorStatusSnapshot();
     });
@@ -4309,80 +4004,42 @@ export class NonceDO {
    */
   async getPoolHealth(): Promise<PoolHealthResponse> {
     const initializedWallets = await this.getInitializedWallets();
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
 
-    // Parallelize KV reads across wallets — avoids N serial awaits as the pool grows
-    const wallets: WalletHealthSnapshot[] = await Promise.all(
-      initializedWallets.map(async ({ walletIndex }) => {
-        const recentQuarantines =
-          (await this.state.storage.get<string[]>(
-            this.walletQuarantineRecentKey(walletIndex)
-          )) ?? [];
-        const activeQuarantines = recentQuarantines.filter(
-          (ts) => new Date(ts).getTime() >= cutoff
-        );
-        const cbOpen = activeQuarantines.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD;
-        const reserved = this.ledgerReservedCount(walletIndex);
-        const available = Math.max(0, CHAINING_LIMIT - reserved);
-        // Queue state for observability (dispatch_queue + replay_buffer)
-        const queueState = this.getDispatchQueueDepth(walletIndex);
-        const replayDepth = this.getReplayBufferDepth(walletIndex);
-        return {
-          walletIndex,
-          circuitBreakerOpen: cbOpen,
-          reserved,
-          available,
-          quarantineCount: activeQuarantines.length,
-          queueDepth: queueState.total,
-          replayBufferDepth: replayDepth,
-          dispatchedCount: queueState.dispatched,
-        };
-      })
-    );
+    const wallets: WalletHealthSnapshot[] = initializedWallets.map(({ walletIndex }) => {
+      const reserved = this.ledgerReservedCount(walletIndex);
+      const available = Math.max(0, CHAINING_LIMIT - reserved);
+      const queueState = this.getDispatchQueueDepth(walletIndex);
+      const replayDepth = this.getReplayBufferDepth(walletIndex);
+      return {
+        walletIndex,
+        circuitBreakerOpen: false,
+        reserved,
+        available,
+        quarantineCount: 0,
+        queueDepth: queueState.total,
+        replayBufferDepth: replayDepth,
+        dispatchedCount: queueState.dispatched,
+      };
+    });
 
     const totalReserved = wallets.reduce((s, w) => s + w.reserved, 0);
-    const degradedCount = wallets.filter((w) => w.circuitBreakerOpen).length;
     const totalCapacity = initializedWallets.length * CHAINING_LIMIT;
-    const allWalletsDegraded =
-      initializedWallets.length > 0 && degradedCount === initializedWallets.length;
 
-    return { allWalletsDegraded, totalReserved, totalCapacity, wallets };
+    return { allWalletsDegraded: false, totalReserved, totalCapacity, wallets };
   }
 
   private async buildSponsorStatusSnapshot(): Promise<StoredSponsorStatusSnapshot> {
     const initializedWallets = await this.getInitializedWallets();
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-    const walletSnapshots = await Promise.all(
-      initializedWallets.map(async ({ walletIndex }) => {
-        const recentQuarantines =
-          (await this.state.storage.get<string[]>(
-            this.walletQuarantineRecentKey(walletIndex)
-          )) ?? [];
-        const activeQuarantines = recentQuarantines.filter(
-          (ts) => new Date(ts).getTime() >= cutoff
-        );
-        const ghostDegraded =
-          (this.getStateValue(this.walletGhostDegradedKey(walletIndex)) ?? 0) === 1;
-        const rawAvailable = this.walletHeadroom(walletIndex);
-        // Ghost-degraded wallets are skipped by assignNonce, so report 0 available
-        const available = ghostDegraded ? 0 : Math.max(0, Math.min(CHAINING_LIMIT, rawAvailable));
-        const reserved = CHAINING_LIMIT - available;
-        return {
-          circuitBreakerOpen:
-            activeQuarantines.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD,
-          ghostDegraded,
-          available,
-          reserved,
-        };
-      })
-    );
+    const walletSnapshots = initializedWallets.map(({ walletIndex }) => {
+      const available = Math.max(0, Math.min(CHAINING_LIMIT, this.walletHeadroom(walletIndex)));
+      const reserved = CHAINING_LIMIT - available;
+      return { available, reserved };
+    });
     const walletCount = walletSnapshots.length;
     const totalAvailable = walletSnapshots.reduce((sum, wallet) => sum + wallet.available, 0);
     const totalReserved = walletSnapshots.reduce((sum, wallet) => sum + wallet.reserved, 0);
     const totalCapacity = walletCount * CHAINING_LIMIT;
-    const allWalletsDegraded =
-      walletCount > 0 &&
-      walletSnapshots.every((wallet) => wallet.circuitBreakerOpen || wallet.ghostDegraded);
+    const allWalletsDegraded = walletCount > 0 && totalAvailable === 0;
     const lastGapDetectedMs = this.getStateValue(STATE_KEYS.lastGapDetected);
     const lastHiroSyncMs = this.getStateValue(STATE_KEYS.lastHiroSync);
     const healInProgress =
@@ -4576,7 +4233,6 @@ export class NonceDO {
    */
   async getObservableNonceState(): Promise<ObservableNonceState> {
     const initializedWallets = await this.getInitializedWallets();
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
     const lastGapDetectedMs = this.getStateValue(STATE_KEYS.lastGapDetected);
     const gapsFilled = this.getStoredCount(STATE_KEYS.gapsFilled);
 
@@ -4675,20 +4331,7 @@ export class NonceDO {
           }
         }
 
-        // Circuit breaker state
-        const recentQuarantines =
-          (await this.state.storage.get<string[]>(
-            this.walletQuarantineRecentKey(walletIndex)
-          )) ?? [];
-        const activeQuarantines = recentQuarantines.filter(
-          (ts) => new Date(ts).getTime() >= cutoff
-        );
-        const circuitBreakerOpen =
-          activeQuarantines.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD;
-
         // Use walletHeadroom() — same calculation as the assignment path.
-        // Counts assigned + broadcasted + confirmed (all in-flight states),
-        // not just 'assigned' like ledgerReservedCount().
         const available = this.walletHeadroom(walletIndex);
         const reserved = CHAINING_LIMIT - available;
 
@@ -4699,10 +4342,6 @@ export class NonceDO {
         // Settlement time percentiles for this wallet (last 24h)
         const settlementTimes = this.computeSettlementPercentiles(walletIndex);
 
-        // Ghost degraded state
-        const ghostDegraded = (this.getStateValue(this.walletGhostDegradedKey(walletIndex)) ?? 0) === 1;
-        const ghostFailures = this.getStateValue(this.walletGhostFailuresKey(walletIndex)) ?? 0;
-
         return {
           walletIndex,
           sponsorAddress: address,
@@ -4712,19 +4351,16 @@ export class NonceDO {
           gaps,
           available,
           reserved,
-          circuitBreakerOpen,
-          healthy: gaps.length === 0 && !circuitBreakerOpen && !ghostDegraded && available > 0,
+          circuitBreakerOpen: false,
+          healthy: gaps.length === 0 && available > 0,
           queueDepth: queueState.total,
           replayBufferDepth: replayDepth,
           settlementTimes,
-          ghostDegraded,
-          ghostFailures,
         };
       })
     );
 
     const anyGaps = wallets.some((w) => w.gaps.length > 0);
-    const allDegraded = wallets.length > 0 && wallets.every((w) => w.circuitBreakerOpen);
     const totalAvailable = wallets.reduce((s, w) => s + w.available, 0);
     const totalReserved = wallets.reduce((s, w) => s + w.reserved, 0);
     const totalCapacity = initializedWallets.length * CHAINING_LIMIT;
@@ -4733,11 +4369,9 @@ export class NonceDO {
     const healInProgress = lastGapDetectedMs !== null &&
       Date.now() - lastGapDetectedMs < ALARM_INTERVAL_ACTIVE_MS * 2;
 
-    const healthy = !anyGaps && !allDegraded && totalAvailable > 0;
-    // recommendation is derived here (single source of truth) so endpoints
-    // don't duplicate the fallback decision logic.
+    const healthy = !anyGaps && totalAvailable > 0;
     const recommendation: "fallback_to_direct" | null =
-      !healthy && (anyGaps || allDegraded) ? "fallback_to_direct" : null;
+      !healthy && anyGaps ? "fallback_to_direct" : null;
 
     // Sender hands: active senders with held transactions waiting for nonce gap fill.
     // Capped at 50 senders to bound the response size.
@@ -5305,7 +4939,6 @@ export class NonceDO {
   private async reconcileNonceForWallet(
     walletIndex: number,
     sponsorAddress: string,
-    cascadeActive = false
   ): Promise<ReconcileResult | null> {
     let nonceInfo: HiroNonceInfo;
     try {
@@ -5386,19 +5019,6 @@ export class NonceDO {
       "conflict_recent_skip",
     ]);
 
-    // -------------------------------------------------------------------------
-    // Cascade-aware RBF threshold: when a cross-wallet cascade is active or this
-    // wallet's circuit breaker is open, reduce the stuck-tx age so RBF fires sooner
-    // and the nonce pipeline drains faster without waiting for agent retries.
-    // -------------------------------------------------------------------------
-    const cutoffForCircuitBreaker = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-    const recentQuarantinesForWallet =
-      (await this.state.storage.get<string[]>(this.walletQuarantineRecentKey(walletIndex))) ?? [];
-    const activeQuarantinesForWallet = recentQuarantinesForWallet.filter(
-      (ts) => new Date(ts).getTime() >= cutoffForCircuitBreaker
-    );
-    const walletCircuitOpen = activeQuarantinesForWallet.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD;
-    const effectiveStuckTxAge = this.getEffectiveStuckTxAge(cascadeActive, walletCircuitOpen);
 
     // -------------------------------------------------------------------------
     // Cross-reference: broadcasted nonces (have a txid recorded in ledger)
@@ -5424,7 +5044,7 @@ export class NonceDO {
         verdict = "pending_agree";
         reason = "ledger_and_hiro_both_pending";
         verdictPendingAgree++;
-      } else if (missingNonceSet.has(nonce) && ageMs < effectiveStuckTxAge) {
+      } else if (missingNonceSet.has(nonce) && ageMs < STUCK_TX_AGE_MS) {
         // Hiro lost sight of tx we know we sent — tx is young, wait for Hiro to catch up
         verdict = "pending_diverge";
         reason = "hiro_missing_but_tx_young";
@@ -5436,7 +5056,7 @@ export class NonceDO {
           ageMs,
           reason: "hiro_reports_missing_but_we_broadcasted_recently",
         });
-      } else if (missingNonceSet.has(nonce) && ageMs >= effectiveStuckTxAge) {
+      } else if (missingNonceSet.has(nonce) && ageMs >= STUCK_TX_AGE_MS) {
         // Hiro and time both say trouble — RBF candidate (tx status check in RBF section)
         verdict = "rbf_candidate";
         reason = "hiro_missing_and_tx_old";
@@ -5445,7 +5065,7 @@ export class NonceDO {
       } else if (
         !mempoolNonceSet.has(nonce) &&
         (last_executed_tx_nonce === null || nonce > last_executed_tx_nonce) &&
-        ageMs >= effectiveStuckTxAge
+        ageMs >= STUCK_TX_AGE_MS
       ) {
         // Not in mempool AND not confirmed AND old — likely evicted from all mempools
         verdict = "rbf_candidate";
@@ -5830,13 +5450,10 @@ export class NonceDO {
         });
       }
       const privateKey = await this.derivePrivateKeyForWallet(walletIndex);
-      // During a cascade, allow more gap-fills per cycle (15 vs 5) to drain stuck nonces faster.
-      // Gap-fills are cheap (1 uSTX + 30k fee) so the cost increase is negligible.
-      const effectiveMaxGapFills = cascadeActive ? 15 : MAX_GAP_FILLS_PER_ALARM;
       const gapsToFill = gapFillNonces
         .slice()
         .sort((a, b) => a - b)
-        .slice(0, Math.min(effectiveMaxGapFills, gapFillBudget));
+        .slice(0, Math.min(MAX_GAP_FILLS_PER_ALARM, gapFillBudget));
       if (privateKey) {
         for (const gapNonce of gapsToFill) {
           // Fee escalation: conflict retries use GAP_FILL_FEE + prior attempts (+1 uSTX each)
@@ -5855,7 +5472,7 @@ export class NonceDO {
             gapFillFilled.push(gapNonce);
             this.ledgerInsertGapFill(walletIndex, gapNonce, txid);
             await this.recordGapFillFee(walletIndex, actualFee.toString());
-            this.resetGhostState(walletIndex);
+
           }
         }
       }
@@ -5949,14 +5566,7 @@ export class NonceDO {
     // dispatch_queue, flush their sponsor nonce slots with self-transfers,
     // and move sender txs to the replay buffer for re-sponsoring.
     // -------------------------------------------------------------------------
-    const flushResult = await this.runFlushAndReplayCycle(walletIndex, effectiveStuckTxAge);
-
-    // -------------------------------------------------------------------------
-    // Auto-clear ghost_degraded when wallet shows confirmed transactions this cycle.
-    // If nonces are confirming, the wallet is broadcasting successfully — ghost state is stale.
-    if (verdictConfirmed > 0) {
-      this.resetGhostState(walletIndex);
-    }
+    const flushResult = await this.runFlushAndReplayCycle(walletIndex, STUCK_TX_AGE_MS);
 
     // Log reconciliation_summary for this wallet
     // -------------------------------------------------------------------------
@@ -6919,10 +6529,6 @@ export class NonceDO {
 
         const initializedWallets = await this.getInitializedWallets();
 
-        // Read cascade state once per alarm cycle so we don't repeat the KV read
-        // inside every wallet's reconcileNonceForWallet call.
-        const cascadeActive = await this.isCascadeActive();
-
         // ---------------------------------------------------------------------------
         // Bounded reconciliation: process MAX_RECONCILE_WALLETS wallets per tick.
         // Round-robin cursor advances each tick so all wallets reconcile over time.
@@ -6941,7 +6547,7 @@ export class NonceDO {
 
         for (const { walletIndex, address } of reconcileWallets) {
           // reconcileNonceForWallet returns null when Hiro is unreachable — skip silently
-          await this.reconcileNonceForWallet(walletIndex, address, cascadeActive);
+          await this.reconcileNonceForWallet(walletIndex, address);
 
           // Clean up StuckTxState entries for nonces that have been confirmed on-chain.
           const cached = this.hiroNonceCache.get(walletIndex);
@@ -7046,22 +6652,19 @@ export class NonceDO {
 
         await this.refreshSponsorStatusSnapshot();
 
-        // Dynamic alarm interval: use cascade (20s) when cascade is active + in-flight nonces,
-        // active (60s) when in-flight nonces present, idle (5min) when all wallets are drained.
+        // Dynamic alarm interval: active (60s) when in-flight nonces present,
+        // idle (5min) when all wallets are drained.
         const totalReservedAfterCycle = this.ledgerTotalAssigned();
         const probeQueuePending = this.sql
           .exec<{ cnt: number }>("SELECT COUNT(*) as cnt FROM probe_queue WHERE state = 'pending'")
           .toArray()[0]?.cnt ?? 0;
         const isActive = totalReservedAfterCycle > 0 || probeQueuePending > 0;
-        const intervalMs = cascadeActive && isActive
-          ? ALARM_INTERVAL_CASCADE_MS
-          : isActive ? ALARM_INTERVAL_ACTIVE_MS : ALARM_INTERVAL_IDLE_MS;
+        const intervalMs = isActive ? ALARM_INTERVAL_ACTIVE_MS : ALARM_INTERVAL_IDLE_MS;
         this.log("info", "nonce_alarm_scheduled", {
           intervalMs,
           activeWallets: initializedWallets.length,
           totalReserved: totalReservedAfterCycle,
           isActive,
-          cascadeActive,
           walletCursor,
           nextWalletCursor,
           reconcileCount: reconcileWallets.length,
@@ -7305,7 +6908,6 @@ export class NonceDO {
           this.ledgerInsertGapFill(walletIndex, gapNonce, txid);
           this.incrementCounter(STATE_KEYS.gapsFilled);
           await this.recordGapFillFee(walletIndex, escalatedFee.toString());
-          this.resetGhostState(walletIndex);
         } else {
           failed.push({ nonce: gapNonce, reason: "broadcast rejected or already occupied" });
         }
@@ -7505,7 +7107,6 @@ export class NonceDO {
                 this.ledgerInsertGapFill(walletIndex, nonce, gapTxid);
                 this.incrementCounter(STATE_KEYS.gapsFilled);
                 await this.recordGapFillFee(walletIndex, flushFee.toString());
-                this.resetGhostState(walletIndex);
                 filled.push({ nonce, txid: gapTxid, method: "gap_fill" });
               } else {
                 failedNonces.push({ nonce, reason: "rbf and gap-fill both failed or already occupied" });
@@ -7542,7 +7143,6 @@ export class NonceDO {
               this.ledgerInsertGapFill(walletIndex, nonce, txid);
               this.incrementCounter(STATE_KEYS.gapsFilled);
               await this.recordGapFillFee(walletIndex, gapFlushFee.toString());
-              this.resetGhostState(walletIndex);
               filled.push({ nonce, txid, method: "gap_fill" });
             } else {
               // ConflictingNonceInMempool means already occupied — not a hard failure
@@ -7640,18 +7240,6 @@ export class NonceDO {
                 "Retry-After": String(error.retryAfterSeconds),
               },
             }
-          );
-        }
-        if (error instanceof AllWalletsDegradedError) {
-          return this.jsonResponse(
-            {
-              error: "All sponsor wallets are circuit-broken; retry after recovery",
-              code: "ALL_WALLETS_DEGRADED",
-              degradedCount: error.degradedCount,
-              totalReserved: error.totalReserved,
-              totalCapacity: error.totalCapacity,
-            },
-            503
           );
         }
         if (error instanceof ChainingLimitError) {

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -3993,14 +3993,12 @@ export class NonceDO {
   }
 
   /**
-   * Lightweight pool health check — returns per-wallet circuit breaker state
-   * and aggregate availability so callers can perform pre-flight gating
-   * before attempting nonce assignment and avoid sending traffic into
-   * known-degraded pools. Exposed via GET /pool-health for observability
-   * and the /health endpoint.
+   * Lightweight pool health check — returns per-wallet availability and
+   * aggregate capacity so callers can perform pre-flight gating before
+   * attempting nonce assignment. Exposed via GET /pool-health and /health.
    *
-   * Much cheaper than getStats() — only reads quarantine lists and reserved counts,
-   * no heavy SQL joins or utilization queries.
+   * Much cheaper than getStats() — only reads reserved counts from the
+   * ledger, no heavy SQL joins or utilization queries.
    */
   async getPoolHealth(): Promise<PoolHealthResponse> {
     const initializedWallets = await this.getInitializedWallets();
@@ -4012,6 +4010,7 @@ export class NonceDO {
       const replayDepth = this.getReplayBufferDepth(walletIndex);
       return {
         walletIndex,
+        // circuit breaker removed; always false for API compatibility
         circuitBreakerOpen: false,
         reserved,
         available,
@@ -4024,8 +4023,10 @@ export class NonceDO {
 
     const totalReserved = wallets.reduce((s, w) => s + w.reserved, 0);
     const totalCapacity = initializedWallets.length * CHAINING_LIMIT;
+    const allWalletsDegraded = initializedWallets.length > 0 &&
+      wallets.every((w) => w.available === 0);
 
-    return { allWalletsDegraded: false, totalReserved, totalCapacity, wallets };
+    return { allWalletsDegraded, totalReserved, totalCapacity, wallets };
   }
 
   private async buildSponsorStatusSnapshot(): Promise<StoredSponsorStatusSnapshot> {
@@ -5472,7 +5473,6 @@ export class NonceDO {
             gapFillFilled.push(gapNonce);
             this.ledgerInsertGapFill(walletIndex, gapNonce, txid);
             await this.recordGapFillFee(walletIndex, actualFee.toString());
-
           }
         }
       }
@@ -5865,6 +5865,34 @@ export class NonceDO {
         error: e instanceof Error ? e.message : String(e),
       });
     }
+  }
+
+  /**
+   * One-shot cleanup: delete orphaned KV keys from removed degradation state machines
+   * (circuit breaker, ghost degraded, cascade detection). These keys are no longer
+   * read but accumulate in DO storage. Runs once; sets a flag to skip on subsequent cycles.
+   */
+  private async cleanupLegacyDegradationKeys(): Promise<void> {
+    const flagKey = "legacy_degradation_keys_cleaned";
+    if (await this.state.storage.get<boolean>(flagKey)) return;
+
+    const keysToDelete: string[] = ["cascade_quarantine_window"];
+    for (let i = 0; i < MAX_WALLET_COUNT; i++) {
+      keysToDelete.push(
+        `wallet_quarantine_recent:${i}`,
+      );
+    }
+    // nonce_state SQL keys for ghost counters
+    for (let i = 0; i < MAX_WALLET_COUNT; i++) {
+      this.setStateValue(`wallet_ghost_failures:${i}`, 0);
+      this.setStateValue(`wallet_ghost_degraded:${i}`, 0);
+    }
+    await this.state.storage.delete(keysToDelete);
+    await this.state.storage.put(flagKey, true);
+    this.log("info", "legacy_degradation_keys_cleaned", {
+      deletedKvKeys: keysToDelete.length,
+      clearedNonceStateKeys: MAX_WALLET_COUNT * 2,
+    });
   }
 
   /**
@@ -6502,8 +6530,9 @@ export class NonceDO {
   async alarm(): Promise<void> {
     await this.state.blockConcurrencyWhile(async () => {
       try {
-        // --- Gin rummy preamble: migration, replay recycling, seed upgrades ---
+        // --- Preamble: migration, cleanup, replay recycling, seed upgrades ---
         this.runGinRummyMigration();
+        await this.cleanupLegacyDegradationKeys();
         this.recycleReplayBuffer();
         await this.retrySeedFirstTxSenders();
 

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -297,11 +297,11 @@ async function processPaymentMessage(
     // Check for retryable broadcast errors
     const isNonceConflict = broadcastResult.nonceConflict === true;
     const isTooMuchChaining = broadcastResult.tooMuchChaining === true;
+    const isOriginChaining = broadcastResult.isOriginChaining === true;
 
     if ((isNonceConflict || isTooMuchChaining) && attempt < MAX_ATTEMPTS) {
       // Release the sponsor nonce back to pool — no errorReason here so the nonce
-      // expires cleanly without feeding the circuit breaker on every retry attempt.
-      // Quarantine only happens on the terminal path when retries are exhausted.
+      // expires cleanly without penalizing sponsor wallets on every retry attempt.
       if (sponsorNonce !== null) {
         await releaseNonceDO(env, logger, sponsorNonce, undefined, walletIndex);
       }
@@ -310,9 +310,11 @@ async function processPaymentMessage(
         route: "PAYMENT_QUEUE",
         paymentId,
         status: "queued",
-        action: isTooMuchChaining
-          ? "queue_retry_too_much_chaining"
-          : "queue_retry_nonce_conflict",
+        action: isOriginChaining
+          ? "queue_retry_origin_chaining"
+          : isTooMuchChaining
+            ? "queue_retry_too_much_chaining"
+            : "queue_retry_nonce_conflict",
         checkStatusUrlPresent: false,
         compatShimUsed: false,
         attempt,
@@ -321,6 +323,7 @@ async function processPaymentMessage(
         paymentId,
         nonceConflict: isNonceConflict,
         tooMuchChaining: isTooMuchChaining,
+        isOriginChaining,
         attempt,
       });
 
@@ -334,10 +337,13 @@ async function processPaymentMessage(
       return;
     }
 
-    // Terminal broadcast failure — only quarantine for contention-specific conditions.
-    // Generic failures (node 500, timeout) release cleanly to avoid penalizing healthy wallets.
+    // Terminal broadcast failure.
+    // Origin-side TooMuchChaining: release cleanly — the agent's address is congested, not the sponsor.
+    // Sponsor-side TooMuchChaining or nonce conflict: release with error reason for tracking.
+    // Generic failures (node 500, timeout): release cleanly to avoid penalizing healthy wallets.
     if (sponsorNonce !== null) {
-      const reason = isTooMuchChaining ? "TooMuchChaining"
+      const reason = isOriginChaining ? undefined
+        : isTooMuchChaining ? "TooMuchChaining"
         : isNonceConflict ? "nonce_conflict"
         : undefined;
       await releaseNonceDO(env, logger, sponsorNonce, undefined, walletIndex, undefined, reason);
@@ -354,8 +360,9 @@ async function processPaymentMessage(
       errorCode: broadcastResult.clientRejection
         ? `CLIENT_${broadcastResult.clientRejection.toUpperCase()}`
         : "BROADCAST_FAILED",
-      terminalReason:
-        isTooMuchChaining || isNonceConflict
+      terminalReason: isOriginChaining
+        ? "origin_chaining_limit"
+        : (isTooMuchChaining || isNonceConflict)
           ? "sponsor_failure"
           : "broadcast_failure",
       retryable: broadcastResult.retryable,

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -299,7 +299,7 @@ async function processPaymentMessage(
     const isTooMuchChaining = broadcastResult.tooMuchChaining === true;
     const isOriginChaining = broadcastResult.isOriginChaining === true;
 
-    if ((isNonceConflict || isTooMuchChaining) && attempt < MAX_ATTEMPTS) {
+    if ((isNonceConflict || (isTooMuchChaining && !isOriginChaining)) && attempt < MAX_ATTEMPTS) {
       // Release the sponsor nonce back to pool — no errorReason here so the nonce
       // expires cleanly without penalizing sponsor wallets on every retry attempt.
       if (sponsorNonce !== null) {

--- a/src/services/settlement.ts
+++ b/src/services/settlement.ts
@@ -821,15 +821,22 @@ export class SettlementService {
           let errorMessage = `HTTP ${broadcastResponse.status}`;
           let errorDetails = responseText.slice(0, 500);
 
+          // reason_data from stacks-core: includes is_origin for TooMuchChaining/BadNonce
+          type StacksReasonData = { is_origin?: boolean; principal?: string; expected?: number; actual?: number; message?: string };
+          let reasonData: StacksReasonData | undefined;
           try {
             const errorJson = JSON.parse(responseText) as {
               error?: string;
               reason?: string;
               message?: string;
+              reason_data?: StacksReasonData;
             };
             if (errorJson.error || errorJson.reason || errorJson.message) {
               errorMessage = errorJson.error ?? errorJson.message ?? errorMessage;
               errorDetails = errorJson.reason ?? errorDetails;
+            }
+            if (errorJson.reason_data) {
+              reasonData = errorJson.reason_data;
             }
           } catch {
             // Body is not JSON — use raw text as details
@@ -892,21 +899,34 @@ export class SettlementService {
             }
 
             // TooMuchChaining: the sender (sponsor or client) has too many pending txs.
+            // The node's reason_data.is_origin distinguishes origin (sender) vs sponsor triggers.
             // On sponsor-side this is relay congestion — retryable after backoff.
-            // clientRejection is intentionally omitted so stats don't attribute this to the client.
-            // On self-pay this falls through to clientRejection handling below.
+            // On origin-side this is the agent's problem — report back, don't penalize sponsor.
             if (matchedReason === "TooMuchChaining" && sponsorNonceForLog !== null) {
-              this.logger.warn("Sponsor wallet chaining limit hit (TooMuchChaining)", {
-                status: broadcastResponse.status,
-                details: errorDetails,
-                sponsorNonce: sponsorNonceForLog,
-                nodeUrl: target.baseUrl,
-              });
+              const isOrigin = reasonData?.is_origin === true;
+              this.logger.warn(
+                isOrigin
+                  ? "Origin (sender) chaining limit hit (TooMuchChaining)"
+                  : "Sponsor wallet chaining limit hit (TooMuchChaining)",
+                {
+                  status: broadcastResponse.status,
+                  details: errorDetails,
+                  sponsorNonce: sponsorNonceForLog,
+                  isOrigin,
+                  principal: reasonData?.principal,
+                  expected: reasonData?.expected,
+                  actual: reasonData?.actual,
+                  nodeUrl: target.baseUrl,
+                }
+              );
               return {
-                error: "Sponsor wallet congested — too many pending transactions",
+                error: isOrigin
+                  ? "Origin address has too many pending transactions"
+                  : "Sponsor wallet congested — too many pending transactions",
                 details: errorDetails,
-                retryable: true,
+                retryable: !isOrigin,
                 tooMuchChaining: true,
+                isOriginChaining: isOrigin,
                 nodeUrl: target.baseUrl,
                 httpStatus: broadcastResponse.status,
               };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1244,6 +1244,10 @@ export type BroadcastAndConfirmResult =
       nonceConflict?: boolean;
       /** Sponsor wallet hit TooMuchChaining — relay-side congestion, retryable after backoff */
       tooMuchChaining?: boolean;
+      /** True when TooMuchChaining was triggered by the origin (sender) address, not the sponsor.
+       *  Parsed from the node's `reason_data.is_origin` field. When true, the relay should NOT
+       *  penalize the sponsor wallet — the agent's address has too many pending transactions. */
+      isOriginChaining?: boolean;
       /** Matched Stacks node rejection reason (e.g. "NotEnoughFunds") when the 4xx
        *  rejection was caused by the client submitting an invalid transaction. */
       clientRejection?: string;
@@ -1263,6 +1267,7 @@ export type BroadcastOnlyResult =
       retryable: boolean;
       nonceConflict?: boolean;
       tooMuchChaining?: boolean;
+      isOriginChaining?: boolean;
       clientRejection?: string;
       nodeUrl?: string;
       httpStatus?: number;


### PR DESCRIPTION
## Summary

- **Parse `is_origin` from TooMuchChaining** — stacks-core's `reason_data.is_origin` field now extracted from broadcast rejections, distinguishing origin (sender) vs sponsor chaining. Origin-side chaining no longer penalizes sponsor wallets
- **Remove 4 degradation state machines** — circuit breaker, ghost degraded, chaining degraded, and cascade detection all removed from NonceDO (~460 lines deleted)
- **Available-headroom wallet selection** — `assignNonce()` now selects wallet with highest `available = CHAINING_LIMIT - inFlightCount` instead of round-robin with degradation skips

### Evidence base
- 72h production log review showed: 34 circuit breaker triggers from only 15 actual conflicts (threshold=1 too sensitive), 0 ghost/chaining degraded triggers, 11 TooMuchChaining events all likely origin-side
- Full analysis in `.planning/2026-04-05-wallet-state-schemas/phases/03-log-review.md`

### What's removed
- `AllWalletsDegradedError`, `CIRCUIT_BREAKER_QUARANTINE_THRESHOLD`, `CIRCUIT_BREAKER_WINDOW_MS`, `GHOST_FAILURE_THRESHOLD`, `CASCADE_DETECTION_THRESHOLD`, `ALARM_INTERVAL_CASCADE_MS`, `STUCK_TX_AGE_CASCADE_MS`, `STUCK_TX_AGE_CIRCUIT_OPEN_MS`
- Methods: `recordQuarantineEvent()`, `checkCascadeThreshold()`, `isCascadeActive()`, `getEffectiveStuckTxAge()`, `incrementGhostFailures()`, `resetGhostState()`
- KV keys: `wallet_quarantine_recent:*`, `ghost_failures:*`, `ghost_degraded:*`, `cascade_quarantine_window`

### What's simplified
- `getPoolHealth()`, `buildSponsorStatusSnapshot()` — sync, pure available math
- `getObservableNonceState()` — `healthy` based on gaps + available only
- Alarm interval — active (60s) or idle (5min), no cascade mode
- Stuck tx age — constant `STUCK_TX_AGE_MS` (15min) everywhere

Supersedes #310. Implements adoption items 1-3 from the wallet-state-schemas quest.
Closes #291, closes #294, closes #302.

## Test plan

- [x] `npm run check` — typecheck passes
- [x] `npx vitest run` — 88 tests pass (11 files)
- [x] `npm run deploy:dry-run` — build succeeds
- [ ] Deploy to staging and monitor logs for 72h
- [ ] Run `npm run test:relay -- https://x402-relay.aibtc.dev` against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)