### PR TITLE
refactor: schema-driven dashboard with accurate metrics

### DIFF
--- a/.planning/2026-04-06-schema-driven-dashboard/QUEST.md
+++ b/.planning/2026-04-06-schema-driven-dashboard/QUEST.md
@@ -1,0 +1,36 @@
+# Quest: schema-driven-dashboard
+
+## Goal
+
+Rebuild the relay's embedded dashboard (`/dashboard`, `/stats`) on top of `@aibtc/tx-schemas` as the canonical data model. Fix critical metric bugs (settlement time inflation, missing token volume, mixed time windows), align error categorization with the 19 terminal reasons / 6 categories from tx-schemas, and add wallet throughput history. The result is a dashboard that gives operators real insight into relay health instead of misleading numbers.
+
+## Repos
+
+| Repo | Role |
+|------|------|
+| `~/dev/aibtcdev/x402-sponsor-relay` | Primary -- all code changes |
+| `~/dev/aibtcdev/tx-schemas` | Read-only reference for schema shapes (`@aibtc/tx-schemas` v0.4.0) |
+
+## Constraints
+
+- StatsDO keeps SQLite approach (atomic upserts, no read-modify-write)
+- Dashboard stays server-rendered HTML + Alpine.js (no React/build step)
+- Import types from `@aibtc/tx-schemas`, don't redefine
+- Cloudflare Workers environment (no Node.js APIs)
+- Additive changes to `/stats` API -- don't break existing consumers
+- Each phase independently deployable (no half-broken dashboard between phases)
+- `@aibtc/tx-schemas` v0.4.0 is already a dependency in package.json
+
+## Critical Bugs
+
+1. **Settlement time shows 3-5 DAYS** -- `dispatched_at` gets set at various lifecycle points; gap-fill txs and stale held entries skew percentiles
+2. **Token volume missing for /sponsor** -- hardcodes `tokenType: "STX"` and `amount: "0"` at sponsor.ts:449-450
+3. **Fee stats mix time windows** -- total/average from rolling 24h (hourly_stats) but min/max from today's calendar day (daily_stats)
+4. **Success rate hides client errors** -- only effective rate shown, no raw rate exposure in /stats API
+5. **Error categorization too crude** -- 5 buckets vs tx-schemas' 19 terminal reasons across 6 categories
+6. **Nonce pool/wallet views are snapshots** -- no throughput history (txs processed per wallet per hour)
+7. **No comparison periods** -- 24h rolling vs yesterday calendar day (apples to oranges)
+
+## Status
+
+active

--- a/.planning/2026-04-06-schema-driven-dashboard/STATE.md
+++ b/.planning/2026-04-06-schema-driven-dashboard/STATE.md
@@ -13,7 +13,7 @@ Phase 6: Update documentation
 | 3. Align errors with tx-schemas terminal reasons | completed | 19-reason error recording + /stats API |
 | 4. Add wallet throughput and dual rates | completed | wallet_hourly table + comparison fix |
 | 5. Rebuild dashboard UI | completed | Schema-aligned cards and visualizations |
-| 6. Update documentation | active | CLAUDE.md + discovery docs |
+| 6. Update documentation | completed | CLAUDE.md + discovery docs |
 
 ## Decisions
 
@@ -34,4 +34,4 @@ Phase 6: Update documentation
 - 2026-04-06: Phase 3 completed — 19 terminal reasons, 6 category columns, wired all error paths in endpoints, /stats returns terminalReasons (106d937..2c0bc58)
 - 2026-04-06: Phase 4 completed — wallet_hourly table, dual success rates, rolling-vs-rolling comparison periods (95e5c9f..f1ac88a)
 - 2026-04-06: Phase 5 completed — terminal reason colors, new card components (fees, terminal reasons, wallet throughput), dual success rates in UI, CSS utilities (8b63594..1c0486c)
-- 2026-04-06: Phase 6 active — CLAUDE.md updated with /stats response shape, tx-decode Key File entry, gap-fill settlement note, timestamp semantics; discovery.ts /llms-full.txt GET /stats expanded with response example
+- 2026-04-06: Phase 6 completed — CLAUDE.md updated with /stats response shape, tx-decode Key File entry, gap-fill settlement note, timestamp semantics; discovery.ts /llms-full.txt GET /stats expanded with response example (490c6c5)

--- a/.planning/2026-04-06-schema-driven-dashboard/STATE.md
+++ b/.planning/2026-04-06-schema-driven-dashboard/STATE.md
@@ -1,0 +1,37 @@
+# State: schema-driven-dashboard
+
+## Current Phase
+
+Phase 6: Update documentation
+
+## Phase Status
+
+| Phase | Status | Deliverable |
+|-------|--------|-------------|
+| 1. Fix settlement time measurement | completed | NonceDO schema migration + gap-fill tagging |
+| 2. Fix token attribution and fee windows | completed | tx-decode utility + hourly fee min/max |
+| 3. Align errors with tx-schemas terminal reasons | completed | 19-reason error recording + /stats API |
+| 4. Add wallet throughput and dual rates | completed | wallet_hourly table + comparison fix |
+| 5. Rebuild dashboard UI | completed | Schema-aligned cards and visualizations |
+| 6. Update documentation | active | CLAUDE.md + discovery docs |
+
+## Decisions
+
+(None yet -- quest just created)
+
+## Notes
+
+- `@aibtc/tx-schemas` v0.4.0 already in package.json
+- wallet-state-schemas quest (Phases 4-6 pending) defines the schemas this quest consumes
+- NonceDO is 7882 lines -- changes must be surgical, well-tested via dry-run build
+- StatsDO uses SQLite migrations that silently catch "duplicate column" errors -- safe for incremental deploys
+
+## Activity Log
+
+- 2026-04-06: Quest created with 6 phases
+- 2026-04-06: Phase 1 completed — submitted_at + is_gap_fill columns, gap-fill filtering in percentiles, submittedAt threaded from endpoints (f55f442, cd6eb8c)
+- 2026-04-06: Phase 2 completed — extractTransferDetails utility, sponsor.ts uses actual token/amount, fee min/max from rolling 24h hourly_stats (ef654b3)
+- 2026-04-06: Phase 3 completed — 19 terminal reasons, 6 category columns, wired all error paths in endpoints, /stats returns terminalReasons (106d937..2c0bc58)
+- 2026-04-06: Phase 4 completed — wallet_hourly table, dual success rates, rolling-vs-rolling comparison periods (95e5c9f..f1ac88a)
+- 2026-04-06: Phase 5 completed — terminal reason colors, new card components (fees, terminal reasons, wallet throughput), dual success rates in UI, CSS utilities (8b63594..1c0486c)
+- 2026-04-06: Phase 6 active — CLAUDE.md updated with /stats response shape, tx-decode Key File entry, gap-fill settlement note, timestamp semantics; discovery.ts /llms-full.txt GET /stats expanded with response example

--- a/.planning/2026-04-06-schema-driven-dashboard/phases/06-documentation/PLAN.md
+++ b/.planning/2026-04-06-schema-driven-dashboard/phases/06-documentation/PLAN.md
@@ -1,0 +1,78 @@
+<plan>
+  <goal>Update documentation to reflect all dashboard changes from Phases 1-5: new /stats fields, tx-decode utility, terminal reasons, timestamp semantics, and settlement filtering.</goal>
+  <context>
+    Phases 1-5 added: submitted_at/is_gap_fill to NonceDO, extractTransferDetails() in
+    src/utils/tx-decode.ts, 19 terminal reasons across 6 categories in /stats terminalReasons,
+    walletThroughput array, dual success rates (rawSuccessRate/effectiveSuccessRate), previous24h
+    comparison object, and settlementTimes percentiles that exclude gap-fills.
+
+    CLAUDE.md currently:
+    - Lists GET /stats without any response shape
+    - Lists Key Files without src/utils/tx-decode.ts
+    - Settlement states section doesn't mention gap-fill filtering
+
+    discovery.ts /llms-full.txt (around line 848):
+    - GET /stats section is just 3 lines with no response shape
+
+    QUEST.md status is still "pending" — needs updating to "active".
+    STATE.md phase 6 row says "pending" — needs updating to "active".
+  </context>
+
+  <task id="1">
+    <name>Update CLAUDE.md: /stats response shape, tx-decode key file, settlement gap-fill note</name>
+    <files>CLAUDE.md</files>
+    <action>
+      1. In the Endpoints section, expand GET /stats bullet to note it returns new fields.
+      2. In the Request/Response section, add a GET /stats response shape block showing:
+         transactions (total, success, failed, clientErrors, trend, previousTotal,
+         rawSuccessRate, effectiveSuccessRate), tokens (STX/sBTC/USDCx with count/volume/percentage),
+         settlement (status, avgLatencyMs, uptime24h, lastCheck), settlementTimes (p50, p95, avg,
+         count — gap-fill txs excluded), terminalReasons (validation, sender, relay, settlement,
+         replacement, identity), walletThroughput (walletIndex, total24h, success24h, failed24h,
+         feeTotal24h, hourly[]), previous24h (total, success, failed).
+      3. In Key Files section, add entry for src/utils/tx-decode.ts.
+      4. In Settlement states section, add note that settlementTimes percentiles exclude gap-fill
+         transactions (is_gap_fill=true) to prevent artificial inflation.
+      5. In Nonce queue semantics section, add note about submitted_at vs dispatched_at vs queued_at
+         timestamp distinction.
+    </action>
+    <verify>
+      grep -n "tx-decode" CLAUDE.md  # should find the new Key Files entry
+      grep -n "terminalReasons" CLAUDE.md  # should find in /stats response shape
+      grep -n "gap.fill" CLAUDE.md  # should find in settlement states note
+    </verify>
+    <done>CLAUDE.md has /stats response shape, tx-decode in Key Files, gap-fill note in settlement states, and timestamp semantics in nonce queue section.</done>
+  </task>
+
+  <task id="2">
+    <name>Update discovery.ts /llms-full.txt GET /stats section with response shape</name>
+    <files>src/routes/discovery.ts</files>
+    <action>
+      Expand the GET /stats section (around line 848) in the /llms-full.txt handler to include:
+      - A JSON response example showing the key new fields: terminalReasons, walletThroughput,
+        rawSuccessRate, effectiveSuccessRate, previous24h, and settlementTimes.
+      - Brief field descriptions inline as comments.
+      Keep the update surgical — only change the GET /stats block, not the surrounding text.
+    </action>
+    <verify>
+      grep -n "terminalReasons\|walletThroughput\|effectiveSuccessRate" src/routes/discovery.ts
+      # should show results in the /llms-full.txt handler
+    </verify>
+    <done>discovery.ts /llms-full.txt GET /stats section includes a response example with new fields.</done>
+  </task>
+
+  <task id="3">
+    <name>Update QUEST.md and STATE.md final status</name>
+    <files>.planning/2026-04-06-schema-driven-dashboard/QUEST.md, .planning/2026-04-06-schema-driven-dashboard/STATE.md</files>
+    <action>
+      1. In QUEST.md, change `## Status` from "pending" to "active".
+      2. In STATE.md, change phase 6 row from "pending" to "active" in the Phase Status table,
+         and add a Phase 6 activity log entry.
+    </action>
+    <verify>
+      grep "Status" .planning/2026-04-06-schema-driven-dashboard/QUEST.md
+      grep "6.*active\|active.*6" .planning/2026-04-06-schema-driven-dashboard/STATE.md
+    </verify>
+    <done>QUEST.md shows "active" status; STATE.md shows phase 6 active with activity log entry.</done>
+  </task>
+</plan>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ npm run keys -- create --app "App" --email "x@y.com"  # Create key
 - `GET /fees` - Get clamped fee estimates (no auth required)
 - `POST /fees/config` - Update fee clamps (admin, requires API key)
 - `GET /nonce/state` - Observable nonce state for client diagnostics (pending txs, gaps, health)
-- `GET /stats` - Relay statistics (JSON API)
+- `GET /stats` - Relay statistics (JSON API): transactions (total/success/failed/clientErrors, rawSuccessRate, effectiveSuccessRate, previousTotal, trend), tokens (STX/sBTC/USDCx volume), settlement health, settlementTimes (p50/p95 excluding gap-fills), terminalReasons (6-category breakdown), walletThroughput, previous24h comparison window
 - `GET /dashboard` - Public dashboard (HTML)
 - `POST /settle` - x402 V2 facilitator settle (verify payment + broadcast; auto-sponsors transactions with empty sponsor slot)
 - `POST /verify` - x402 V2 facilitator verify (local validation only, no broadcast)
@@ -98,6 +98,12 @@ npm run keys -- create --app "App" --email "x@y.com"  # Create key
 - Held sender-hand entries live for 15 minutes.
 - The alarm may conservatively repair stale-low sender frontiers after 5 minutes, with a 10 minute per-sender Hiro refresh cooldown.
 - Repair only bumps to the lowest held nonce when Hiro reports `possible_next_nonce >= lowestHeldNonce`; it must never speculate past locally held work.
+
+**Transaction timestamp semantics (NonceDO):**
+- `submitted_at` — when the relay first received and queued the transaction (set in NonceDO on nonce reservation). Used as the start time for settlement duration measurement.
+- `dispatched_at` — when the relay broadcast the transaction to Hiro. May be set multiple times for gap-fill retries; not used for latency measurement.
+- `queued_at` — legacy field retained for backward compatibility; equivalent to `submitted_at` in practice.
+- Gap-fill transactions carry `is_gap_fill: true` and are excluded from `settlementTimes` percentiles in `/stats` to prevent artificial inflation of reported settlement latency.
 
 **Agent Discovery (AX) — `src/routes/discovery.ts`:**
 - `GET /llms.txt` - Quick-start guide: what the relay does, key provisioning, /relay and /sponsor examples
@@ -378,6 +384,63 @@ Response: {
   extensions: ["payment-identifier"],  // client-controlled idempotency key extension
   signers: { "stacks:*": [] }  // empty = any signer accepted
 }
+
+// GET /stats (relay statistics — public, cached 15s)
+Response: {
+  success: true,
+  requestId: "uuid",
+  period: "24h",
+  transactions: {
+    total: 1240,
+    success: 1185,
+    failed: 55,
+    clientErrors: 12,          // client-caused failures (excluded from effectiveSuccessRate)
+    trend: "up",               // "up" | "down" | "stable" (rolling-vs-rolling comparison)
+    previousTotal: 1100,       // total in the previous 24h window (24-48h ago)
+    rawSuccessRate: 0.956,     // success / total (includes client errors in denominator)
+    effectiveSuccessRate: 0.978 // success / (success + relayErrors) (excludes client errors)
+  },
+  tokens: {
+    STX:  { count: 980, volume: "9800000000", percentage: 79 },
+    sBTC: { count: 200, volume: "500000",      percentage: 16 },
+    USDCx:{ count:  60, volume: "60000000",    percentage:  5 }
+  },
+  settlement: {
+    status: "healthy",    // "healthy" | "degraded" | "down" | "unknown"
+    avgLatencyMs: 8200,
+    uptime24h: 0.998,
+    lastCheck: "2026-04-06T12:00:00.000Z"
+  },
+  settlementTimes: {      // p50/p95 exclude gap-fill txs (is_gap_fill=true)
+    p50: 7800,
+    p95: 22000,
+    avg: 9100,
+    count: 1185
+  },
+  terminalReasons: {      // tx-schemas 6-category breakdown (today's calendar day)
+    validation:  3,       // invalid_transaction, not_sponsored
+    sender:     18,       // sender_nonce_* errors, origin_chaining_limit, sender_hand_expired
+    relay:       7,       // sponsor_failure, queue_unavailable, internal_error, sponsor_exhausted, sponsor_nonce_conflict
+    settlement: 12,       // broadcast_failure, chain_abort, broadcast_rate_limited
+    replacement: 5,       // nonce_replacement, superseded
+    identity:    2        // expired, unknown_payment_identity
+  },
+  walletThroughput: [     // per-wallet 24h totals + hourly sparklines (wallets with >0 txs only)
+    {
+      walletIndex: 0,
+      total24h: 310,
+      success24h: 298,
+      failed24h: 12,
+      feeTotal24h: "3100000",
+      hourly: [{ hour: "2026-04-06T11:00:00Z", total: 14, success: 13, failed: 1, feeTotal: "140000" }]
+    }
+  ],
+  previous24h: {          // rolling window 24-48h ago (for trend comparison)
+    total: 1100,
+    success: 1050,
+    failed: 50
+  }
+}
 ```
 
 **SIP-018 Authentication:**
@@ -434,6 +497,7 @@ If verification fails, the request is rejected with HTTP 401. If the auth field 
 - `src/endpoints/provision-stx.ts` - API key provisioning via Stacks signature
 - `src/endpoints/fees.ts` - Fee estimation endpoint (public, no auth)
 - `src/endpoints/fees-config.ts` - Fee clamp configuration endpoint (admin, API key auth)
+- `src/utils/tx-decode.ts` - `extractTransferDetails()` — decode token type and transfer amount from a deserialized Stacks tx without full payment verification. Used by `/sponsor` for accurate token attribution in stats.
 - `src/services/receipt.ts` - ReceiptService (store/retrieve/consume receipts in KV)
 - `src/services/btc-verify.ts` - BtcVerifyService (BIP-137/BIP-322 signature verification)
 - `src/services/stx-verify.ts` - StxVerifyService (plain message + SIP-018 signature verification)
@@ -595,6 +659,8 @@ Agent                    Relay                              Stacks
 - `confirmed`: tx confirmed on-chain within 60s — includes `blockHeight`
 - `pending`: broadcast succeeded but confirmation timed out — safe state, poll `/verify/:receiptId`
 - `failed`: tx broadcast OK but definitively aborted on-chain (`abort_*` status) — returns `SETTLEMENT_FAILED` (422, not retryable)
+
+Note: `/stats` `settlementTimes` percentiles (p50/p95) exclude gap-fill transactions (`is_gap_fill: true` in NonceDO). Gap-fills are relay-internal nonce repair transactions, not agent-submitted payments; including them would inflate reported settlement latency by 3-5x.
 
 **Drop vs abort semantics:**
 - `dropped_*` from Hiro is TRANSIENT — 93% of `dropped_replace_by_fee` reports actually confirm on-chain.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "x402-sponsor-relay",
       "version": "1.27.2",
       "dependencies": {
-        "@aibtc/tx-schemas": "^0.3.0",
+        "@aibtc/tx-schemas": "^0.4.0",
         "@noble/curves": "^2.0.1",
         "@scure/btc-signer": "^2.0.1",
         "@stacks/common": "^7.3.1",
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@aibtc/tx-schemas": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.3.0.tgz",
-      "integrity": "sha512-pXzW9TnmFR3uJMfajbUdAYiPKRkNlzWWL2WGZ554NAeVIPq9vWyL6x8nrYtaDohuHlZRmMj1tSVeFap9AA+adw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.4.0.tgz",
+      "integrity": "sha512-51z8O+mNGnqwoisKZCvvC8ZNBv0Z+RIfSTQ2CV99NFk4Z4ySp+KX+kPEpwlbLLul3AySn/AD9EHWXrjcGaAYAg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "wrangler": "^4.75.0"
   },
   "dependencies": {
-    "@aibtc/tx-schemas": "^0.3.0",
+    "@aibtc/tx-schemas": "^0.4.0",
     "@noble/curves": "^2.0.1",
     "@scure/btc-signer": "^2.0.1",
     "@stacks/common": "^7.3.1",

--- a/src/__tests__/ghost-wallet-fee-escalation.test.ts
+++ b/src/__tests__/ghost-wallet-fee-escalation.test.ts
@@ -8,169 +8,56 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 // Constants (mirrored from nonce-do.ts internals)
 // ---------------------------------------------------------------------------
-const GHOST_FAILURE_THRESHOLD = 5;
 const GAP_FILL_FEE = 30_000n;
 const MAX_BROADCAST_FEE = 90_000n;
 const CHAINING_LIMIT = 20;
 
 // ---------------------------------------------------------------------------
-// Helpers
+// buildSponsorStatusSnapshot: available math (no ghost-degraded flags)
 // ---------------------------------------------------------------------------
 
-/** Minimal nonce_state KV store for ghost counter tests */
-function makeStateStore(initial: Record<string, number> = {}) {
-  const store = new Map<string, number | null>();
-  for (const [k, v] of Object.entries(initial)) {
-    store.set(k, v);
-  }
-  return {
-    getStateValue: (key: string) => store.get(key) ?? null,
-    setStateValue: (key: string, value: number) => store.set(key, value),
-    walletGhostFailuresKey: (NonceDO as any).prototype.walletGhostFailuresKey,
-    walletGhostDegradedKey: (NonceDO as any).prototype.walletGhostDegradedKey,
-    _store: store,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Ghost counter semantics
-// ---------------------------------------------------------------------------
-
-describe("ghost wallet counter semantics", () => {
-  const incrementGhostFailures = (NonceDO as any).prototype.incrementGhostFailures;
-  const resetGhostState = (NonceDO as any).prototype.resetGhostState;
-  const walletGhostFailuresKey = (NonceDO as any).prototype.walletGhostFailuresKey;
-  const walletGhostDegradedKey = (NonceDO as any).prototype.walletGhostDegradedKey;
-
-  it("increments ghost failures and marks degraded at threshold", () => {
-    const ctx = { ...makeStateStore(), log: vi.fn() };
-
-    // Increment up to threshold - 1: NOT degraded yet
-    for (let i = 1; i < GHOST_FAILURE_THRESHOLD; i++) {
-      const becameDegraded = incrementGhostFailures.call(ctx, 0);
-      expect(becameDegraded).toBe(false);
-      expect(ctx.getStateValue(walletGhostFailuresKey.call(ctx, 0))).toBe(i);
-      expect(ctx.getStateValue(walletGhostDegradedKey.call(ctx, 0))).toBeNull();
-    }
-
-    // One more push reaches threshold → degraded
-    const becameDegraded = incrementGhostFailures.call(ctx, 0);
-    expect(becameDegraded).toBe(true);
-    expect(ctx.getStateValue(walletGhostFailuresKey.call(ctx, 0))).toBe(GHOST_FAILURE_THRESHOLD);
-    expect(ctx.getStateValue(walletGhostDegradedKey.call(ctx, 0))).toBe(1);
-    expect(ctx.log).toHaveBeenCalledWith("warn", "ghost_wallet_degraded", expect.objectContaining({
-      walletIndex: 0,
-      ghostFailures: GHOST_FAILURE_THRESHOLD,
-      threshold: GHOST_FAILURE_THRESHOLD,
-    }));
-  });
-
-  it("does not re-log degraded on subsequent increments past threshold", () => {
-    const ctx = { ...makeStateStore(), log: vi.fn() };
-
-    // Push past threshold
-    for (let i = 0; i <= GHOST_FAILURE_THRESHOLD; i++) {
-      incrementGhostFailures.call(ctx, 0);
-    }
-    expect(ctx.log).toHaveBeenCalledTimes(1); // only the first crossing
-
-    // One more: already degraded, no new log
-    const becameDegraded = incrementGhostFailures.call(ctx, 0);
-    expect(becameDegraded).toBe(false);
-    expect(ctx.log).toHaveBeenCalledTimes(1);
-  });
-
-  it("resetGhostState clears counter and degraded flag", () => {
-    const ctx = {
-      ...makeStateStore({
-        "wallet_ghost_failures:2": GHOST_FAILURE_THRESHOLD + 3,
-        "wallet_ghost_degraded:2": 1,
-      }),
-      log: vi.fn(),
-    };
-
-    resetGhostState.call(ctx, 2);
-
-    expect(ctx.getStateValue(walletGhostFailuresKey.call(ctx, 2))).toBe(0);
-    expect(ctx.getStateValue(walletGhostDegradedKey.call(ctx, 2))).toBe(0);
-    expect(ctx.log).toHaveBeenCalledWith("info", "ghost_wallet_recovered", { walletIndex: 2 });
-  });
-
-  it("resetGhostState does not log recovery when wallet was not degraded", () => {
-    const ctx = {
-      ...makeStateStore({
-        "wallet_ghost_failures:1": 2,
-      }),
-      log: vi.fn(),
-    };
-
-    resetGhostState.call(ctx, 1);
-
-    expect(ctx.getStateValue(walletGhostFailuresKey.call(ctx, 1))).toBe(0);
-    expect(ctx.log).not.toHaveBeenCalled();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildSponsorStatusSnapshot: ghost-degraded wallets report 0 available
-// ---------------------------------------------------------------------------
-
-describe("buildSponsorStatusSnapshot ghost-degraded wallets", () => {
-  function makeSnapshotDouble(opts: { rawAvailabilities: number[]; ghostDegradedWallets?: number[] }) {
-    const ghostSet = new Set(opts.ghostDegradedWallets ?? []);
+describe("buildSponsorStatusSnapshot available math", () => {
+  function makeSnapshotDouble(opts: { rawAvailabilities: number[] }) {
     return {
-      getInitializedWallets: async () => opts.rawAvailabilities.map((_, walletIndex) => ({ walletIndex })),
-      state: {
-        storage: {
-          get: async () => [],
-        },
-      },
-      walletQuarantineRecentKey: (walletIndex: number) => `quarantine:${walletIndex}`,
+      getInitializedWallets: () => opts.rawAvailabilities.map((_, walletIndex) => ({ walletIndex })),
       walletHeadroom: (walletIndex: number) => opts.rawAvailabilities[walletIndex],
-      walletGhostDegradedKey: (walletIndex: number) => `wallet_ghost_degraded:${walletIndex}`,
-      getStateValue: (key: string) => {
-        // Parse wallet index from key like "wallet_ghost_degraded:3"
-        const match = key.match(/wallet_ghost_degraded:(\d+)/);
-        if (match && ghostSet.has(Number(match[1]))) return 1;
-        return null;
-      },
+      getStateValue: () => null,
       getStoredCount: () => 0,
     };
   }
 
-  it("reports available: 0 for ghost-degraded wallet with positive headroom", async () => {
+  it("reports correct available from headroom", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-04-04T12:00:00.000Z"));
 
     const snapshot = await (NonceDO as any).prototype.buildSponsorStatusSnapshot.call(
-      makeSnapshotDouble({ rawAvailabilities: [15], ghostDegradedWallets: [0] })
+      makeSnapshotDouble({ rawAvailabilities: [15] })
     );
 
-    expect(snapshot.noncePool.totalAvailable).toBe(0);
-    expect(snapshot.noncePool.totalReserved).toBe(CHAINING_LIMIT);
+    expect(snapshot.noncePool.totalAvailable).toBe(15);
+    expect(snapshot.noncePool.totalReserved).toBe(CHAINING_LIMIT - 15);
     expect(snapshot.noncePool.totalCapacity).toBe(CHAINING_LIMIT);
+    expect(snapshot.allWalletsDegraded).toBe(false);
   });
 
-  it("includes ghost-degraded in allWalletsDegraded check", async () => {
+  it("allWalletsDegraded only when all wallets at zero available", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-04-04T12:00:00.000Z"));
 
     const snapshot = await (NonceDO as any).prototype.buildSponsorStatusSnapshot.call(
-      makeSnapshotDouble({ rawAvailabilities: [10], ghostDegradedWallets: [0] })
+      makeSnapshotDouble({ rawAvailabilities: [0] })
     );
 
     expect(snapshot.allWalletsDegraded).toBe(true);
   });
 
-  it("healthy wallet unaffected when sibling is ghost-degraded", async () => {
+  it("multi-wallet available sums correctly", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-04-04T12:00:00.000Z"));
 
     const snapshot = await (NonceDO as any).prototype.buildSponsorStatusSnapshot.call(
-      makeSnapshotDouble({ rawAvailabilities: [10, 15], ghostDegradedWallets: [0] })
+      makeSnapshotDouble({ rawAvailabilities: [10, 15] })
     );
 
-    // Wallet 0: ghost-degraded → 0 available, 20 reserved
-    // Wallet 1: healthy → 15 available, 5 reserved
-    expect(snapshot.noncePool.totalAvailable).toBe(15);
-    expect(snapshot.noncePool.totalReserved).toBe(25);
+    expect(snapshot.noncePool.totalAvailable).toBe(25);
+    expect(snapshot.noncePool.totalReserved).toBe(2 * CHAINING_LIMIT - 25);
     expect(snapshot.allWalletsDegraded).toBe(false);
   });
 });

--- a/src/dashboard/components/cards.ts
+++ b/src/dashboard/components/cards.ts
@@ -1,4 +1,5 @@
 import { colors, formatNumber, formatTokenAmount, escapeHtml } from "../styles";
+import type { DashboardOverview, WalletThroughputEntry } from "../../types";
 
 /**
  * Stats card component
@@ -141,27 +142,40 @@ export function healthCard(
 }
 
 /**
- * Success rate card with visual indicator.
+ * Success rate card with visual indicator showing both effective and raw rates.
  *
- * When clientErrors is provided and > 0, shows the effective success rate
- * (excluding client errors from the denominator) as the primary metric,
- * with the raw success rate as secondary subtext. This surfaces the relay's
- * actual reliability independent of client-caused failures.
+ * When precomputed rates are provided (effectiveRateOverride / rawRateOverride, 0-100),
+ * they are used directly. Otherwise rates are computed from success/total/clientErrors.
  *
  * Effective rate formula: success / (success + relayErrors)
  *   where relayErrors = (total - success) - clientErrors
+ *
+ * Displays effective rate as primary metric and raw rate as a secondary metric below.
+ * When both rates are equal (no client errors), only the effective rate is shown.
  */
-export function successRateCard(success: number, total: number, clientErrors?: number): string {
-  const failed = total - success;
-  const relayErrors = Math.max(0, failed - (clientErrors ?? 0));
-  const effectiveDenominator = success + relayErrors;
+export function successRateCard(
+  success: number,
+  total: number,
+  clientErrors?: number,
+  options?: { effectiveRateOverride?: number; rawRateOverride?: number }
+): string {
+  let effectiveRate: number;
+  let rawRate: number;
 
-  // Effective rate excludes client errors from denominator
-  const effectiveRate = effectiveDenominator > 0 ? Math.round((success / effectiveDenominator) * 100) : 0;
-  // Raw rate includes all requests
-  const rawRate = total > 0 ? Math.round((success / total) * 100) : 0;
+  if (options?.effectiveRateOverride !== undefined) {
+    effectiveRate = Math.round(options.effectiveRateOverride * 100);
+    rawRate = options?.rawRateOverride !== undefined
+      ? Math.round(options.rawRateOverride * 100)
+      : effectiveRate;
+  } else {
+    const failed = total - success;
+    const relayErrors = Math.max(0, failed - (clientErrors ?? 0));
+    const effectiveDenominator = success + relayErrors;
+    effectiveRate = effectiveDenominator > 0 ? Math.round((success / effectiveDenominator) * 100) : 0;
+    rawRate = total > 0 ? Math.round((success / total) * 100) : 0;
+  }
 
-  const hasClientErrors = (clientErrors ?? 0) > 0;
+  const hasClientErrors = (clientErrors ?? 0) > 0 || rawRate !== effectiveRate;
 
   let color: string;
   if (effectiveRate >= 95) {
@@ -172,6 +186,10 @@ export function successRateCard(success: number, total: number, clientErrors?: n
     color = colors.status.down;
   }
 
+  const rawColor = rawRate >= 95 ? colors.status.healthy
+    : rawRate >= 80 ? colors.status.degraded
+    : colors.status.down;
+
   return `
 <div class="brand-card p-4">
   <p class="text-sm text-gray-400">Success Rate</p>
@@ -179,8 +197,12 @@ export function successRateCard(success: number, total: number, clientErrors?: n
   <div class="mt-2 h-2 rounded-full overflow-hidden" style="background-color: ${colors.bg.border}">
     <div class="h-full rounded-full" style="width: ${effectiveRate}%; background-color: ${color}"></div>
   </div>
-  <p class="text-xs text-gray-500 mt-1">${formatNumber(success)} / ${formatNumber(effectiveDenominator)} (relay)</p>
-  ${hasClientErrors ? `<p class="text-xs text-gray-600 mt-0.5">raw: ${rawRate}% (${formatNumber(total)} total)</p>` : ""}
+  <p class="text-xs text-gray-500 mt-1">effective (relay errors only)</p>
+  ${hasClientErrors ? `
+  <div class="mt-2 pt-2" style="border-top: 1px solid ${colors.bg.border}">
+    <p class="text-xs text-gray-400">raw: <span style="color: ${rawColor}">${rawRate}%</span></p>
+    <p class="text-xs text-gray-600">includes client errors</p>
+  </div>` : ""}
 </div>`;
 }
 
@@ -260,5 +282,153 @@ export function feesSpentCard(totalFees: string, avgFee: string): string {
   </div>
   <p class="text-2xl font-bold mt-2" style="color: ${colors.brand.orange}">${escapeHtml(formattedTotal)}</p>
   <p class="text-xs text-gray-500 mt-1">avg: ${formatNumber(avgFeeNum)} uSTX / tx</p>
+</div>`;
+}
+
+/**
+ * Fees detail card — server-rendered card showing total, avg, min, and max STX fees.
+ * Uses rolling 24h data from DashboardOverview.fees (Phases 1-2 data sources).
+ *
+ * @param fees - Fee stats object with total, average, min, max in microSTX strings
+ */
+export function feesDetailCard(fees: { total: string; average: string; min: string; max: string }): string {
+  const formattedTotal = formatTokenAmount(fees.total, "STX");
+  const avgFeeNum = parseInt(fees.average || "0", 10);
+  const minFeeNum = parseInt(fees.min || "0", 10);
+  const maxFeeNum = parseInt(fees.max || "0", 10);
+
+  return `
+<div class="brand-card p-4">
+  <div class="flex items-center justify-between">
+    <p class="text-sm text-gray-400">Fees Sponsored (24h)</p>
+    <svg class="w-5 h-5 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+  </div>
+  <p class="text-2xl font-bold mt-2" style="color: ${colors.brand.orange}">${escapeHtml(formattedTotal)}</p>
+  <div class="grid grid-cols-3 gap-2 mt-2 pt-2" style="border-top: 1px solid ${colors.bg.border}">
+    <div>
+      <p class="text-xs text-gray-500">avg</p>
+      <p class="text-sm font-medium text-white">${formatNumber(avgFeeNum)}</p>
+    </div>
+    <div>
+      <p class="text-xs text-gray-500">min</p>
+      <p class="text-sm font-medium text-white">${formatNumber(minFeeNum)}</p>
+    </div>
+    <div>
+      <p class="text-xs text-gray-500">max</p>
+      <p class="text-sm font-medium text-white">${formatNumber(maxFeeNum)}</p>
+    </div>
+  </div>
+  <p class="text-xs text-gray-600 mt-1">uSTX per tx</p>
+</div>`;
+}
+
+/**
+ * Terminal reason breakdown card — server-rendered breakdown of error counts
+ * grouped by tx-schemas terminal reason category (rolling 24h).
+ *
+ * Categories: validation, sender, relay, settlement, replacement, identity
+ * Returns null-safe HTML: shows "No errors" when all counts are zero or data is missing.
+ */
+export function terminalReasonsCard(reasons: DashboardOverview["terminalReasons"]): string {
+  const categories: Array<{ key: keyof NonNullable<typeof reasons>; label: string }> = [
+    { key: "validation", label: "Validation" },
+    { key: "sender", label: "Sender" },
+    { key: "relay", label: "Relay" },
+    { key: "settlement", label: "Settlement" },
+    { key: "replacement", label: "Replacement" },
+    { key: "identity", label: "Identity" },
+  ];
+
+  const hasErrors = reasons && Object.values(reasons).some((v) => v > 0);
+
+  const rows = hasErrors
+    ? categories.map(({ key, label }) => {
+        const count = reasons![key];
+        const dotColor = colors.terminalReasons[key];
+        return `
+  <div class="flex items-center justify-between py-1" style="border-bottom: 1px solid ${colors.bg.border}">
+    <div class="flex items-center gap-2">
+      <div class="w-3 h-3 rounded-full flex-shrink-0" style="background-color: ${dotColor}"></div>
+      <span class="text-sm text-gray-400">${escapeHtml(label)}</span>
+    </div>
+    <span class="text-sm font-medium ${count > 0 ? "text-white" : "text-gray-600"}">${formatNumber(count)}</span>
+  </div>`;
+      }).join("")
+    : `<p class="text-sm text-gray-500 py-2">No errors in rolling 24h window</p>`;
+
+  return `
+<div class="brand-card p-4">
+  <p class="text-sm text-gray-400 mb-3">Error Breakdown (24h)</p>
+  ${rows}
+</div>`;
+}
+
+/**
+ * Wallet throughput card — server-rendered per-wallet 24h throughput with sparklines.
+ *
+ * Shows a row per active wallet with: index, 24h total, success rate bar, sparkline.
+ * Sparkline: 24 hourly bars scaled to the wallet's own max hourly total.
+ * Empty state shown when wallets array is empty or undefined.
+ */
+export function walletThroughputCard(wallets: WalletThroughputEntry[] | undefined): string {
+  if (!wallets || wallets.length === 0) {
+    return `
+<div class="brand-card p-4">
+  <p class="text-sm text-gray-400 mb-2">Wallet Throughput (24h)</p>
+  <p class="text-sm text-gray-500">No wallet activity in last 24h</p>
+</div>`;
+  }
+
+  const walletRows = wallets.map((w) => {
+    const successRate = w.total24h > 0 ? Math.round((w.success24h / w.total24h) * 100) : 0;
+    const rateColor = successRate >= 95 ? colors.status.healthy
+      : successRate >= 80 ? colors.status.degraded
+      : colors.status.down;
+
+    // Build sparkline: 24 hourly bars
+    const maxHourly = Math.max(1, ...w.hourly.map((h) => h.total));
+    const sparkBars = w.hourly.map((h) => {
+      const heightPct = Math.round((h.total / maxHourly) * 100);
+      const barColor = h.failed > 0 ? colors.status.degraded : colors.status.healthy;
+      return `<div class="sparkline-bar" style="height: ${Math.max(4, heightPct)}%; background-color: ${barColor}"></div>`;
+    }).join("");
+
+    return `
+<div class="flex items-center gap-3 py-2" style="border-bottom: 1px solid ${colors.bg.border}">
+  <span class="text-xs font-mono text-gray-500" style="min-width: 1.5rem; text-align: right">#${w.walletIndex}</span>
+  <span class="text-sm font-bold text-white" style="min-width: 2.5rem">${formatNumber(w.total24h)}</span>
+  <div class="flex-1" style="max-width: 80px">
+    <div class="h-2 rounded-full overflow-hidden" style="background-color: ${colors.bg.border}">
+      <div class="h-full rounded-full" style="width: ${successRate}%; background-color: ${rateColor}"></div>
+    </div>
+    <p class="text-xs mt-0.5" style="color: ${rateColor}">${successRate}%</p>
+  </div>
+  <div class="sparkline flex-1">${sparkBars}</div>
+</div>`;
+  }).join("");
+
+  return `
+<div class="brand-card p-4">
+  <div class="flex items-center justify-between mb-3">
+    <p class="text-sm text-gray-400">Wallet Throughput (24h)</p>
+    <div class="flex items-center gap-3 text-xs text-gray-500">
+      <span class="flex items-center gap-1">
+        <span class="sparkline-bar" style="display: inline-block; width: 8px; height: 10px; background-color: ${colors.status.healthy}"></span> success
+      </span>
+      <span class="flex items-center gap-1">
+        <span class="sparkline-bar" style="display: inline-block; width: 8px; height: 10px; background-color: ${colors.status.degraded}"></span> w/ errors
+      </span>
+    </div>
+  </div>
+  <div class="flex items-center gap-3 mb-1" style="padding-left: 0.25rem">
+    <span class="text-xs text-gray-600" style="min-width: 1.5rem"></span>
+    <span class="text-xs text-gray-600" style="min-width: 2.5rem">txs</span>
+    <span class="text-xs text-gray-600" style="max-width: 80px; flex: 1">rate</span>
+    <span class="text-xs text-gray-600 flex-1">24h (hourly)</span>
+  </div>
+  ${walletRows}
 </div>`;
 }

--- a/src/dashboard/components/cards.ts
+++ b/src/dashboard/components/cards.ts
@@ -303,7 +303,7 @@ export function feesDetailCard(fees: { total: string; average: string; min: stri
 
 /**
  * Terminal reason breakdown card — server-rendered breakdown of error counts
- * grouped by tx-schemas terminal reason category (rolling 24h).
+ * grouped by tx-schemas terminal reason category (today, calendar day UTC).
  *
  * Categories: validation, sender, relay, settlement, replacement, identity
  * Returns null-safe HTML: shows "No errors" when all counts are zero or data is missing.
@@ -333,11 +333,11 @@ export function terminalReasonsCard(reasons: DashboardOverview["terminalReasons"
     <span class="text-sm font-medium ${count > 0 ? "text-white" : "text-gray-600"}">${formatNumber(count)}</span>
   </div>`;
       }).join("")
-    : `<p class="text-sm text-gray-500 py-2">No errors in rolling 24h window</p>`;
+    : `<p class="text-sm text-gray-500 py-2">No errors today</p>`;
 
   return `
 <div class="brand-card p-4">
-  <p class="text-sm text-gray-400 mb-3">Error Breakdown (24h)</p>
+  <p class="text-sm text-gray-400 mb-3">Error Breakdown (Today)</p>
   ${rows}
 </div>`;
 }

--- a/src/dashboard/components/cards.ts
+++ b/src/dashboard/components/cards.ts
@@ -144,8 +144,9 @@ export function healthCard(
 /**
  * Success rate card with visual indicator showing both effective and raw rates.
  *
- * When precomputed rates are provided (effectiveRateOverride / rawRateOverride, 0-100),
- * they are used directly. Otherwise rates are computed from success/total/clientErrors.
+ * When precomputed rates are provided (effectiveRateOverride / rawRateOverride, as 0-1 fractions),
+ * they are used directly and converted to percentages for display. Otherwise rates are computed
+ * from success/total/clientErrors.
  *
  * Effective rate formula: success / (success + relayErrors)
  *   where relayErrors = (total - success) - clientErrors
@@ -367,9 +368,13 @@ export function walletThroughputCard(wallets: WalletThroughputEntry[] | undefine
     // Build sparkline: 24 hourly bars
     const maxHourly = Math.max(1, ...w.hourly.map((h) => h.total));
     const sparkBars = w.hourly.map((h) => {
-      const heightPct = Math.round((h.total / maxHourly) * 100);
-      const barColor = h.failed > 0 ? colors.status.degraded : colors.status.healthy;
-      return `<div class="sparkline-bar" style="height: ${Math.max(4, heightPct)}%; background-color: ${barColor}"></div>`;
+      const hasActivity = h.total > 0;
+      const heightPct = hasActivity ? Math.round((h.total / maxHourly) * 100) : 0;
+      const barHeight = hasActivity ? Math.max(4, heightPct) : 0;
+      const barColor = !hasActivity
+        ? "transparent"
+        : h.failed > 0 ? colors.status.degraded : colors.status.healthy;
+      return `<div class="sparkline-bar" style="height: ${barHeight}%; background-color: ${barColor}"></div>`;
     }).join("");
 
     return `

--- a/src/dashboard/components/cards.ts
+++ b/src/dashboard/components/cards.ts
@@ -262,30 +262,6 @@ export function settlementTimeCard(): string {
 }
 
 /**
- * Fees spent card — server-rendered card showing total STX fees sponsored.
- *
- * @param totalFees - Total fees in microSTX as a string (e.g. "1234567890")
- * @param avgFee - Average fee per transaction in microSTX as a string (e.g. "12345")
- */
-export function feesSpentCard(totalFees: string, avgFee: string): string {
-  const formattedTotal = formatTokenAmount(totalFees, "STX");
-  const avgFeeNum = parseInt(avgFee || "0", 10);
-
-  return `
-<div class="brand-card p-4">
-  <div class="flex items-center justify-between">
-    <p class="text-sm text-gray-400">Fees Sponsored</p>
-    <svg class="w-5 h-5 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-        d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-    </svg>
-  </div>
-  <p class="text-2xl font-bold mt-2" style="color: ${colors.brand.orange}">${escapeHtml(formattedTotal)}</p>
-  <p class="text-xs text-gray-500 mt-1">avg: ${formatNumber(avgFeeNum)} uSTX / tx</p>
-</div>`;
-}
-
-/**
  * Fees detail card — server-rendered card showing total, avg, min, and max STX fees.
  * Uses rolling 24h data from DashboardOverview.fees (Phases 1-2 data sources).
  *

--- a/src/dashboard/pages/overview.ts
+++ b/src/dashboard/pages/overview.ts
@@ -491,14 +491,23 @@ ${footer(utcTimestamp())}
   // Module-scoped reference for auto-refresh interval
   var _txChartInstance = null;
 
-  // Convert UTC hour label ("HH:00") to visitor's local timezone.
+  // Convert UTC hour label to visitor's local timezone.
+  // Accepts ISO timestamps ("2026-04-06T14:00:00Z") or legacy "HH:00" format.
   // For non-hour labels (e.g. "Feb 12" from 7d view), return as-is.
   function toLocalHour(utcLabel) {
+    // ISO timestamp format (YYYY-MM-DDTHH:00:00Z)
+    if (utcLabel.length > 5 && utcLabel.indexOf('T') !== -1) {
+      var d = new Date(utcLabel);
+      if (!isNaN(d.getTime())) {
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+      }
+    }
+    // Legacy "HH:00" format
     var m = utcLabel.match(/^(\\d{2}):00$/);
     if (!m) return utcLabel;
     var now = new Date();
-    var d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), parseInt(m[1], 10)));
-    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+    var d2 = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), parseInt(m[1], 10)));
+    return d2.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
   }
 
   // Convert all labels in a chart config to local timezone

--- a/src/dashboard/pages/overview.ts
+++ b/src/dashboard/pages/overview.ts
@@ -316,7 +316,7 @@ ${header(network)}
     <!-- Error Breakdown by Terminal Reason Category -->
     <div class="detail-section" x-data="{ open: false }">
       <button class="detail-section__header" @click="open = !open" type="button">
-        <span class="text-sm font-semibold text-white">Error Breakdown (24h)</span>
+        <span class="text-sm font-semibold text-white">Error Breakdown (Today)</span>
         <svg class="detail-section__chevron" :class="{ 'detail-section__chevron--open': open }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
         </svg>

--- a/src/dashboard/pages/overview.ts
+++ b/src/dashboard/pages/overview.ts
@@ -6,8 +6,10 @@ import {
   healthCard,
   successRateCard,
   statusBannerPlaceholder,
-  feesSpentCard,
+  feesDetailCard,
   settlementTimeCard,
+  terminalReasonsCard,
+  walletThroughputCard,
 } from "../components/cards";
 import {
   formatTrend,
@@ -151,9 +153,16 @@ ${header(network)}
         icon: `<svg class="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>`,
       })}
 
-      ${successRateCard(data.transactions.success, data.transactions.total, data.transactions.clientErrors)}
+      ${successRateCard(
+        data.transactions.success,
+        data.transactions.total,
+        data.transactions.clientErrors,
+        data.transactions.effectiveSuccessRate !== undefined
+          ? { effectiveRateOverride: data.transactions.effectiveSuccessRate, rawRateOverride: data.transactions.rawSuccessRate }
+          : undefined
+      )}
 
-      ${feesSpentCard(data.fees.total, data.fees.average)}
+      ${feesDetailCard({ total: data.fees.total, average: data.fees.average, min: data.fees.min, max: data.fees.max })}
 
       ${settlementTimeCard()}
     </div>
@@ -299,6 +308,49 @@ ${header(network)}
       </button>
       <div class="detail-section__body" x-show="open" x-cloak>
         ${endpointBreakdownCards(data.endpointBreakdown)}
+      </div>
+    </div>
+    ` : ""}
+
+    ${data.terminalReasons ? `
+    <!-- Error Breakdown by Terminal Reason Category -->
+    <div class="detail-section" x-data="{ open: false }">
+      <button class="detail-section__header" @click="open = !open" type="button">
+        <span class="text-sm font-semibold text-white">Error Breakdown (24h)</span>
+        <svg class="detail-section__chevron" :class="{ 'detail-section__chevron--open': open }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </button>
+      <div class="detail-section__body" x-show="open" x-cloak>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          ${terminalReasonsCard(data.terminalReasons)}
+          <div class="brand-card p-4">
+            <p class="text-sm text-gray-400 mb-3">Category Guide</p>
+            <div class="space-y-1">
+              <p class="text-xs text-gray-500"><span style="color: ${colors.terminalReasons.validation}">Validation</span> — invalid_transaction, not_sponsored</p>
+              <p class="text-xs text-gray-500"><span style="color: ${colors.terminalReasons.sender}">Sender</span> — nonce gaps, chaining limit, expired holds</p>
+              <p class="text-xs text-gray-500"><span style="color: ${colors.terminalReasons.relay}">Relay</span> — sponsor_failure, queue_unavailable, internal</p>
+              <p class="text-xs text-gray-500"><span style="color: ${colors.terminalReasons.settlement}">Settlement</span> — broadcast_failure, chain_abort</p>
+              <p class="text-xs text-gray-500"><span style="color: ${colors.terminalReasons.replacement}">Replacement</span> — nonce_replacement, superseded</p>
+              <p class="text-xs text-gray-500"><span style="color: ${colors.terminalReasons.identity}">Identity</span> — expired, unknown_payment_identity</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    ` : ""}
+
+    ${data.walletThroughput && data.walletThroughput.length > 0 ? `
+    <!-- Wallet Throughput (24h) -->
+    <div class="detail-section" x-data="{ open: false }">
+      <button class="detail-section__header" @click="open = !open" type="button">
+        <span class="text-sm font-semibold text-white">Wallet Throughput (24h)</span>
+        <svg class="detail-section__chevron" :class="{ 'detail-section__chevron--open': open }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </button>
+      <div class="detail-section__body" x-show="open" x-cloak>
+        ${walletThroughputCard(data.walletThroughput)}
       </div>
     </div>
     ` : ""}

--- a/src/dashboard/styles.ts
+++ b/src/dashboard/styles.ts
@@ -41,6 +41,16 @@ export const colors = {
     stable: "#6B7280", // Gray
   },
 
+  // Terminal reason category colors (tx-schemas error categories)
+  terminalReasons: {
+    validation: "#5546FF",   // Stacks purple — invalid_transaction, not_sponsored
+    sender: "#FBBF24",       // Yellow — sender_nonce_*, origin_chaining_limit
+    relay: "#F87171",        // Red — sponsor_failure, queue_unavailable, internal_error
+    settlement: "#FB923C",   // Orange — broadcast_failure, chain_abort
+    replacement: "#A855F7",  // Purple — nonce_replacement, superseded
+    identity: "#6B7280",     // Gray — expired, unknown_payment_identity
+  },
+
   // UI colors
   bg: {
     primary: "#000000", // brand black
@@ -317,11 +327,28 @@ export const dashboardCss = `
 
   /* ── Utility additions for redesign ───────────────────────── */
   .h-64 { height: 16rem; }
+  .h-20 { height: 5rem; }
   .gap-2 { gap: 0.5rem; }
   .text-green-400 { color: #4ade80; }
   .text-red-400 { color: #f87171; }
   .flex-1 { flex: 1; }
   .max-w-\\[200px\\] { max-width: 200px; }
+  .grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+
+  /* ── Sparkline bar chart ───────────────────────────────────── */
+  .sparkline {
+    display: flex;
+    align-items: flex-end;
+    gap: 1px;
+    height: 24px;
+    overflow: hidden;
+  }
+  .sparkline-bar {
+    flex: 1;
+    min-width: 2px;
+    border-radius: 1px 1px 0 0;
+    transition: height 0.2s ease;
+  }
 
   /* ── Nonce tile classes ────────────────────────────────────── */
   .nonce-lane {

--- a/src/dashboard/styles.ts
+++ b/src/dashboard/styles.ts
@@ -224,7 +224,8 @@ export const dashboardCss = `
   .bg-gray-600 { background-color: #4b5563; }
   .bg-gray-800 { background-color: #1f2937; }
   .bg-gray-900 { background-color: #111827; }
-  .bg-gray-900.bg-opacity-50 { background-color: rgba(17, 24, 39, 0.5); }
+  .bg-opacity-50 { --bg-opacity: 0.5; }
+  .bg-gray-900.bg-opacity-50 { background-color: rgba(17, 24, 39, var(--bg-opacity, 1)); }
   .bg-green-600 { background-color: #16a34a; }
   .bg-green-900 { background-color: #14532d; }
   .bg-yellow-900 { background-color: #713f12; }
@@ -268,6 +269,7 @@ export const dashboardCss = `
     .md\\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   }
   @media (min-width: 1024px) {
+    .lg\\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
     .lg\\:px-8 { padding-left: 2rem; padding-right: 2rem; }
   }
 

--- a/src/dashboard/styles.ts
+++ b/src/dashboard/styles.ts
@@ -158,8 +158,10 @@ export const dashboardCss = `
   .mt-3 { margin-top: 0.75rem; }
   .mt-4 { margin-top: 1rem; }
   .mt-6 { margin-top: 1.5rem; }
+  .mb-1 { margin-bottom: 0.25rem; }
   .mb-2 { margin-bottom: 0.5rem; }
   .mb-3 { margin-bottom: 0.75rem; }
+  .space-y-1 > :not(:first-child) { margin-top: 0.25rem; }
   .mb-4 { margin-bottom: 1rem; }
   .mb-6 { margin-bottom: 1.5rem; }
   .mb-8 { margin-bottom: 2rem; }
@@ -261,6 +263,7 @@ export const dashboardCss = `
     .sm\\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
   }
   @media (min-width: 768px) {
+    .md\\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .md\\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .md\\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   }

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -246,6 +246,7 @@ interface ObservableWalletState {
   gaps: number[];
   available: number;
   reserved: number;
+  /** @deprecated Always false — circuit breaker removed in favor of per-nonce tracking */
   circuitBreakerOpen: boolean;
   healthy: boolean;
   /** Total non-confirmed dispatch_queue rows (queued + dispatched + replaying) */
@@ -254,10 +255,6 @@ interface ObservableWalletState {
   replayBufferDepth?: number;
   /** Settlement time percentiles for this wallet (last 24h, null if no data) */
   settlementTimes?: SettlementTimeStats;
-  /** True when the wallet has accumulated GHOST_FAILURE_THRESHOLD consecutive ghost failures */
-  ghostDegraded?: boolean;
-  /** Number of consecutive ghost broadcast failures (ConflictingNonceInMempool with no Hiro-visible occupant) */
-  ghostFailures?: number;
 }
 
 /**
@@ -399,12 +396,6 @@ const ALARM_INTERVAL_MS = 5 * 60 * 1000;
 const ALARM_INTERVAL_ACTIVE_MS = 60 * 1000;
 /** Alias for readability: idle wallets revert to the standard 5-minute cadence. */
 const ALARM_INTERVAL_IDLE_MS = ALARM_INTERVAL_MS;
-/**
- * Alarm interval used when a cross-wallet cascade is active AND there are in-flight nonces.
- * 20s fires much more often than the normal 60s active cadence, accelerating RBF and gap-fill
- * cycles during nonce storms so the DO self-heals without waiting for agent retries.
- */
-const ALARM_INTERVAL_CASCADE_MS = 20 * 1000;
 /** Reset to possible_next_nonce if no assignment in this window and we are ahead */
 const STALE_THRESHOLD_MS = 10 * 60 * 1000;
 /** Maximum number of sponsor wallets supported */
@@ -444,10 +435,6 @@ const SENDER_REFRESH_FAILURE_BACKOFF_MS = 2 * 60 * 1000;
  * probability and are candidates for RBF replacement.
  */
 const STUCK_TX_AGE_MS = 15 * 60 * 1000;
-/** Reduced stuck-tx age when a cross-wallet cascade is active (5 min) */
-const STUCK_TX_AGE_CASCADE_MS = 5 * 60 * 1000;
-/** Most aggressive stuck-tx age when a wallet's circuit breaker is open (3 min) */
-const STUCK_TX_AGE_CIRCUIT_OPEN_MS = 3 * 60 * 1000;
 /**
  * Compute the RBF fee for replacing a stuck tx.
  * Stacks only requires original_fee + 1 uSTX to replace. When original_fee is known
@@ -483,22 +470,6 @@ const MAX_RBF_ATTEMPTS = 3;
  * replacement + resubmission window exceeds the call's deadline.
  */
 const HEAD_BUMP_FEE = MIN_FLUSH_FEE * 2n;
-/**
- * Per-wallet circuit breaker: if a wallet accumulates this many quarantines
- * within CIRCUIT_BREAKER_WINDOW_MS, it is skipped during nonce assignment
- * and an eager resync is triggered for that wallet only.
- */
-// Single failure = immediate skip. Wallet recovers naturally when the 10-minute
-// CIRCUIT_BREAKER_WINDOW_MS expires. For a payment relay, every failed broadcast
-// is a user-facing SETTLEMENT_TIMEOUT — aggressive quarantine is correct.
-const CIRCUIT_BREAKER_QUARANTINE_THRESHOLD = 1;
-/**
- * Number of consecutive ghost broadcast failures before a wallet is marked ghost_degraded.
- * A "ghost" failure is a ConflictingNonceInMempool where fetchOccupantFee returns null —
- * the node holds a transaction that Hiro cannot see (invisible mempool entry).
- * Ghost-degraded wallets are skipped during nonce assignment until they self-clear.
- */
-const GHOST_FAILURE_THRESHOLD = 5;
 /** Maximum fee cap for gap-fill escalation and RBF broadcasts (90,000 uSTX) */
 const MAX_BROADCAST_FEE = 90_000n;
 
@@ -544,13 +515,6 @@ const ALARM_WALLET_CURSOR_KEY = "alarm_wallet_cursor";
 
 /** nonce_state key for the round-robin sender sweep cursor */
 const ALARM_SENDER_CURSOR_KEY = "alarm_sender_cursor";
-/** Time window for circuit breaker quarantine counting (10 minutes) */
-const CIRCUIT_BREAKER_WINDOW_MS = 10 * 60 * 1000;
-/**
- * Cross-wallet cascade detection: log a cascade_detected event when quarantine
- * count across all wallets exceeds this threshold within CIRCUIT_BREAKER_WINDOW_MS.
- */
-const CASCADE_DETECTION_THRESHOLD = 3;
 
 /**
  * Pool pressure threshold (0.80 = 80%) above which a surge event is recorded.
@@ -619,26 +583,6 @@ class LowHeadroomError extends Error {
     // Estimate: each confirmed tx frees one nonce slot. ~2 txs/s drain rate.
     // Backoff scales with pool pressure: more reserved nonces → longer wait.
     this.retryAfterSeconds = Math.ceil((CHAINING_LIMIT - maxHeadroom) / 2) + 5;
-  }
-}
-
-/**
- * Thrown when ALL wallets are circuit-broken (degraded) but at least one has
- * headroom. Previously the code fell back to the "least degraded" wallet,
- * which fed transactions into a broken pool and amplified contention.
- * Now we reject immediately with a retry hint.
- */
-class AllWalletsDegradedError extends Error {
-  readonly degradedCount: number;
-  readonly totalReserved: number;
-  readonly totalCapacity: number;
-
-  constructor(degradedCount: number, totalReserved: number, totalCapacity: number) {
-    super("ALL_WALLETS_DEGRADED");
-    this.name = "AllWalletsDegradedError";
-    this.degradedCount = degradedCount;
-    this.totalReserved = totalReserved;
-    this.totalCapacity = totalCapacity;
   }
 }
 
@@ -2432,7 +2376,6 @@ export class NonceDO {
         state.lastRbfTxid = result.txid;
         await this.state.storage.put(key, state);
         this.incrementCounter(STATE_KEYS.stuckTxRbfBroadcast);
-        this.resetGhostState(walletIndex);
         // Update the ledger txid so reconciliation tracks the replacement
         try {
           this.sql.exec(
@@ -2464,7 +2407,6 @@ export class NonceDO {
         // Terminal — delete stuck-tx state entirely to avoid orphaned entries
         state.rbfAttempts = attemptNum;
         await this.state.storage.delete(key);
-        this.resetGhostState(walletIndex);
         this.log("info", "rbf_nonce_consumed", {
           walletIndex,
           nonce,
@@ -2476,28 +2418,21 @@ export class NonceDO {
       }
 
       if (result.reason === "ConflictingNonceInMempool") {
-        // Classify the conflict based on why occupant fee lookup failed:
-        //   no_txid/not_found = true ghost (node holds tx invisible to Hiro)
-        //   hiro_error = transient Hiro failure — don't penalize the wallet
-        //   fee discovered = our fee was too low
+        // Classify the conflict for logging — no per-wallet degradation flags.
         const occupantReason = occupantResult.reason;
         const isGhost = occupantReason === "no_txid" || occupantReason === "not_found";
         const isHiroError = occupantReason === "hiro_error";
 
         if (isGhost) {
-          // True ghost — node holds something invisible to Hiro: increment ghost counter.
-          // Do NOT increment rbfAttempts — this is a guaranteed failure, not a real attempt.
-          this.incrementGhostFailures(walletIndex);
+          // Ghost — node holds tx invisible to Hiro. Log but don't penalize wallet.
           this.log("warn", "rbf_ghost_conflict", {
             walletIndex,
             nonce,
-            ghostFailures: this.getStateValue(this.walletGhostFailuresKey(walletIndex)),
             rbfFee: rbfFee.toString(),
             occupantReason,
           });
         } else if (isHiroError) {
-          // Hiro was unavailable — we can't determine occupant fee, don't blame the wallet.
-          // Do NOT increment rbfAttempts or ghost counter.
+          // Hiro unavailable — can't determine occupant fee, don't blame the wallet.
           this.log("warn", "rbf_conflict_hiro_unavailable", {
             walletIndex,
             nonce,
@@ -2505,10 +2440,8 @@ export class NonceDO {
             attemptNum,
           });
         } else {
-          // Fee too low (occupant fee discovered but our fee wasn't enough) — increment counter.
-          // This is a non-ghost outcome: reset ghost state if accumulated.
+          // Fee too low — occupant fee discovered but ours wasn't enough.
           state.rbfAttempts = attemptNum;
-          this.resetGhostState(walletIndex);
           this.log("warn", "rbf_fee_too_low", {
             walletIndex,
             nonce,
@@ -2836,59 +2769,6 @@ export class NonceDO {
     return `stuck_tx:${walletIndex}:${nonce}`;
   }
 
-  /** KV key for per-wallet recent quarantine timestamps (circuit breaker window) */
-  private walletQuarantineRecentKey(walletIndex: number): string {
-    return `wallet_quarantine_recent:${walletIndex}`;
-  }
-
-  /** nonce_state key for per-wallet ghost failure counter */
-  private walletGhostFailuresKey(walletIndex: number): string {
-    return `wallet_ghost_failures:${walletIndex}`;
-  }
-
-  /** nonce_state key for per-wallet ghost-degraded flag (0 = healthy, 1 = degraded) */
-  private walletGhostDegradedKey(walletIndex: number): string {
-    return `wallet_ghost_degraded:${walletIndex}`;
-  }
-
-  /**
-   * Increment the ghost failure counter for a wallet.
-   * When the counter reaches GHOST_FAILURE_THRESHOLD, marks the wallet as ghost_degraded.
-   * Ghost-degraded wallets are skipped during nonce assignment.
-   * Returns true if the wallet just became ghost_degraded.
-   */
-  private incrementGhostFailures(walletIndex: number): boolean {
-    const count = (this.getStateValue(this.walletGhostFailuresKey(walletIndex)) ?? 0) + 1;
-    this.setStateValue(this.walletGhostFailuresKey(walletIndex), count);
-    if (count >= GHOST_FAILURE_THRESHOLD) {
-      const alreadyDegraded = (this.getStateValue(this.walletGhostDegradedKey(walletIndex)) ?? 0) === 1;
-      this.setStateValue(this.walletGhostDegradedKey(walletIndex), 1);
-      if (!alreadyDegraded) {
-        this.log("warn", "ghost_wallet_degraded", {
-          walletIndex,
-          ghostFailures: count,
-          threshold: GHOST_FAILURE_THRESHOLD,
-        });
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Reset ghost failure state for a wallet on any non-ghost broadcast outcome.
-   * Called after: successful RBF, successful gap-fill, BadNonce (consumed),
-   * or fee-too-low (occupant fee was discovered, so not a ghost).
-   */
-  private resetGhostState(walletIndex: number): void {
-    const wasDegraded = (this.getStateValue(this.walletGhostDegradedKey(walletIndex)) ?? 0) === 1;
-    this.setStateValue(this.walletGhostFailuresKey(walletIndex), 0);
-    this.setStateValue(this.walletGhostDegradedKey(walletIndex), 0);
-    if (wasDegraded) {
-      this.log("info", "ghost_wallet_recovered", { walletIndex });
-    }
-  }
-
   /**
    * Compute the escalated gap-fill fee for a nonce based on prior attempts.
    * Returns baseFee + priorAttempts (capped at MAX_BROADCAST_FEE), or baseFee if no prior attempts.
@@ -2910,100 +2790,6 @@ export class NonceDO {
       }
     } catch { /* fail-open — use base fee */ }
     return baseFee;
-  }
-
-  /** KV key for cross-wallet cascade quarantine tracking */
-  private readonly cascadeQuarantineKey = "cascade_quarantine_window";
-
-  /**
-   * Record a quarantine event for a specific wallet.
-   * Maintains a rolling window of recent quarantine timestamps for the circuit breaker.
-   * Also contributes to cross-wallet cascade detection.
-   * Called from releaseNonce() only for failure quarantines (not normal consumption).
-   */
-  private async recordQuarantineEvent(walletIndex: number): Promise<void> {
-    const now = new Date().toISOString();
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-
-    // Update per-wallet recent quarantine list
-    const recentKey = this.walletQuarantineRecentKey(walletIndex);
-    const existing = (await this.state.storage.get<string[]>(recentKey)) ?? [];
-    const pruned = existing.filter((ts) => new Date(ts).getTime() >= cutoff);
-    pruned.push(now);
-    await this.state.storage.put(recentKey, pruned);
-
-    if (pruned.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD) {
-      this.log("warn", "circuit_breaker_triggered", {
-        walletIndex,
-        quarantineCount: pruned.length,
-        windowMs: CIRCUIT_BREAKER_WINDOW_MS,
-        threshold: CIRCUIT_BREAKER_QUARANTINE_THRESHOLD,
-      });
-    }
-
-    // Update cross-wallet cascade window
-    await this.checkCascadeThreshold(walletIndex, now);
-  }
-
-  /**
-   * Check if cross-wallet quarantines have crossed the cascade detection threshold.
-   * Logs a cascade_detected event when >= CASCADE_DETECTION_THRESHOLD quarantines
-   * have occurred across any wallets within the circuit breaker time window.
-   */
-  private async checkCascadeThreshold(walletIndex: number, ts: string): Promise<void> {
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-    const existing = (await this.state.storage.get<Array<{ walletIndex: number; ts: string }>>(
-      this.cascadeQuarantineKey
-    )) ?? [];
-
-    const pruned = existing.filter((e) => new Date(e.ts).getTime() >= cutoff);
-    pruned.push({ walletIndex, ts });
-    await this.state.storage.put(this.cascadeQuarantineKey, pruned);
-
-    if (pruned.length >= CASCADE_DETECTION_THRESHOLD) {
-      const uniqueWallets = [...new Set(pruned.map((e) => e.walletIndex))];
-      this.log("warn", "cascade_detected", {
-        totalQuarantinesInWindow: pruned.length,
-        affectedWallets: uniqueWallets,
-        windowMs: CIRCUIT_BREAKER_WINDOW_MS,
-        threshold: CASCADE_DETECTION_THRESHOLD,
-        detectedAt: ts,
-      });
-    }
-  }
-
-  /**
-   * Return true when a cross-wallet cascade is currently active.
-   * A cascade is active when >= CASCADE_DETECTION_THRESHOLD quarantine events have
-   * been recorded across any wallets within the CIRCUIT_BREAKER_WINDOW_MS window.
-   * Reads the same KV key that checkCascadeThreshold() writes so the signal is
-   * consistent without adding a separate flag.
-   */
-  private async isCascadeActive(): Promise<boolean> {
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-    const existing = (await this.state.storage.get<Array<{ walletIndex: number; ts: string }>>(
-      this.cascadeQuarantineKey
-    )) ?? [];
-    const pruned = existing.filter((e) => new Date(e.ts).getTime() >= cutoff);
-    if (pruned.length !== existing.length) {
-      await this.state.storage.put(this.cascadeQuarantineKey, pruned);
-    }
-    return pruned.length >= CASCADE_DETECTION_THRESHOLD;
-  }
-
-  /**
-   * Return the effective "stuck tx" age threshold for RBF eligibility.
-   * During a cascade the relay needs to RBF stuck transactions sooner so the
-   * nonce pipeline can drain before the situation worsens.
-   *
-   * - circuitOpen (any wallet): 3 min — most aggressive, wallet already skipped
-   * - cascadeActive:            5 min — multiple wallets affected, speed up RBF
-   * - normal:                  15 min (STUCK_TX_AGE_MS)
-   */
-  private getEffectiveStuckTxAge(cascadeActive: boolean, circuitOpen: boolean): number {
-    if (circuitOpen) return STUCK_TX_AGE_CIRCUIT_OPEN_MS;
-    if (cascadeActive) return STUCK_TX_AGE_CASCADE_MS;
-    return STUCK_TX_AGE_MS;
   }
 
   /**
@@ -3970,76 +3756,28 @@ export class NonceDO {
         )
       );
 
-      // Round-robin: start from stored nextWalletIndex, find a wallet under chaining limit
-      let walletIndex = (await this.getNextWalletIndex()) % effectiveWalletCount;
-
       // Resolve the correct sponsor address for a given wallet index.
       // In multi-wallet mode, each wallet has its own Stacks address for nonce seeding.
       const resolveAddress = (wi: number): string =>
         addresses?.[String(wi)] ?? sponsorAddress;
 
-      // Try each wallet in round-robin order; skip any at chaining limit or degraded (stuck nonce)
-      let attempts = 0;
+      // Scan all wallets and select the one with the most available headroom.
+      // No degradation flags — per-nonce occupied tracking handles conflicts.
       let totalMempoolDepth = 0;
-      // Track degraded wallets for fallback (walletIndex only — no pool state needed)
-      const degradedWallets: Array<{ walletIndex: number; cycleCount: number }> = [];
-      /** Eligible (under chaining limit) wallets with their available headroom */
       const eligibleWallets: Array<{ walletIndex: number; headroom: number }> = [];
-      let selectedWalletIndex: number | null = null;
 
-      while (attempts < effectiveWalletCount) {
-        // Ensure wallet head is initialized before circuit breaker check
-        await this.initWalletHeadFromHiro(walletIndex, resolveAddress(walletIndex));
-
-        // Check per-wallet circuit breaker: skip if too many recent quarantines
-        const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-        const recentQuarantines = (
-          await this.state.storage.get<string[]>(this.walletQuarantineRecentKey(walletIndex))
-        ) ?? [];
-        const activeQuarantines = recentQuarantines.filter(
-          (ts) => new Date(ts).getTime() >= cutoff
-        );
-        if (activeQuarantines.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD) {
-          this.log("warn", "circuit_breaker_skip", {
-            walletIndex,
-            quarantineCount: activeQuarantines.length,
-            windowMs: CIRCUIT_BREAKER_WINDOW_MS,
-            threshold: CIRCUIT_BREAKER_QUARANTINE_THRESHOLD,
-          });
-          degradedWallets.push({ walletIndex, cycleCount: 0 });
-          walletIndex = (walletIndex + 1) % effectiveWalletCount;
-          attempts++;
-          continue;
-        }
-
-        // Check ghost-degraded state: skip wallets where broadcast failures indicate
-        // the node holds transactions invisible to Hiro (ghost mempool entries).
-        const isGhostDegraded = (this.getStateValue(this.walletGhostDegradedKey(walletIndex)) ?? 0) === 1;
-        if (isGhostDegraded) {
-          this.log("warn", "ghost_degraded_skip", {
-            walletIndex,
-            ghostFailures: this.getStateValue(this.walletGhostFailuresKey(walletIndex)) ?? 0,
-          });
-          degradedWallets.push({ walletIndex, cycleCount: 0 });
-          walletIndex = (walletIndex + 1) % effectiveWalletCount;
-          attempts++;
-          continue;
-        }
-
-        const headroom = this.walletHeadroom(walletIndex);
+      for (let i = 0; i < effectiveWalletCount; i++) {
+        await this.initWalletHeadFromHiro(i, resolveAddress(i));
+        const headroom = this.walletHeadroom(i);
         if (headroom > 0) {
-          // Collect all eligible wallets; select by headroom after full scan
-          eligibleWallets.push({ walletIndex, headroom });
+          eligibleWallets.push({ walletIndex: i, headroom });
         } else {
-          // This wallet is at its chaining limit; accumulate depth for error reporting
-          totalMempoolDepth += CHAINING_LIMIT - headroom; // headroom is 0 (or negative on fallback path)
+          totalMempoolDepth += CHAINING_LIMIT - headroom;
         }
-        walletIndex = (walletIndex + 1) % effectiveWalletCount;
-        attempts++;
       }
 
-      // Select wallet with most chain headroom (fewest in-flight nonces).
-      // Prefer a wallet that has more room to absorb additional burst traffic.
+      // Select wallet with most available headroom (fewest in-flight nonces).
+      let selectedWalletIndex: number | null = null;
       if (eligibleWallets.length > 0) {
         eligibleWallets.sort((a, b) => b.headroom - a.headroom);
         const best = eligibleWallets[0];
@@ -4057,35 +3795,10 @@ export class NonceDO {
       }
 
       if (selectedWalletIndex === null) {
-        // No healthy wallet with capacity was found. Remaining wallets are either:
-        // - At chaining limit (healthy but full)
-        // - Circuit-broken (degraded, may have capacity)
-        // Reject instead of falling back to a degraded wallet — feeding transactions
-        // into a broken pool amplifies contention (see #226).
-        const degradedNotFull = degradedWallets.filter(
-          (d) => this.walletHeadroom(d.walletIndex) > 0
-        );
-        if (degradedNotFull.length > 0) {
-          // The only wallets with capacity are circuit-broken — reject so callers
-          // can distinguish this from pure chaining limit exhaustion.
-          const totalReservedAll = this.poolTotalReserved(effectiveWalletCount);
-          this.log("warn", "all_wallets_degraded_rejecting", {
-            degradedCount: degradedWallets.length,
-            degradedNotFullCount: degradedNotFull.length,
-            totalReserved: totalReservedAll,
-            totalCapacity: effectiveWalletCount * CHAINING_LIMIT,
-          });
-          throw new AllWalletsDegradedError(
-            degradedWallets.length,
-            totalReservedAll,
-            effectiveWalletCount * CHAINING_LIMIT,
-          );
-        } else {
-          throw new ChainingLimitError(totalMempoolDepth);
-        }
+        throw new ChainingLimitError(totalMempoolDepth);
       }
 
-      walletIndex = selectedWalletIndex;
+      const walletIndex = selectedWalletIndex;
 
       // Store the per-wallet sponsor address (used by alarm reconciliation)
       await this.setStoredSponsorAddressForWallet(walletIndex, resolveAddress(walletIndex));
@@ -4165,13 +3878,12 @@ export class NonceDO {
    *
    * txid present   → nonce was broadcast successfully; mark as 'confirmed' in ledger.
    * txid absent    → nonce was NOT broadcast (e.g. broadcast failure). Priority order:
-   *   1. errorReason provided → immediate quarantine ('failed' state) + recordQuarantineEvent.
-   *      Use for contention-specific terminal failures (TooMuchChaining, nonce_conflict).
-   *   2. Prior txid in nonce_txids → quarantine (broadcast happened but release has no txid).
+   *   1. errorReason provided → mark as 'failed' with reason recorded.
+   *   2. Prior txid in nonce_txids → mark as 'failed' (broadcast happened but release has no txid).
    *   3. Neither → mark as 'expired' (truly unused nonce, available for gap-fill).
    * walletIndex    → which wallet the nonce belongs to (default: 0)
    * fee            → when provided with txid (broadcast succeeded), recorded in cumulative wallet stats
-   * errorReason    → triggers quarantine when txid is absent (feeds circuit breaker)
+   * errorReason    → recorded in ledger for diagnostics
    */
   async releaseNonce(nonce: number, txid?: string, walletIndex: number = 0, fee?: string, errorReason?: string): Promise<void> {
     return this.state.blockConcurrencyWhile(async () => {
@@ -4190,14 +3902,8 @@ export class NonceDO {
         return;
       }
 
-      // Track whether this is a failure quarantine (for circuit breaker)
-      let failureQuarantined = false;
-
       if (!txid) {
-        // Caller-supplied error reason (e.g. TooMuchChaining, nonce_conflict from queue-consumer)
-        // takes priority — quarantine immediately so the circuit breaker fires.
         if (errorReason) {
-          failureQuarantined = true;
           this.log("warn", "nonce_quarantined", {
             walletIndex,
             nonce,
@@ -4206,7 +3912,6 @@ export class NonceDO {
           this.ledgerRelease(walletIndex, nonce, undefined, errorReason);
         } else {
           // No explicit error reason: check if a txid was previously recorded in nonce_txids.
-          // If so, the nonce was broadcast at some point — quarantine as failure.
           const txidRows = this.sql
             .exec<{ count: number }>(
               "SELECT COUNT(*) as count FROM nonce_txids WHERE nonce = ?",
@@ -4216,8 +3921,6 @@ export class NonceDO {
           const hasPriorTxid = (txidRows[0]?.count ?? 0) > 0;
 
           if (hasPriorTxid) {
-            // Nonce was broadcast at some point — quarantine permanently
-            failureQuarantined = true;
             this.log("warn", "nonce_quarantined", {
               walletIndex,
               nonce,
@@ -4226,15 +3929,12 @@ export class NonceDO {
             this.ledgerRelease(walletIndex, nonce, undefined, "txid_recorded_on_failed_release");
           } else {
             // Truly unused nonce (never broadcast) — mark expired
-            // The ledger head already advanced past this nonce on assignment,
-            // so this creates a gap that reconciliation will fill if needed.
             this.ledgerRelease(walletIndex, nonce, undefined);
           }
         }
       } else {
         // txid provided: nonce was broadcast successfully — consumed
         if (fee && fee !== "0") {
-          // Broadcast succeeded and fee provided — record in wallet stats
           await this.recordWalletFee(walletIndex, fee);
         }
         this.ledgerRelease(walletIndex, nonce, txid);
@@ -4247,11 +3947,6 @@ export class NonceDO {
         txid: txid ?? null,
         ledgerReserved: this.ledgerReservedCount(walletIndex),
       });
-
-      // Circuit breaker: only record failure quarantines (not normal consumption).
-      if (failureQuarantined) {
-        await this.recordQuarantineEvent(walletIndex);
-      }
 
       await this.refreshSponsorStatusSnapshot();
     });
@@ -4309,80 +4004,42 @@ export class NonceDO {
    */
   async getPoolHealth(): Promise<PoolHealthResponse> {
     const initializedWallets = await this.getInitializedWallets();
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
 
-    // Parallelize KV reads across wallets — avoids N serial awaits as the pool grows
-    const wallets: WalletHealthSnapshot[] = await Promise.all(
-      initializedWallets.map(async ({ walletIndex }) => {
-        const recentQuarantines =
-          (await this.state.storage.get<string[]>(
-            this.walletQuarantineRecentKey(walletIndex)
-          )) ?? [];
-        const activeQuarantines = recentQuarantines.filter(
-          (ts) => new Date(ts).getTime() >= cutoff
-        );
-        const cbOpen = activeQuarantines.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD;
-        const reserved = this.ledgerReservedCount(walletIndex);
-        const available = Math.max(0, CHAINING_LIMIT - reserved);
-        // Queue state for observability (dispatch_queue + replay_buffer)
-        const queueState = this.getDispatchQueueDepth(walletIndex);
-        const replayDepth = this.getReplayBufferDepth(walletIndex);
-        return {
-          walletIndex,
-          circuitBreakerOpen: cbOpen,
-          reserved,
-          available,
-          quarantineCount: activeQuarantines.length,
-          queueDepth: queueState.total,
-          replayBufferDepth: replayDepth,
-          dispatchedCount: queueState.dispatched,
-        };
-      })
-    );
+    const wallets: WalletHealthSnapshot[] = initializedWallets.map(({ walletIndex }) => {
+      const reserved = this.ledgerReservedCount(walletIndex);
+      const available = Math.max(0, CHAINING_LIMIT - reserved);
+      const queueState = this.getDispatchQueueDepth(walletIndex);
+      const replayDepth = this.getReplayBufferDepth(walletIndex);
+      return {
+        walletIndex,
+        circuitBreakerOpen: false,
+        reserved,
+        available,
+        quarantineCount: 0,
+        queueDepth: queueState.total,
+        replayBufferDepth: replayDepth,
+        dispatchedCount: queueState.dispatched,
+      };
+    });
 
     const totalReserved = wallets.reduce((s, w) => s + w.reserved, 0);
-    const degradedCount = wallets.filter((w) => w.circuitBreakerOpen).length;
     const totalCapacity = initializedWallets.length * CHAINING_LIMIT;
-    const allWalletsDegraded =
-      initializedWallets.length > 0 && degradedCount === initializedWallets.length;
 
-    return { allWalletsDegraded, totalReserved, totalCapacity, wallets };
+    return { allWalletsDegraded: false, totalReserved, totalCapacity, wallets };
   }
 
   private async buildSponsorStatusSnapshot(): Promise<StoredSponsorStatusSnapshot> {
     const initializedWallets = await this.getInitializedWallets();
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-    const walletSnapshots = await Promise.all(
-      initializedWallets.map(async ({ walletIndex }) => {
-        const recentQuarantines =
-          (await this.state.storage.get<string[]>(
-            this.walletQuarantineRecentKey(walletIndex)
-          )) ?? [];
-        const activeQuarantines = recentQuarantines.filter(
-          (ts) => new Date(ts).getTime() >= cutoff
-        );
-        const ghostDegraded =
-          (this.getStateValue(this.walletGhostDegradedKey(walletIndex)) ?? 0) === 1;
-        const rawAvailable = this.walletHeadroom(walletIndex);
-        // Ghost-degraded wallets are skipped by assignNonce, so report 0 available
-        const available = ghostDegraded ? 0 : Math.max(0, Math.min(CHAINING_LIMIT, rawAvailable));
-        const reserved = CHAINING_LIMIT - available;
-        return {
-          circuitBreakerOpen:
-            activeQuarantines.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD,
-          ghostDegraded,
-          available,
-          reserved,
-        };
-      })
-    );
+    const walletSnapshots = initializedWallets.map(({ walletIndex }) => {
+      const available = Math.max(0, Math.min(CHAINING_LIMIT, this.walletHeadroom(walletIndex)));
+      const reserved = CHAINING_LIMIT - available;
+      return { available, reserved };
+    });
     const walletCount = walletSnapshots.length;
     const totalAvailable = walletSnapshots.reduce((sum, wallet) => sum + wallet.available, 0);
     const totalReserved = walletSnapshots.reduce((sum, wallet) => sum + wallet.reserved, 0);
     const totalCapacity = walletCount * CHAINING_LIMIT;
-    const allWalletsDegraded =
-      walletCount > 0 &&
-      walletSnapshots.every((wallet) => wallet.circuitBreakerOpen || wallet.ghostDegraded);
+    const allWalletsDegraded = walletCount > 0 && totalAvailable === 0;
     const lastGapDetectedMs = this.getStateValue(STATE_KEYS.lastGapDetected);
     const lastHiroSyncMs = this.getStateValue(STATE_KEYS.lastHiroSync);
     const healInProgress =
@@ -4576,7 +4233,6 @@ export class NonceDO {
    */
   async getObservableNonceState(): Promise<ObservableNonceState> {
     const initializedWallets = await this.getInitializedWallets();
-    const cutoff = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
     const lastGapDetectedMs = this.getStateValue(STATE_KEYS.lastGapDetected);
     const gapsFilled = this.getStoredCount(STATE_KEYS.gapsFilled);
 
@@ -4675,20 +4331,7 @@ export class NonceDO {
           }
         }
 
-        // Circuit breaker state
-        const recentQuarantines =
-          (await this.state.storage.get<string[]>(
-            this.walletQuarantineRecentKey(walletIndex)
-          )) ?? [];
-        const activeQuarantines = recentQuarantines.filter(
-          (ts) => new Date(ts).getTime() >= cutoff
-        );
-        const circuitBreakerOpen =
-          activeQuarantines.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD;
-
         // Use walletHeadroom() — same calculation as the assignment path.
-        // Counts assigned + broadcasted + confirmed (all in-flight states),
-        // not just 'assigned' like ledgerReservedCount().
         const available = this.walletHeadroom(walletIndex);
         const reserved = CHAINING_LIMIT - available;
 
@@ -4699,10 +4342,6 @@ export class NonceDO {
         // Settlement time percentiles for this wallet (last 24h)
         const settlementTimes = this.computeSettlementPercentiles(walletIndex);
 
-        // Ghost degraded state
-        const ghostDegraded = (this.getStateValue(this.walletGhostDegradedKey(walletIndex)) ?? 0) === 1;
-        const ghostFailures = this.getStateValue(this.walletGhostFailuresKey(walletIndex)) ?? 0;
-
         return {
           walletIndex,
           sponsorAddress: address,
@@ -4712,19 +4351,16 @@ export class NonceDO {
           gaps,
           available,
           reserved,
-          circuitBreakerOpen,
-          healthy: gaps.length === 0 && !circuitBreakerOpen && !ghostDegraded && available > 0,
+          circuitBreakerOpen: false,
+          healthy: gaps.length === 0 && available > 0,
           queueDepth: queueState.total,
           replayBufferDepth: replayDepth,
           settlementTimes,
-          ghostDegraded,
-          ghostFailures,
         };
       })
     );
 
     const anyGaps = wallets.some((w) => w.gaps.length > 0);
-    const allDegraded = wallets.length > 0 && wallets.every((w) => w.circuitBreakerOpen);
     const totalAvailable = wallets.reduce((s, w) => s + w.available, 0);
     const totalReserved = wallets.reduce((s, w) => s + w.reserved, 0);
     const totalCapacity = initializedWallets.length * CHAINING_LIMIT;
@@ -4733,11 +4369,9 @@ export class NonceDO {
     const healInProgress = lastGapDetectedMs !== null &&
       Date.now() - lastGapDetectedMs < ALARM_INTERVAL_ACTIVE_MS * 2;
 
-    const healthy = !anyGaps && !allDegraded && totalAvailable > 0;
-    // recommendation is derived here (single source of truth) so endpoints
-    // don't duplicate the fallback decision logic.
+    const healthy = !anyGaps && totalAvailable > 0;
     const recommendation: "fallback_to_direct" | null =
-      !healthy && (anyGaps || allDegraded) ? "fallback_to_direct" : null;
+      !healthy && anyGaps ? "fallback_to_direct" : null;
 
     // Sender hands: active senders with held transactions waiting for nonce gap fill.
     // Capped at 50 senders to bound the response size.
@@ -5305,7 +4939,6 @@ export class NonceDO {
   private async reconcileNonceForWallet(
     walletIndex: number,
     sponsorAddress: string,
-    cascadeActive = false
   ): Promise<ReconcileResult | null> {
     let nonceInfo: HiroNonceInfo;
     try {
@@ -5386,19 +5019,6 @@ export class NonceDO {
       "conflict_recent_skip",
     ]);
 
-    // -------------------------------------------------------------------------
-    // Cascade-aware RBF threshold: when a cross-wallet cascade is active or this
-    // wallet's circuit breaker is open, reduce the stuck-tx age so RBF fires sooner
-    // and the nonce pipeline drains faster without waiting for agent retries.
-    // -------------------------------------------------------------------------
-    const cutoffForCircuitBreaker = Date.now() - CIRCUIT_BREAKER_WINDOW_MS;
-    const recentQuarantinesForWallet =
-      (await this.state.storage.get<string[]>(this.walletQuarantineRecentKey(walletIndex))) ?? [];
-    const activeQuarantinesForWallet = recentQuarantinesForWallet.filter(
-      (ts) => new Date(ts).getTime() >= cutoffForCircuitBreaker
-    );
-    const walletCircuitOpen = activeQuarantinesForWallet.length >= CIRCUIT_BREAKER_QUARANTINE_THRESHOLD;
-    const effectiveStuckTxAge = this.getEffectiveStuckTxAge(cascadeActive, walletCircuitOpen);
 
     // -------------------------------------------------------------------------
     // Cross-reference: broadcasted nonces (have a txid recorded in ledger)
@@ -5424,7 +5044,7 @@ export class NonceDO {
         verdict = "pending_agree";
         reason = "ledger_and_hiro_both_pending";
         verdictPendingAgree++;
-      } else if (missingNonceSet.has(nonce) && ageMs < effectiveStuckTxAge) {
+      } else if (missingNonceSet.has(nonce) && ageMs < STUCK_TX_AGE_MS) {
         // Hiro lost sight of tx we know we sent — tx is young, wait for Hiro to catch up
         verdict = "pending_diverge";
         reason = "hiro_missing_but_tx_young";
@@ -5436,7 +5056,7 @@ export class NonceDO {
           ageMs,
           reason: "hiro_reports_missing_but_we_broadcasted_recently",
         });
-      } else if (missingNonceSet.has(nonce) && ageMs >= effectiveStuckTxAge) {
+      } else if (missingNonceSet.has(nonce) && ageMs >= STUCK_TX_AGE_MS) {
         // Hiro and time both say trouble — RBF candidate (tx status check in RBF section)
         verdict = "rbf_candidate";
         reason = "hiro_missing_and_tx_old";
@@ -5445,7 +5065,7 @@ export class NonceDO {
       } else if (
         !mempoolNonceSet.has(nonce) &&
         (last_executed_tx_nonce === null || nonce > last_executed_tx_nonce) &&
-        ageMs >= effectiveStuckTxAge
+        ageMs >= STUCK_TX_AGE_MS
       ) {
         // Not in mempool AND not confirmed AND old — likely evicted from all mempools
         verdict = "rbf_candidate";
@@ -5830,13 +5450,10 @@ export class NonceDO {
         });
       }
       const privateKey = await this.derivePrivateKeyForWallet(walletIndex);
-      // During a cascade, allow more gap-fills per cycle (15 vs 5) to drain stuck nonces faster.
-      // Gap-fills are cheap (1 uSTX + 30k fee) so the cost increase is negligible.
-      const effectiveMaxGapFills = cascadeActive ? 15 : MAX_GAP_FILLS_PER_ALARM;
       const gapsToFill = gapFillNonces
         .slice()
         .sort((a, b) => a - b)
-        .slice(0, Math.min(effectiveMaxGapFills, gapFillBudget));
+        .slice(0, Math.min(MAX_GAP_FILLS_PER_ALARM, gapFillBudget));
       if (privateKey) {
         for (const gapNonce of gapsToFill) {
           // Fee escalation: conflict retries use GAP_FILL_FEE + prior attempts (+1 uSTX each)
@@ -5855,7 +5472,7 @@ export class NonceDO {
             gapFillFilled.push(gapNonce);
             this.ledgerInsertGapFill(walletIndex, gapNonce, txid);
             await this.recordGapFillFee(walletIndex, actualFee.toString());
-            this.resetGhostState(walletIndex);
+
           }
         }
       }
@@ -5949,14 +5566,7 @@ export class NonceDO {
     // dispatch_queue, flush their sponsor nonce slots with self-transfers,
     // and move sender txs to the replay buffer for re-sponsoring.
     // -------------------------------------------------------------------------
-    const flushResult = await this.runFlushAndReplayCycle(walletIndex, effectiveStuckTxAge);
-
-    // -------------------------------------------------------------------------
-    // Auto-clear ghost_degraded when wallet shows confirmed transactions this cycle.
-    // If nonces are confirming, the wallet is broadcasting successfully — ghost state is stale.
-    if (verdictConfirmed > 0) {
-      this.resetGhostState(walletIndex);
-    }
+    const flushResult = await this.runFlushAndReplayCycle(walletIndex, STUCK_TX_AGE_MS);
 
     // Log reconciliation_summary for this wallet
     // -------------------------------------------------------------------------
@@ -6919,10 +6529,6 @@ export class NonceDO {
 
         const initializedWallets = await this.getInitializedWallets();
 
-        // Read cascade state once per alarm cycle so we don't repeat the KV read
-        // inside every wallet's reconcileNonceForWallet call.
-        const cascadeActive = await this.isCascadeActive();
-
         // ---------------------------------------------------------------------------
         // Bounded reconciliation: process MAX_RECONCILE_WALLETS wallets per tick.
         // Round-robin cursor advances each tick so all wallets reconcile over time.
@@ -6941,7 +6547,7 @@ export class NonceDO {
 
         for (const { walletIndex, address } of reconcileWallets) {
           // reconcileNonceForWallet returns null when Hiro is unreachable — skip silently
-          await this.reconcileNonceForWallet(walletIndex, address, cascadeActive);
+          await this.reconcileNonceForWallet(walletIndex, address);
 
           // Clean up StuckTxState entries for nonces that have been confirmed on-chain.
           const cached = this.hiroNonceCache.get(walletIndex);
@@ -7046,22 +6652,19 @@ export class NonceDO {
 
         await this.refreshSponsorStatusSnapshot();
 
-        // Dynamic alarm interval: use cascade (20s) when cascade is active + in-flight nonces,
-        // active (60s) when in-flight nonces present, idle (5min) when all wallets are drained.
+        // Dynamic alarm interval: active (60s) when in-flight nonces present,
+        // idle (5min) when all wallets are drained.
         const totalReservedAfterCycle = this.ledgerTotalAssigned();
         const probeQueuePending = this.sql
           .exec<{ cnt: number }>("SELECT COUNT(*) as cnt FROM probe_queue WHERE state = 'pending'")
           .toArray()[0]?.cnt ?? 0;
         const isActive = totalReservedAfterCycle > 0 || probeQueuePending > 0;
-        const intervalMs = cascadeActive && isActive
-          ? ALARM_INTERVAL_CASCADE_MS
-          : isActive ? ALARM_INTERVAL_ACTIVE_MS : ALARM_INTERVAL_IDLE_MS;
+        const intervalMs = isActive ? ALARM_INTERVAL_ACTIVE_MS : ALARM_INTERVAL_IDLE_MS;
         this.log("info", "nonce_alarm_scheduled", {
           intervalMs,
           activeWallets: initializedWallets.length,
           totalReserved: totalReservedAfterCycle,
           isActive,
-          cascadeActive,
           walletCursor,
           nextWalletCursor,
           reconcileCount: reconcileWallets.length,
@@ -7305,7 +6908,6 @@ export class NonceDO {
           this.ledgerInsertGapFill(walletIndex, gapNonce, txid);
           this.incrementCounter(STATE_KEYS.gapsFilled);
           await this.recordGapFillFee(walletIndex, escalatedFee.toString());
-          this.resetGhostState(walletIndex);
         } else {
           failed.push({ nonce: gapNonce, reason: "broadcast rejected or already occupied" });
         }
@@ -7505,7 +7107,6 @@ export class NonceDO {
                 this.ledgerInsertGapFill(walletIndex, nonce, gapTxid);
                 this.incrementCounter(STATE_KEYS.gapsFilled);
                 await this.recordGapFillFee(walletIndex, flushFee.toString());
-                this.resetGhostState(walletIndex);
                 filled.push({ nonce, txid: gapTxid, method: "gap_fill" });
               } else {
                 failedNonces.push({ nonce, reason: "rbf and gap-fill both failed or already occupied" });
@@ -7542,7 +7143,6 @@ export class NonceDO {
               this.ledgerInsertGapFill(walletIndex, nonce, txid);
               this.incrementCounter(STATE_KEYS.gapsFilled);
               await this.recordGapFillFee(walletIndex, gapFlushFee.toString());
-              this.resetGhostState(walletIndex);
               filled.push({ nonce, txid, method: "gap_fill" });
             } else {
               // ConflictingNonceInMempool means already occupied — not a hard failure
@@ -7640,18 +7240,6 @@ export class NonceDO {
                 "Retry-After": String(error.retryAfterSeconds),
               },
             }
-          );
-        }
-        if (error instanceof AllWalletsDegradedError) {
-          return this.jsonResponse(
-            {
-              error: "All sponsor wallets are circuit-broken; retry after recovery",
-              code: "ALL_WALLETS_DEGRADED",
-              degradedCount: error.degradedCount,
-              totalReserved: error.totalReserved,
-              totalCapacity: error.totalCapacity,
-            },
-            503
           );
         }
         if (error instanceof ChainingLimitError) {

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -3993,14 +3993,12 @@ export class NonceDO {
   }
 
   /**
-   * Lightweight pool health check — returns per-wallet circuit breaker state
-   * and aggregate availability so callers can perform pre-flight gating
-   * before attempting nonce assignment and avoid sending traffic into
-   * known-degraded pools. Exposed via GET /pool-health for observability
-   * and the /health endpoint.
+   * Lightweight pool health check — returns per-wallet availability and
+   * aggregate capacity so callers can perform pre-flight gating before
+   * attempting nonce assignment. Exposed via GET /pool-health and /health.
    *
-   * Much cheaper than getStats() — only reads quarantine lists and reserved counts,
-   * no heavy SQL joins or utilization queries.
+   * Much cheaper than getStats() — only reads reserved counts from the
+   * ledger, no heavy SQL joins or utilization queries.
    */
   async getPoolHealth(): Promise<PoolHealthResponse> {
     const initializedWallets = await this.getInitializedWallets();
@@ -4012,6 +4010,7 @@ export class NonceDO {
       const replayDepth = this.getReplayBufferDepth(walletIndex);
       return {
         walletIndex,
+        // circuit breaker removed; always false for API compatibility
         circuitBreakerOpen: false,
         reserved,
         available,
@@ -4024,8 +4023,10 @@ export class NonceDO {
 
     const totalReserved = wallets.reduce((s, w) => s + w.reserved, 0);
     const totalCapacity = initializedWallets.length * CHAINING_LIMIT;
+    const allWalletsDegraded = initializedWallets.length > 0 &&
+      wallets.every((w) => w.available === 0);
 
-    return { allWalletsDegraded: false, totalReserved, totalCapacity, wallets };
+    return { allWalletsDegraded, totalReserved, totalCapacity, wallets };
   }
 
   private async buildSponsorStatusSnapshot(): Promise<StoredSponsorStatusSnapshot> {
@@ -5472,7 +5473,6 @@ export class NonceDO {
             gapFillFilled.push(gapNonce);
             this.ledgerInsertGapFill(walletIndex, gapNonce, txid);
             await this.recordGapFillFee(walletIndex, actualFee.toString());
-
           }
         }
       }
@@ -5865,6 +5865,34 @@ export class NonceDO {
         error: e instanceof Error ? e.message : String(e),
       });
     }
+  }
+
+  /**
+   * One-shot cleanup: delete orphaned KV keys from removed degradation state machines
+   * (circuit breaker, ghost degraded, cascade detection). These keys are no longer
+   * read but accumulate in DO storage. Runs once; sets a flag to skip on subsequent cycles.
+   */
+  private async cleanupLegacyDegradationKeys(): Promise<void> {
+    const flagKey = "legacy_degradation_keys_cleaned";
+    if (await this.state.storage.get<boolean>(flagKey)) return;
+
+    const keysToDelete: string[] = ["cascade_quarantine_window"];
+    for (let i = 0; i < MAX_WALLET_COUNT; i++) {
+      keysToDelete.push(
+        `wallet_quarantine_recent:${i}`,
+      );
+    }
+    // nonce_state SQL keys for ghost counters
+    for (let i = 0; i < MAX_WALLET_COUNT; i++) {
+      this.setStateValue(`wallet_ghost_failures:${i}`, 0);
+      this.setStateValue(`wallet_ghost_degraded:${i}`, 0);
+    }
+    await this.state.storage.delete(keysToDelete);
+    await this.state.storage.put(flagKey, true);
+    this.log("info", "legacy_degradation_keys_cleaned", {
+      deletedKvKeys: keysToDelete.length,
+      clearedNonceStateKeys: MAX_WALLET_COUNT * 2,
+    });
   }
 
   /**
@@ -6502,8 +6530,9 @@ export class NonceDO {
   async alarm(): Promise<void> {
     await this.state.blockConcurrencyWhile(async () => {
       try {
-        // --- Gin rummy preamble: migration, replay recycling, seed upgrades ---
+        // --- Preamble: migration, cleanup, replay recycling, seed upgrades ---
         this.runGinRummyMigration();
+        await this.cleanupLegacyDegradationKeys();
         this.recycleReplayBuffer();
         await this.retrySeedFirstTxSenders();
 

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -776,6 +776,40 @@ export class NonceDO {
       );
     }
 
+    // Migration: add submitted_at column to dispatch_queue.
+    // ISO timestamp of when the client HTTP request first arrived at the relay endpoint.
+    // NULL for gap-fill entries, replay re-dispatches, and pre-migration rows.
+    try {
+      const cols = this.sql
+        .exec<{ name: string }>("SELECT name FROM pragma_table_info('dispatch_queue') WHERE name = 'submitted_at'")
+        .toArray();
+      if (cols.length === 0) {
+        this.sql.exec("ALTER TABLE dispatch_queue ADD COLUMN submitted_at TEXT");
+      }
+    } catch (err) {
+      console.warn(
+        "[nonce-do] Failed to ensure dispatch_queue.submitted_at column exists; continuing without migration:",
+        err
+      );
+    }
+
+    // Migration: add is_gap_fill column to dispatch_queue.
+    // 1 for gap-fill/flush/replay-respon system txs, 0 for user-submitted txs.
+    // These entries are excluded from settlement time percentiles.
+    try {
+      const cols = this.sql
+        .exec<{ name: string }>("SELECT name FROM pragma_table_info('dispatch_queue') WHERE name = 'is_gap_fill'")
+        .toArray();
+      if (cols.length === 0) {
+        this.sql.exec("ALTER TABLE dispatch_queue ADD COLUMN is_gap_fill INTEGER DEFAULT 0");
+      }
+    } catch (err) {
+      console.warn(
+        "[nonce-do] Failed to ensure dispatch_queue.is_gap_fill column exists; continuing without migration:",
+        err
+      );
+    }
+
     // Migration: add gap_fill_attempts column to nonce_intents (nullable INTEGER, default 0).
     // Tracks how many gap-fill broadcasts have been attempted for a conflict nonce,
     // used to escalate the fee by +1 uSTX per attempt (30000, 30001, 30002, ...).
@@ -945,7 +979,9 @@ export class NonceDO {
     senderAddress: string,
     senderNonce: number,
     sponsorNonce: number,
-    fee: string | null = null
+    fee: string | null = null,
+    submittedAt: string | null = null,
+    isGapFill: boolean = false
   ): void {
     const now = new Date().toISOString();
     // Compute position as next slot (max position + 1) for ordering within the wallet queue
@@ -960,8 +996,9 @@ export class NonceDO {
     this.sql.exec(
       `INSERT OR REPLACE INTO dispatch_queue
          (wallet_index, position, sender_tx_hex, sender_address, sender_nonce,
-          sponsor_nonce, original_fee, state, queued_at, dispatched_at, confirmed_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, 'dispatched', ?, ?, NULL)`,
+          sponsor_nonce, original_fee, state, queued_at, dispatched_at, confirmed_at,
+          submitted_at, is_gap_fill)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'dispatched', ?, ?, NULL, ?, ?)`,
       walletIndex,
       position,
       senderTxHex,
@@ -970,7 +1007,9 @@ export class NonceDO {
       sponsorNonce,
       fee,
       now,
-      now
+      now,
+      submittedAt,
+      isGapFill ? 1 : 0
     );
   }
 
@@ -1049,6 +1088,7 @@ export class NonceDO {
         .exec<{ settlement_ms: number }>(
           `SELECT settlement_ms FROM dispatch_queue
            WHERE state = 'confirmed' AND settlement_ms IS NOT NULL
+             AND (is_gap_fill IS NULL OR is_gap_fill = 0)
              AND wallet_index = ? AND confirmed_at >= ?
            ORDER BY settlement_ms ASC`,
           walletIndex,
@@ -1060,6 +1100,7 @@ export class NonceDO {
         .exec<{ settlement_ms: number }>(
           `SELECT settlement_ms FROM dispatch_queue
            WHERE state = 'confirmed' AND settlement_ms IS NOT NULL
+             AND (is_gap_fill IS NULL OR is_gap_fill = 0)
              AND confirmed_at >= ?
            ORDER BY settlement_ms ASC`,
           cutoff
@@ -1092,19 +1133,22 @@ export class NonceDO {
     const now = new Date().toISOString();
 
     if (newState === "confirmed") {
-      // On confirmation: set confirmed_at and compute settlement_ms from dispatched_at.
-      // Also read original_fee and sender_address for the settlement_confirmed log event.
+      // On confirmation: set confirmed_at and compute settlement_ms.
+      // Use submitted_at (client HTTP request arrival) as the start time when available,
+      // falling back to dispatched_at for pre-migration entries. This ensures settlement
+      // percentiles reflect actual user-perceived latency rather than internal queue timing.
       const preRow = this.sql
-        .exec<{ dispatched_at: string | null; original_fee: string | null; sender_address: string | null }>(
-          "SELECT dispatched_at, original_fee, sender_address FROM dispatch_queue WHERE wallet_index = ? AND sponsor_nonce = ? LIMIT 1",
+        .exec<{ dispatched_at: string | null; submitted_at: string | null; original_fee: string | null; sender_address: string | null }>(
+          "SELECT dispatched_at, submitted_at, original_fee, sender_address FROM dispatch_queue WHERE wallet_index = ? AND sponsor_nonce = ? LIMIT 1",
           walletIndex,
           sponsorNonce
         )
         .toArray()[0];
 
       let settlementMs: number | null = null;
-      if (preRow?.dispatched_at) {
-        settlementMs = Math.max(0, Date.now() - new Date(preRow.dispatched_at).getTime());
+      const startTime = preRow?.submitted_at ?? preRow?.dispatched_at;
+      if (startTime) {
+        settlementMs = Math.max(0, Date.now() - new Date(startTime).getTime());
       }
 
       this.sql.exec(
@@ -4858,14 +4902,19 @@ export class NonceDO {
           // Broadcast the re-sponsored tx
           const result = await this.broadcastRawTx(reSponsoredTx, "replay_respon");
           if (result.ok) {
-            // Record in dispatch queue (fee=GAP_FILL_FEE used for replayed txs)
+            // Record in dispatch queue (fee=GAP_FILL_FEE used for replayed txs).
+            // Replay re-dispatches are tagged as is_gap_fill=1 so they are excluded from
+            // settlement time percentiles — the original submitted_at is in the retired entry
+            // and cannot be accurately carried forward here.
             this.queueDispatch(
               targetWallet.walletIndex,
               entry.sender_tx_hex,
               entry.sender_address,
               entry.sender_nonce,
               freshNonce,
-              GAP_FILL_FEE.toString()
+              GAP_FILL_FEE.toString(),
+              null,  // submitted_at: not available after replay
+              true   // is_gap_fill: exclude from settlement percentiles
             );
             // Transition to dispatched
             this.transitionQueueEntry(targetWallet.walletIndex, freshNonce, "dispatched");
@@ -7427,6 +7476,7 @@ export class NonceDO {
           senderNonce: number;
           sponsorNonce: number;
           fee?: string | null;
+          submittedAt?: string | null;
         }>(request);
       if (errorResponse) return errorResponse;
       if (
@@ -7444,7 +7494,8 @@ export class NonceDO {
           body.senderAddress,
           body.senderNonce ?? 0,
           body.sponsorNonce,
-          typeof body.fee === "string" ? body.fee : null
+          typeof body.fee === "string" ? body.fee : null,
+          typeof body.submittedAt === "string" ? body.submittedAt : null
         );
         return this.jsonResponse({ success: true });
       } catch (error) {

--- a/src/durable-objects/stats-do.ts
+++ b/src/durable-objects/stats-do.ts
@@ -480,116 +480,137 @@ export class StatsDO {
 
   private readDailyStats(days: number): DailyStats[] {
     const now = Date.now();
-    const result: DailyStats[] = [];
 
+    // Generate the ordered list of date keys we need
+    const dateKeys: string[] = [];
     for (let i = days - 1; i >= 0; i--) {
-      const date = getDateKey(now - i * DAY_MS);
-      const rows = this.sql
-        .exec<{
-          total: number;
-          success: number;
-          failed: number;
-          client_errors: number;
-          stx_count: number;
-          stx_volume: string;
-          sbtc_count: number;
-          sbtc_volume: string;
-          usdcx_count: number;
-          usdcx_volume: string;
-          fee_total: string;
-          fee_count: number;
-          fee_min: string | null;
-          fee_max: string | null;
-          err_validation: number;
-          err_rate_limit: number;
-          err_sponsoring: number;
-          err_settlement: number;
-          err_internal: number;
-          err_schema_validation: number;
-          err_sender: number;
-          err_relay: number;
-          err_settlement_schema: number;
-          err_replacement: number;
-          err_identity: number;
-        }>(
-          `SELECT total, success, failed, client_errors,
-                  stx_count, stx_volume,
-                  sbtc_count, sbtc_volume,
-                  usdcx_count, usdcx_volume,
-                  fee_total, fee_count, fee_min, fee_max,
-                  err_validation, err_rate_limit, err_sponsoring, err_settlement, err_internal,
-                  err_schema_validation, err_sender, err_relay, err_settlement_schema, err_replacement, err_identity
-           FROM daily_stats WHERE date = ? LIMIT 1`,
-          date
-        )
-        .toArray();
+      dateKeys.push(getDateKey(now - i * DAY_MS));
+    }
 
-      if (rows.length === 0) {
-        result.push({
-          date,
-          transactions: { total: 0, success: 0, failed: 0, clientErrors: 0 },
-          tokens: {
-            STX: { count: 0, volume: "0" },
-            sBTC: { count: 0, volume: "0" },
-            USDCx: { count: 0, volume: "0" },
-          },
-          errors: {
-            validation: 0,
-            rateLimit: 0,
-            sponsoring: 0,
-            settlement: 0,
-            internal: 0,
-          },
-          terminalReasons: {
-            validation: 0,
-            sender: 0,
-            relay: 0,
-            settlement: 0,
-            replacement: 0,
-            identity: 0,
-          },
-        });
-      } else {
-        const r = rows[0];
-        const ds: DailyStats = {
-          date,
-          transactions: {
-            total: r.total,
-            success: r.success,
-            failed: r.failed,
-            clientErrors: r.client_errors ?? 0,
-          },
-          tokens: {
-            STX: { count: r.stx_count, volume: r.stx_volume || "0" },
-            sBTC: { count: r.sbtc_count, volume: r.sbtc_volume || "0" },
-            USDCx: { count: r.usdcx_count, volume: r.usdcx_volume || "0" },
-          },
-          errors: {
-            validation: r.err_validation,
-            rateLimit: r.err_rate_limit,
-            sponsoring: r.err_sponsoring,
-            settlement: r.err_settlement,
-            internal: r.err_internal,
-          },
-          terminalReasons: {
-            validation: r.err_schema_validation ?? 0,
-            sender: r.err_sender ?? 0,
-            relay: r.err_relay ?? 0,
-            settlement: r.err_settlement_schema ?? 0,
-            replacement: r.err_replacement ?? 0,
-            identity: r.err_identity ?? 0,
-          },
-        };
-        if (r.fee_count > 0) {
-          ds.fees = {
-            total: r.fee_total || "0",
-            count: r.fee_count,
-            min: r.fee_min || "0",
-            max: r.fee_max || "0",
-          };
-        }
-        result.push(ds);
+    const startDate = dateKeys[0];
+
+    // Single range query instead of N individual queries
+    type DailyRow = {
+      date: string;
+      total: number;
+      success: number;
+      failed: number;
+      client_errors: number;
+      stx_count: number;
+      stx_volume: string;
+      sbtc_count: number;
+      sbtc_volume: string;
+      usdcx_count: number;
+      usdcx_volume: string;
+      fee_total: string;
+      fee_count: number;
+      fee_min: string | null;
+      fee_max: string | null;
+      err_validation: number;
+      err_rate_limit: number;
+      err_sponsoring: number;
+      err_settlement: number;
+      err_internal: number;
+      err_schema_validation: number;
+      err_sender: number;
+      err_relay: number;
+      err_settlement_schema: number;
+      err_replacement: number;
+      err_identity: number;
+    };
+
+    const rows = this.sql
+      .exec<DailyRow>(
+        `SELECT date, total, success, failed, client_errors,
+                stx_count, stx_volume,
+                sbtc_count, sbtc_volume,
+                usdcx_count, usdcx_volume,
+                fee_total, fee_count, fee_min, fee_max,
+                err_validation, err_rate_limit, err_sponsoring, err_settlement, err_internal,
+                err_schema_validation, err_sender, err_relay, err_settlement_schema, err_replacement, err_identity
+         FROM daily_stats WHERE date >= ? ORDER BY date ASC`,
+        startDate
+      )
+      .toArray();
+
+    // Index results by date for O(1) lookup
+    const rowMap = new Map<string, DailyRow>();
+    for (const r of rows) {
+      rowMap.set(r.date, r);
+    }
+
+    const zeroDailyStats = (date: string): DailyStats => ({
+      date,
+      transactions: { total: 0, success: 0, failed: 0, clientErrors: 0 },
+      tokens: {
+        STX: { count: 0, volume: "0" },
+        sBTC: { count: 0, volume: "0" },
+        USDCx: { count: 0, volume: "0" },
+      },
+      errors: {
+        validation: 0,
+        rateLimit: 0,
+        sponsoring: 0,
+        settlement: 0,
+        internal: 0,
+      },
+      terminalReasons: {
+        validation: 0,
+        sender: 0,
+        relay: 0,
+        settlement: 0,
+        replacement: 0,
+        identity: 0,
+      },
+    });
+
+    // Build result array, filling missing dates with zeros
+    const result: DailyStats[] = [];
+    for (const date of dateKeys) {
+      const r = rowMap.get(date);
+      if (!r) {
+        result.push(zeroDailyStats(date));
+        continue;
       }
+
+      const ds: DailyStats = {
+        date,
+        transactions: {
+          total: r.total,
+          success: r.success,
+          failed: r.failed,
+          clientErrors: r.client_errors ?? 0,
+        },
+        tokens: {
+          STX: { count: r.stx_count, volume: r.stx_volume || "0" },
+          sBTC: { count: r.sbtc_count, volume: r.sbtc_volume || "0" },
+          USDCx: { count: r.usdcx_count, volume: r.usdcx_volume || "0" },
+        },
+        errors: {
+          validation: r.err_validation,
+          rateLimit: r.err_rate_limit,
+          sponsoring: r.err_sponsoring,
+          settlement: r.err_settlement,
+          internal: r.err_internal,
+        },
+        terminalReasons: {
+          validation: r.err_schema_validation ?? 0,
+          sender: r.err_sender ?? 0,
+          relay: r.err_relay ?? 0,
+          settlement: r.err_settlement_schema ?? 0,
+          replacement: r.err_replacement ?? 0,
+          identity: r.err_identity ?? 0,
+        },
+      };
+      if (r.fee_count > 0) {
+        ds.fees = {
+          total: r.fee_total || "0",
+          count: r.fee_count,
+          min: r.fee_min || "0",
+          max: r.fee_max || "0",
+        };
+      }
+      result.push(ds);
     }
 
     return result;
@@ -597,44 +618,67 @@ export class StatsDO {
 
   private readHourlyData(): Array<{ hour: string; transactions: number; success: number; fees?: string; feeMin?: string; feeMax?: string; clientErrors?: number }> {
     const now = Date.now();
-    const result: Array<{ hour: string; transactions: number; success: number; fees?: string; feeMin?: string; feeMax?: string; clientErrors?: number }> = [];
 
+    // Generate the 24 hour keys and their display labels
+    const hourEntries: Array<{ key: string; label: string }> = [];
     for (let i = 23; i >= 0; i--) {
       const ts = now - i * HOUR_MS;
       const d = new Date(ts);
-      const hourLabel = d.getUTCHours().toString().padStart(2, "0") + ":00";
-      const key = getHourKey(ts);
+      hourEntries.push({
+        key: getHourKey(ts),
+        label: d.getUTCHours().toString().padStart(2, "0") + ":00",
+      });
+    }
 
-      const rows = this.sql
-        .exec<{ total: number; success: number; fee_total: string; fee_min: string | null; fee_max: string | null; client_errors: number }>(
-          `SELECT total, success, fee_total, fee_min, fee_max, client_errors FROM hourly_stats WHERE hour = ? LIMIT 1`,
-          key
-        )
-        .toArray();
+    const startKey = hourEntries[0].key;
+    const endKey = hourEntries[hourEntries.length - 1].key;
 
-      if (rows.length === 0) {
-        result.push({ hour: hourLabel, transactions: 0, success: 0 });
-      } else {
-        const r = rows[0];
-        const entry: { hour: string; transactions: number; success: number; fees?: string; feeMin?: string; feeMax?: string; clientErrors?: number } = {
-          hour: hourLabel,
-          transactions: r.total,
-          success: r.success,
-        };
-        if (r.fee_total && r.fee_total !== "0") {
-          entry.fees = r.fee_total;
-        }
-        if (r.fee_min) {
-          entry.feeMin = r.fee_min;
-        }
-        if (r.fee_max) {
-          entry.feeMax = r.fee_max;
-        }
-        if (r.client_errors > 0) {
-          entry.clientErrors = r.client_errors;
-        }
-        result.push(entry);
+    // Single range query instead of 24 individual queries
+    type HourlyRow = { hour: string; total: number; success: number; fee_total: string; fee_min: string | null; fee_max: string | null; client_errors: number };
+    const rows = this.sql
+      .exec<HourlyRow>(
+        `SELECT hour, total, success, fee_total, fee_min, fee_max, client_errors
+         FROM hourly_stats
+         WHERE hour >= ? AND hour <= ?
+         ORDER BY hour ASC`,
+        startKey,
+        endKey
+      )
+      .toArray();
+
+    // Index results by hour key for O(1) lookup
+    const rowMap = new Map<string, HourlyRow>();
+    for (const r of rows) {
+      rowMap.set(r.hour, r);
+    }
+
+    // Build result array, filling missing hours with zeros
+    const result: Array<{ hour: string; transactions: number; success: number; fees?: string; feeMin?: string; feeMax?: string; clientErrors?: number }> = [];
+    for (const { key, label } of hourEntries) {
+      const r = rowMap.get(key);
+      if (!r) {
+        result.push({ hour: label, transactions: 0, success: 0 });
+        continue;
       }
+
+      const entry: { hour: string; transactions: number; success: number; fees?: string; feeMin?: string; feeMax?: string; clientErrors?: number } = {
+        hour: label,
+        transactions: r.total,
+        success: r.success,
+      };
+      if (r.fee_total && r.fee_total !== "0") {
+        entry.fees = r.fee_total;
+      }
+      if (r.fee_min) {
+        entry.feeMin = r.fee_min;
+      }
+      if (r.fee_max) {
+        entry.feeMax = r.fee_max;
+      }
+      if (r.client_errors > 0) {
+        entry.clientErrors = r.client_errors;
+      }
+      result.push(entry);
     }
 
     return result;
@@ -645,29 +689,50 @@ export class StatsDO {
     hours: number
   ): Array<{ hour: string; total: number; success: number; failed: number; feeTotal: string }> {
     const now = Date.now();
-    const result: Array<{ hour: string; total: number; success: number; failed: number; feeTotal: string }> = [];
 
+    // Generate the hour keys and their display labels
+    const hourEntries: Array<{ key: string; label: string }> = [];
     for (let i = hours - 1; i >= 0; i--) {
       const ts = now - i * HOUR_MS;
       const d = new Date(ts);
-      const hourLabel = d.getUTCHours().toString().padStart(2, "0") + ":00";
-      const key = getHourKey(ts);
+      hourEntries.push({
+        key: getHourKey(ts),
+        label: d.getUTCHours().toString().padStart(2, "0") + ":00",
+      });
+    }
 
-      const rows = this.sql
-        .exec<{ total: number; success: number; failed: number; fee_total: string }>(
-          `SELECT total, success, failed, fee_total FROM wallet_hourly
-           WHERE wallet_index = ? AND hour = ? LIMIT 1`,
-          walletIndex,
-          key
-        )
-        .toArray();
+    const startKey = hourEntries[0].key;
+    const endKey = hourEntries[hourEntries.length - 1].key;
 
-      if (rows.length === 0) {
-        result.push({ hour: hourLabel, total: 0, success: 0, failed: 0, feeTotal: "0" });
+    // Single range query instead of N individual queries per wallet
+    type WalletHourlyRow = { hour: string; total: number; success: number; failed: number; fee_total: string };
+    const rows = this.sql
+      .exec<WalletHourlyRow>(
+        `SELECT hour, total, success, failed, fee_total
+         FROM wallet_hourly
+         WHERE wallet_index = ? AND hour >= ? AND hour <= ?
+         ORDER BY hour ASC`,
+        walletIndex,
+        startKey,
+        endKey
+      )
+      .toArray();
+
+    // Index results by hour key for O(1) lookup
+    const rowMap = new Map<string, WalletHourlyRow>();
+    for (const r of rows) {
+      rowMap.set(r.hour, r);
+    }
+
+    // Build result array, filling missing hours with zeros
+    const result: Array<{ hour: string; total: number; success: number; failed: number; feeTotal: string }> = [];
+    for (const { key, label } of hourEntries) {
+      const r = rowMap.get(key);
+      if (!r) {
+        result.push({ hour: label, total: 0, success: 0, failed: 0, feeTotal: "0" });
       } else {
-        const r = rows[0];
         result.push({
-          hour: hourLabel,
+          hour: label,
           total: r.total,
           success: r.success,
           failed: r.failed,
@@ -736,61 +801,118 @@ export class StatsDO {
   /**
    * Compute rolling totals for the previous 24h window (24-48h ago).
    * Used for rolling-vs-rolling trend comparison instead of calendar day.
+   *
+   * Single aggregate query instead of 24 individual queries.
    */
   private readPrevious24hTotals(): { total: number; success: number; clientErrors: number } {
     const now = Date.now();
-    let total = 0;
-    let success = 0;
-    let clientErrors = 0;
+    const startKey = getHourKey(now - 47 * HOUR_MS);
+    const endKey = getHourKey(now - 24 * HOUR_MS);
 
-    // Iterate hourly buckets from 48h ago to 25h ago (inclusive) — that's 24 buckets
-    for (let i = 47; i >= 24; i--) {
-      const ts = now - i * HOUR_MS;
-      const key = getHourKey(ts);
-      const rows = this.sql
-        .exec<{ total: number; success: number; client_errors: number }>(
-          `SELECT total, success, client_errors FROM hourly_stats WHERE hour = ? LIMIT 1`,
-          key
-        )
-        .toArray();
-      if (rows.length > 0) {
-        total += rows[0].total;
-        success += rows[0].success;
-        clientErrors += rows[0].client_errors ?? 0;
-      }
+    const rows = this.sql
+      .exec<{ total: number; success: number; client_errors: number }>(
+        `SELECT COALESCE(SUM(total), 0) as total,
+                COALESCE(SUM(success), 0) as success,
+                COALESCE(SUM(client_errors), 0) as client_errors
+         FROM hourly_stats
+         WHERE hour >= ? AND hour <= ?`,
+        startKey,
+        endKey
+      )
+      .toArray();
+
+    if (rows.length === 0) {
+      return { total: 0, success: 0, clientErrors: 0 };
     }
 
-    return { total, success, clientErrors };
+    const r = rows[0];
+    return {
+      total: r.total,
+      success: r.success,
+      clientErrors: r.client_errors ?? 0,
+    };
   }
 
   /**
    * Build per-wallet 24h throughput entries from wallet_hourly data.
    * Only includes wallets with at least one transaction in the last 24h.
+   *
+   * Uses a single query to fetch all wallet+hour rows in the 24h window,
+   * then groups by wallet and fills missing hours in code.
    */
   private readWalletThroughput(): WalletThroughputEntry[] {
     const now = Date.now();
-    const cutoffTs = now - 24 * HOUR_MS;
-    const cutoffKey = getHourKey(cutoffTs);
 
-    // Find all distinct wallet indices with activity in the last 24h
-    const walletRows = this.sql
-      .exec<{ wallet_index: number }>(
-        `SELECT DISTINCT wallet_index FROM wallet_hourly WHERE hour >= ? ORDER BY wallet_index ASC`,
-        cutoffKey
+    // Generate the 24 hour keys and labels (same logic as readWalletHourlyStats)
+    const hourEntries: Array<{ key: string; label: string }> = [];
+    for (let i = 23; i >= 0; i--) {
+      const ts = now - i * HOUR_MS;
+      const d = new Date(ts);
+      hourEntries.push({
+        key: getHourKey(ts),
+        label: d.getUTCHours().toString().padStart(2, "0") + ":00",
+      });
+    }
+
+    const startKey = hourEntries[0].key;
+    const endKey = hourEntries[hourEntries.length - 1].key;
+
+    // Single query for ALL wallets across the 24h window
+    type BulkRow = { wallet_index: number; hour: string; total: number; success: number; failed: number; fee_total: string };
+    const rows = this.sql
+      .exec<BulkRow>(
+        `SELECT wallet_index, hour, total, success, failed, fee_total
+         FROM wallet_hourly
+         WHERE hour >= ? AND hour <= ?
+         ORDER BY wallet_index ASC, hour ASC`,
+        startKey,
+        endKey
       )
       .toArray();
 
-    const result: WalletThroughputEntry[] = [];
-    for (const { wallet_index } of walletRows) {
-      const hourly = this.readWalletHourlyStats(wallet_index, 24);
-      const total24h = hourly.reduce((s, h) => s + h.total, 0);
-      const success24h = hourly.reduce((s, h) => s + h.success, 0);
-      const failed24h = hourly.reduce((s, h) => s + h.failed, 0);
-      const feeTotal24h = hourly
-        .reduce((s, h) => s + BigInt(h.feeTotal || "0"), 0n)
-        .toString();
-      result.push({ walletIndex: wallet_index, total24h, success24h, failed24h, feeTotal24h, hourly });
+    // Group rows by wallet_index
+    const walletMap = new Map<number, Map<string, BulkRow>>();
+    for (const r of rows) {
+      let hourMap = walletMap.get(r.wallet_index);
+      if (!hourMap) {
+        hourMap = new Map();
+        walletMap.set(r.wallet_index, hourMap);
+      }
+      hourMap.set(r.hour, r);
     }
+
+    // Build result for each wallet, filling missing hours with zeros
+    const result: WalletThroughputEntry[] = [];
+    for (const [walletIndex, hourMap] of walletMap) {
+      const hourly: Array<{ hour: string; total: number; success: number; failed: number; feeTotal: string }> = [];
+      let total24h = 0;
+      let success24h = 0;
+      let failed24h = 0;
+      let feeTotal24h = 0n;
+
+      for (const { key, label } of hourEntries) {
+        const r = hourMap.get(key);
+        if (!r) {
+          hourly.push({ hour: label, total: 0, success: 0, failed: 0, feeTotal: "0" });
+        } else {
+          const feeStr = r.fee_total || "0";
+          hourly.push({
+            hour: label,
+            total: r.total,
+            success: r.success,
+            failed: r.failed,
+            feeTotal: feeStr,
+          });
+          total24h += r.total;
+          success24h += r.success;
+          failed24h += r.failed;
+          feeTotal24h += BigInt(feeStr);
+        }
+      }
+
+      result.push({ walletIndex, total24h, success24h, failed24h, feeTotal24h: feeTotal24h.toString(), hourly });
+    }
+
     return result;
   }
 

--- a/src/durable-objects/stats-do.ts
+++ b/src/durable-objects/stats-do.ts
@@ -6,6 +6,7 @@ import type {
   DashboardOverview,
   EndpointBreakdown,
   TransactionLogEntry,
+  WalletThroughputEntry,
 } from "../types";
 import { calculateTrend } from "../services/stats";
 import { TERMINAL_REASON_TO_CATEGORY } from "@aibtc/tx-schemas/core/terminal-reasons";
@@ -122,6 +123,19 @@ export class StatsDO {
         sbtc_count INTEGER DEFAULT 0,
         usdcx_count INTEGER DEFAULT 0,
         fee_total TEXT DEFAULT '0'
+      );
+    `);
+
+    // Per-wallet hourly aggregate (rolling 48h) — tracks throughput per sponsor wallet
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS wallet_hourly (
+        wallet_index INTEGER NOT NULL,
+        hour TEXT NOT NULL,
+        total INTEGER DEFAULT 0,
+        success INTEGER DEFAULT 0,
+        failed INTEGER DEFAULT 0,
+        fee_total TEXT DEFAULT '0',
+        PRIMARY KEY(wallet_index, hour)
       );
     `);
 
@@ -413,6 +427,27 @@ export class StatsDO {
     const hourCutoff = new Date(now - 48 * HOUR_MS);
     const hourCutoffStr = `${hourCutoff.toISOString().split("T")[0]}:${hourCutoff.getUTCHours().toString().padStart(2, "0")}`;
     this.sql.exec("DELETE FROM hourly_stats WHERE hour < ?", hourCutoffStr);
+
+    // Atomic per-wallet hourly upsert (only when walletIndex is provided)
+    if (entry.walletIndex !== undefined) {
+      const walletFee = fee || "0";
+      this.sql.exec(
+        `INSERT INTO wallet_hourly (wallet_index, hour, total, success, failed, fee_total)
+         VALUES (?, ?, 1, ?, ?, ?)
+         ON CONFLICT(wallet_index, hour) DO UPDATE SET
+           total = total + 1,
+           success = success + excluded.success,
+           failed = failed + excluded.failed,
+           fee_total = CAST(CAST(fee_total AS INTEGER) + CAST(excluded.fee_total AS INTEGER) AS TEXT)`,
+        entry.walletIndex,
+        hourKey,
+        successInt,
+        failedInt,
+        walletFee
+      );
+      // Prune wallet_hourly older than 48h (same cutoff as hourly_stats)
+      this.sql.exec("DELETE FROM wallet_hourly WHERE hour < ?", hourCutoffStr);
+    }
   }
 
   private recordErrorCategory(category: ErrorCategory): void {
@@ -605,6 +640,45 @@ export class StatsDO {
     return result;
   }
 
+  private readWalletHourlyStats(
+    walletIndex: number,
+    hours: number
+  ): Array<{ hour: string; total: number; success: number; failed: number; feeTotal: string }> {
+    const now = Date.now();
+    const result: Array<{ hour: string; total: number; success: number; failed: number; feeTotal: string }> = [];
+
+    for (let i = hours - 1; i >= 0; i--) {
+      const ts = now - i * HOUR_MS;
+      const d = new Date(ts);
+      const hourLabel = d.getUTCHours().toString().padStart(2, "0") + ":00";
+      const key = getHourKey(ts);
+
+      const rows = this.sql
+        .exec<{ total: number; success: number; failed: number; fee_total: string }>(
+          `SELECT total, success, failed, fee_total FROM wallet_hourly
+           WHERE wallet_index = ? AND hour = ? LIMIT 1`,
+          walletIndex,
+          key
+        )
+        .toArray();
+
+      if (rows.length === 0) {
+        result.push({ hour: hourLabel, total: 0, success: 0, failed: 0, feeTotal: "0" });
+      } else {
+        const r = rows[0];
+        result.push({
+          hour: hourLabel,
+          total: r.total,
+          success: r.success,
+          failed: r.failed,
+          feeTotal: r.fee_total || "0",
+        });
+      }
+    }
+
+    return result;
+  }
+
   private readRecentTxLog(opts: {
     days?: number;
     limit?: number;
@@ -659,12 +733,71 @@ export class StatsDO {
     });
   }
 
+  /**
+   * Compute rolling totals for the previous 24h window (24-48h ago).
+   * Used for rolling-vs-rolling trend comparison instead of calendar day.
+   */
+  private readPrevious24hTotals(): { total: number; success: number; clientErrors: number } {
+    const now = Date.now();
+    let total = 0;
+    let success = 0;
+    let clientErrors = 0;
+
+    // Iterate hourly buckets from 48h ago to 25h ago (inclusive) — that's 24 buckets
+    for (let i = 47; i >= 24; i--) {
+      const ts = now - i * HOUR_MS;
+      const key = getHourKey(ts);
+      const rows = this.sql
+        .exec<{ total: number; success: number; client_errors: number }>(
+          `SELECT total, success, client_errors FROM hourly_stats WHERE hour = ? LIMIT 1`,
+          key
+        )
+        .toArray();
+      if (rows.length > 0) {
+        total += rows[0].total;
+        success += rows[0].success;
+        clientErrors += rows[0].client_errors ?? 0;
+      }
+    }
+
+    return { total, success, clientErrors };
+  }
+
+  /**
+   * Build per-wallet 24h throughput entries from wallet_hourly data.
+   * Only includes wallets with at least one transaction in the last 24h.
+   */
+  private readWalletThroughput(): WalletThroughputEntry[] {
+    const now = Date.now();
+    const cutoffTs = now - 24 * HOUR_MS;
+    const cutoffKey = getHourKey(cutoffTs);
+
+    // Find all distinct wallet indices with activity in the last 24h
+    const walletRows = this.sql
+      .exec<{ wallet_index: number }>(
+        `SELECT DISTINCT wallet_index FROM wallet_hourly WHERE hour >= ? ORDER BY wallet_index ASC`,
+        cutoffKey
+      )
+      .toArray();
+
+    const result: WalletThroughputEntry[] = [];
+    for (const { wallet_index } of walletRows) {
+      const hourly = this.readWalletHourlyStats(wallet_index, 24);
+      const total24h = hourly.reduce((s, h) => s + h.total, 0);
+      const success24h = hourly.reduce((s, h) => s + h.success, 0);
+      const failed24h = hourly.reduce((s, h) => s + h.failed, 0);
+      const feeTotal24h = hourly
+        .reduce((s, h) => s + BigInt(h.feeTotal || "0"), 0n)
+        .toString();
+      result.push({ walletIndex: wallet_index, total24h, success24h, failed24h, feeTotal24h, hourly });
+    }
+    return result;
+  }
+
   private buildOverview(): DashboardOverview {
-    // readDailyStats(2) returns [yesterday, today] — reuse instead of
-    // duplicating the raw SQL query for yesterday's row.
-    const twoDays = this.readDailyStats(2);
-    const previous = twoDays[0] ?? null;
-    const current = twoDays[1];
+    // readDailyStats(1) returns [today] — used for calendar-day token and fee breakdown.
+    const todayArr = this.readDailyStats(1);
+    const current = todayArr[0];
 
     // Token percentages (from today's daily_stats — calendar-day token breakdown)
     const totalTokenTx =
@@ -676,24 +809,11 @@ export class StatsDO {
 
     // Fee aggregates (from today's daily_stats)
     const currentFees = current.fees ?? { total: "0", count: 0, min: "0", max: "0" };
-    const previousFees = previous?.fees ?? { total: "0", count: 0, min: "0", max: "0" };
 
     const avgFee =
       currentFees.count > 0
         ? (BigInt(currentFees.total) / BigInt(currentFees.count)).toString()
         : "0";
-
-    const currentFeeTotal = BigInt(currentFees.total);
-    const previousFeeTotal = BigInt(previousFees.total);
-    let feeTrend: "up" | "down" | "stable" = "stable";
-    if (previousFeeTotal === 0n) {
-      feeTrend = currentFeeTotal > 0n ? "up" : "stable";
-    } else {
-      const diff = currentFeeTotal - previousFeeTotal;
-      const pctChange = (diff * 100n) / previousFeeTotal;
-      if (pctChange > 5n) feeTrend = "up";
-      else if (pctChange < -5n) feeTrend = "down";
-    }
 
     // Hourly data covers the rolling 24h window (crossing midnight).
     // Sum it to produce headline totals that match the hourly chart exactly.
@@ -744,8 +864,41 @@ export class StatsDO {
         ? (rolling.fees / BigInt(rolling.feeCount)).toString()
         : avgFee;
 
+    // Rolling previous 24h (24-48h ago) for rolling-vs-rolling comparison (Bug #7 fix).
+    const prev24h = this.readPrevious24hTotals();
+
+    // Fee trend: compare rolling fee total vs previous 24h rolling fee total.
+    // Previous rolling fee data isn't tracked in hourly_stats (would need a separate window query).
+    // Use previous 24h transaction count as a proxy to avoid needing extra columns.
+    const previousFeeTotal = 0n; // Fee trend vs previous window not yet tracked
+    const currentFeeTotal = rolling.fees;
+    let feeTrend: "up" | "down" | "stable" = "stable";
+    if (previousFeeTotal === 0n) {
+      feeTrend = currentFeeTotal > 0n ? "up" : "stable";
+    } else {
+      const diff = currentFeeTotal - previousFeeTotal;
+      const pctChange = (diff * 100n) / previousFeeTotal;
+      if (pctChange > 5n) feeTrend = "up";
+      else if (pctChange < -5n) feeTrend = "down";
+    }
+
     // Per-endpoint breakdown from today's daily_stats
     const endpointBreakdown = this.readEndpointBreakdown(current.date);
+
+    // Dual success rates (Bug #4)
+    // rawSuccessRate: success / total (includes all failures in denominator)
+    const rawSuccessRate = rolling.total > 0
+      ? Math.round((rolling.success / rolling.total) * 10000) / 10000
+      : 0;
+    // effectiveSuccessRate: success / (success + relayErrors) — excludes client errors
+    const relayErrors = rollingFailed - rolling.clientErrors;
+    const effectiveDenominator = rolling.success + Math.max(0, relayErrors);
+    const effectiveSuccessRate = effectiveDenominator > 0
+      ? Math.round((rolling.success / effectiveDenominator) * 10000) / 10000
+      : 0;
+
+    // Per-wallet throughput (Bug #6)
+    const walletThroughput = this.readWalletThroughput();
 
     return {
       period: "24h",
@@ -754,11 +907,11 @@ export class StatsDO {
         success: rolling.success,
         failed: rollingFailed,
         clientErrors: rolling.clientErrors,
-        trend: calculateTrend(
-          rolling.total,
-          previous?.transactions.total ?? 0
-        ),
-        previousTotal: previous?.transactions.total ?? 0,
+        // Rolling-vs-rolling trend comparison (Bug #7 fix)
+        trend: calculateTrend(rolling.total, prev24h.total),
+        previousTotal: prev24h.total,
+        rawSuccessRate,
+        effectiveSuccessRate,
       },
       tokens: {
         STX: {
@@ -783,7 +936,7 @@ export class StatsDO {
         min: rolling.feeMin ?? currentFees.min ?? "0",
         max: rolling.feeMax ?? currentFees.max ?? "0",
         trend: feeTrend,
-        previousTotal: previousFees.total,
+        previousTotal: currentFees.total,
       },
       hourlyData,
       endpointBreakdown,
@@ -795,6 +948,12 @@ export class StatsDO {
         settlement: current.terminalReasons?.settlement ?? 0,
         replacement: current.terminalReasons?.replacement ?? 0,
         identity: current.terminalReasons?.identity ?? 0,
+      },
+      walletThroughput,
+      previous24h: {
+        total: prev24h.total,
+        success: prev24h.success,
+        failed: prev24h.total - prev24h.success,
       },
     };
   }
@@ -1027,6 +1186,21 @@ export class StatsDO {
       // GET /hourly — return 24h hourly data
       if (method === "GET" && url.pathname === "/hourly") {
         const data = this.readHourlyData();
+        return this.jsonResponse(data);
+      }
+
+      // GET /wallet-hourly?walletIndex=N&hours=N — per-wallet hourly data
+      if (method === "GET" && url.pathname === "/wallet-hourly") {
+        const walletIndexParam = url.searchParams.get("walletIndex");
+        if (!walletIndexParam) {
+          return this.badRequest("Missing walletIndex");
+        }
+        const walletIndex = parseInt(walletIndexParam, 10);
+        if (isNaN(walletIndex)) {
+          return this.badRequest("Invalid walletIndex");
+        }
+        const hours = Math.min(Math.max(parseInt(url.searchParams.get("hours") || "24", 10), 1), 48);
+        const data = this.readWalletHourlyStats(walletIndex, hours);
         return this.jsonResponse(data);
       }
 

--- a/src/durable-objects/stats-do.ts
+++ b/src/durable-objects/stats-do.ts
@@ -8,6 +8,7 @@ import type {
   TransactionLogEntry,
 } from "../types";
 import { calculateTrend } from "../services/stats";
+import { TERMINAL_REASON_TO_CATEGORY } from "@aibtc/tx-schemas/core/terminal-reasons";
 
 // ===========================================================================
 // Time helpers
@@ -143,6 +144,15 @@ export class StatsDO {
       ["hourly_stats", "client_errors INTEGER DEFAULT 0"],
       ["hourly_stats", "fee_min TEXT"],
       ["hourly_stats", "fee_max TEXT"],
+      // Terminal reason category columns (tx-schemas v0.4.0 alignment)
+      // Named with _schema suffix to avoid collision with legacy err_validation / err_settlement columns.
+      ["tx_log", "terminal_reason TEXT"],
+      ["daily_stats", "err_schema_validation INTEGER DEFAULT 0"],
+      ["daily_stats", "err_sender INTEGER DEFAULT 0"],
+      ["daily_stats", "err_relay INTEGER DEFAULT 0"],
+      ["daily_stats", "err_settlement_schema INTEGER DEFAULT 0"],
+      ["daily_stats", "err_replacement INTEGER DEFAULT 0"],
+      ["daily_stats", "err_identity INTEGER DEFAULT 0"],
     ];
     for (const [table, columnDef] of migrations) {
       try {
@@ -191,13 +201,14 @@ export class StatsDO {
     const amount = entry.amount || "0";
     const fee = entry.fee || null;
 
-    // Insert into tx_log (includes new client_error column)
+    // Insert into tx_log (includes client_error and terminal_reason columns)
     const id = crypto.randomUUID();
     const timestamp = new Date(entry.timestamp).getTime() || now;
+    const terminalReason = entry.terminalReason || null;
     this.sql.exec(
       `INSERT OR IGNORE INTO tx_log
-         (id, endpoint, timestamp, success, token, amount, fee, txid, sender, recipient, status, block_height, client_error)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         (id, endpoint, timestamp, success, token, amount, fee, txid, sender, recipient, status, block_height, client_error, terminal_reason)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       id,
       entry.endpoint,
       timestamp,
@@ -210,7 +221,8 @@ export class StatsDO {
       entry.recipient || null,
       entry.status || null,
       entry.blockHeight || null,
-      clientErrorInt
+      clientErrorInt,
+      terminalReason
     );
 
     // Prune tx_log older than 7 days
@@ -279,6 +291,30 @@ export class StatsDO {
         `UPDATE daily_stats SET verify_total = verify_total + 1 WHERE date = ?`,
         today
       );
+    }
+
+    // Atomic daily upsert — terminal reason category increment (tx-schemas alignment)
+    // Only applies to failed transactions with a known terminal reason.
+    if (!entry.success && terminalReason) {
+      const category = TERMINAL_REASON_TO_CATEGORY[terminalReason as keyof typeof TERMINAL_REASON_TO_CATEGORY];
+      const categoryColMap: Record<string, string> = {
+        validation: "err_schema_validation",
+        sender: "err_sender",
+        relay: "err_relay",
+        settlement: "err_settlement_schema",
+        replacement: "err_replacement",
+        identity: "err_identity",
+      };
+      const categoryCol = category ? categoryColMap[category] : null;
+      if (categoryCol) {
+        this.sql.exec(
+          `INSERT INTO daily_stats (date, ${categoryCol})
+           VALUES (?, 1)
+           ON CONFLICT(date) DO UPDATE SET
+             ${categoryCol} = ${categoryCol} + 1`,
+          today
+        );
+      }
     }
 
     // Atomic daily upsert — volumes (must be separate to use BigInt arithmetic safely)
@@ -434,13 +470,20 @@ export class StatsDO {
           err_sponsoring: number;
           err_settlement: number;
           err_internal: number;
+          err_schema_validation: number;
+          err_sender: number;
+          err_relay: number;
+          err_settlement_schema: number;
+          err_replacement: number;
+          err_identity: number;
         }>(
           `SELECT total, success, failed, client_errors,
                   stx_count, stx_volume,
                   sbtc_count, sbtc_volume,
                   usdcx_count, usdcx_volume,
                   fee_total, fee_count, fee_min, fee_max,
-                  err_validation, err_rate_limit, err_sponsoring, err_settlement, err_internal
+                  err_validation, err_rate_limit, err_sponsoring, err_settlement, err_internal,
+                  err_schema_validation, err_sender, err_relay, err_settlement_schema, err_replacement, err_identity
            FROM daily_stats WHERE date = ? LIMIT 1`,
           date
         )
@@ -461,6 +504,14 @@ export class StatsDO {
             sponsoring: 0,
             settlement: 0,
             internal: 0,
+          },
+          terminalReasons: {
+            validation: 0,
+            sender: 0,
+            relay: 0,
+            settlement: 0,
+            replacement: 0,
+            identity: 0,
           },
         });
       } else {
@@ -484,6 +535,14 @@ export class StatsDO {
             sponsoring: r.err_sponsoring,
             settlement: r.err_settlement,
             internal: r.err_internal,
+          },
+          terminalReasons: {
+            validation: r.err_schema_validation ?? 0,
+            sender: r.err_sender ?? 0,
+            relay: r.err_relay ?? 0,
+            settlement: r.err_settlement_schema ?? 0,
+            replacement: r.err_replacement ?? 0,
+            identity: r.err_identity ?? 0,
           },
         };
         if (r.fee_count > 0) {
@@ -728,6 +787,15 @@ export class StatsDO {
       },
       hourlyData,
       endpointBreakdown,
+      // Terminal reason category counts from today's daily_stats row
+      terminalReasons: {
+        validation: current.terminalReasons?.validation ?? 0,
+        sender: current.terminalReasons?.sender ?? 0,
+        relay: current.terminalReasons?.relay ?? 0,
+        settlement: current.terminalReasons?.settlement ?? 0,
+        replacement: current.terminalReasons?.replacement ?? 0,
+        identity: current.terminalReasons?.identity ?? 0,
+      },
     };
   }
 

--- a/src/durable-objects/stats-do.ts
+++ b/src/durable-objects/stats-do.ts
@@ -989,20 +989,8 @@ export class StatsDO {
     // Rolling previous 24h (24-48h ago) for rolling-vs-rolling comparison (Bug #7 fix).
     const prev24h = this.readPrevious24hTotals();
 
-    // Fee trend: compare rolling fee total vs previous 24h rolling fee total.
-    // Previous rolling fee data isn't tracked in hourly_stats (would need a separate window query).
-    // Use previous 24h transaction count as a proxy to avoid needing extra columns.
-    const previousFeeTotal = 0n; // Fee trend vs previous window not yet tracked
-    const currentFeeTotal = rolling.fees;
-    let feeTrend: "up" | "down" | "stable" = "stable";
-    if (previousFeeTotal === 0n) {
-      feeTrend = currentFeeTotal > 0n ? "up" : "stable";
-    } else {
-      const diff = currentFeeTotal - previousFeeTotal;
-      const pctChange = (diff * 100n) / previousFeeTotal;
-      if (pctChange > 5n) feeTrend = "up";
-      else if (pctChange < -5n) feeTrend = "down";
-    }
+    // TODO: implement previous-window fee comparison
+    const feeTrend: "up" | "down" | "stable" = rolling.fees > 0n ? "up" : "stable";
 
     // Per-endpoint breakdown from today's daily_stats
     const endpointBreakdown = this.readEndpointBreakdown(current.date);

--- a/src/durable-objects/stats-do.ts
+++ b/src/durable-objects/stats-do.ts
@@ -141,6 +141,8 @@ export class StatsDO {
       ["daily_stats", "settle_client_errors INTEGER DEFAULT 0"],
       ["daily_stats", "verify_total INTEGER DEFAULT 0"],
       ["hourly_stats", "client_errors INTEGER DEFAULT 0"],
+      ["hourly_stats", "fee_min TEXT"],
+      ["hourly_stats", "fee_max TEXT"],
     ];
     for (const [table, columnDef] of migrations) {
       try {
@@ -345,11 +347,28 @@ export class StatsDO {
       clientErrorInt
     );
 
-    // Hourly fee total
+    // Hourly fee total + min/max (only for successful transactions with fee data)
     if (entry.success && fee) {
       this.sql.exec(
         `UPDATE hourly_stats SET fee_total = CAST(CAST(fee_total AS INTEGER) + ? AS TEXT) WHERE hour = ?`,
         fee,
+        hourKey
+      );
+      this.sql.exec(
+        `UPDATE hourly_stats SET
+           fee_min = CASE
+             WHEN fee_min IS NULL THEN ?
+             WHEN CAST(? AS INTEGER) < CAST(fee_min AS INTEGER) THEN ?
+             ELSE fee_min
+           END,
+           fee_max = CASE
+             WHEN fee_max IS NULL THEN ?
+             WHEN CAST(? AS INTEGER) > CAST(fee_max AS INTEGER) THEN ?
+             ELSE fee_max
+           END
+         WHERE hour = ?`,
+        fee, fee, fee,
+        fee, fee, fee,
         hourKey
       );
     }
@@ -482,9 +501,9 @@ export class StatsDO {
     return result;
   }
 
-  private readHourlyData(): Array<{ hour: string; transactions: number; success: number; fees?: string; clientErrors?: number }> {
+  private readHourlyData(): Array<{ hour: string; transactions: number; success: number; fees?: string; feeMin?: string; feeMax?: string; clientErrors?: number }> {
     const now = Date.now();
-    const result: Array<{ hour: string; transactions: number; success: number; fees?: string; clientErrors?: number }> = [];
+    const result: Array<{ hour: string; transactions: number; success: number; fees?: string; feeMin?: string; feeMax?: string; clientErrors?: number }> = [];
 
     for (let i = 23; i >= 0; i--) {
       const ts = now - i * HOUR_MS;
@@ -493,8 +512,8 @@ export class StatsDO {
       const key = getHourKey(ts);
 
       const rows = this.sql
-        .exec<{ total: number; success: number; fee_total: string; client_errors: number }>(
-          `SELECT total, success, fee_total, client_errors FROM hourly_stats WHERE hour = ? LIMIT 1`,
+        .exec<{ total: number; success: number; fee_total: string; fee_min: string | null; fee_max: string | null; client_errors: number }>(
+          `SELECT total, success, fee_total, fee_min, fee_max, client_errors FROM hourly_stats WHERE hour = ? LIMIT 1`,
           key
         )
         .toArray();
@@ -503,13 +522,19 @@ export class StatsDO {
         result.push({ hour: hourLabel, transactions: 0, success: 0 });
       } else {
         const r = rows[0];
-        const entry: { hour: string; transactions: number; success: number; fees?: string; clientErrors?: number } = {
+        const entry: { hour: string; transactions: number; success: number; fees?: string; feeMin?: string; feeMax?: string; clientErrors?: number } = {
           hour: hourLabel,
           transactions: r.total,
           success: r.success,
         };
         if (r.fee_total && r.fee_total !== "0") {
           entry.fees = r.fee_total;
+        }
+        if (r.fee_min) {
+          entry.feeMin = r.fee_min;
+        }
+        if (r.fee_max) {
+          entry.feeMax = r.fee_max;
         }
         if (r.client_errors > 0) {
           entry.clientErrors = r.client_errors;
@@ -617,14 +642,37 @@ export class StatsDO {
     // (when daily_stats has reset but the rolling window still has fee data from yesterday).
     const hourlyData = this.readHourlyData();
     const rolling = hourlyData.reduce(
-      (acc, h) => ({
-        total: acc.total + h.transactions,
-        success: acc.success + h.success,
-        clientErrors: acc.clientErrors + (h.clientErrors ?? 0),
-        fees: acc.fees + BigInt(h.fees || "0"),
-        feeCount: h.fees && h.fees !== "0" ? acc.feeCount + 1 : acc.feeCount,
-      }),
-      { total: 0, success: 0, clientErrors: 0, fees: 0n, feeCount: 0 }
+      (acc, h) => {
+        const hasHourFee = h.fees && h.fees !== "0";
+        // Rolling fee min: track the lowest fee_min across all hours in the window
+        let newFeeMin = acc.feeMin;
+        if (h.feeMin) {
+          if (newFeeMin === null) {
+            newFeeMin = h.feeMin;
+          } else if (BigInt(h.feeMin) < BigInt(newFeeMin)) {
+            newFeeMin = h.feeMin;
+          }
+        }
+        // Rolling fee max: track the highest fee_max across all hours in the window
+        let newFeeMax = acc.feeMax;
+        if (h.feeMax) {
+          if (newFeeMax === null) {
+            newFeeMax = h.feeMax;
+          } else if (BigInt(h.feeMax) > BigInt(newFeeMax)) {
+            newFeeMax = h.feeMax;
+          }
+        }
+        return {
+          total: acc.total + h.transactions,
+          success: acc.success + h.success,
+          clientErrors: acc.clientErrors + (h.clientErrors ?? 0),
+          fees: acc.fees + BigInt(h.fees || "0"),
+          feeCount: hasHourFee ? acc.feeCount + 1 : acc.feeCount,
+          feeMin: newFeeMin,
+          feeMax: newFeeMax,
+        };
+      },
+      { total: 0, success: 0, clientErrors: 0, fees: 0n, feeCount: 0, feeMin: null as string | null, feeMax: null as string | null }
     );
     const rollingFailed = rolling.total - rolling.success;
 
@@ -673,8 +721,8 @@ export class StatsDO {
       fees: {
         total: rollingFeeTotal,
         average: rollingFeeAvg,
-        min: currentFees.min || "0",
-        max: currentFees.max || "0",
+        min: rolling.feeMin ?? currentFees.min ?? "0",
+        max: rolling.feeMax ?? currentFees.max ?? "0",
         trend: feeTrend,
         previousTotal: previousFees.total,
       },

--- a/src/durable-objects/stats-do.ts
+++ b/src/durable-objects/stats-do.ts
@@ -29,6 +29,12 @@ function getHourKey(now: number = Date.now()): string {
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 
+/** Convert a DB hour key ("YYYY-MM-DD:HH") to an ISO 8601 timestamp ("YYYY-MM-DDTHH:00:00Z"). */
+function hourKeyToISO(key: string): string {
+  const [date, hh] = key.split(":");
+  return `${date}T${hh}:00:00Z`;
+}
+
 // ===========================================================================
 // StatsDO — SQLite-backed atomic stats for the x402 sponsor relay
 //
@@ -311,6 +317,8 @@ export class StatsDO {
     // Only applies to failed transactions with a known terminal reason.
     if (!entry.success && terminalReason) {
       const category = TERMINAL_REASON_TO_CATEGORY[terminalReason as keyof typeof TERMINAL_REASON_TO_CATEGORY];
+      // categoryColMap must stay in sync with TERMINAL_REASON_TO_CATEGORY categories in @aibtc/tx-schemas.
+      // If tx-schemas adds a new category, add the corresponding column here and in the migrations array.
       const categoryColMap: Record<string, string> = {
         validation: "err_schema_validation",
         sender: "err_sender",
@@ -397,15 +405,11 @@ export class StatsDO {
       clientErrorInt
     );
 
-    // Hourly fee total + min/max (only for successful transactions with fee data)
+    // Hourly fee total + min/max in a single UPDATE (only for successful transactions with fee data)
     if (entry.success && fee) {
       this.sql.exec(
-        `UPDATE hourly_stats SET fee_total = CAST(CAST(fee_total AS INTEGER) + ? AS TEXT) WHERE hour = ?`,
-        fee,
-        hourKey
-      );
-      this.sql.exec(
         `UPDATE hourly_stats SET
+           fee_total = CAST(CAST(fee_total AS INTEGER) + ? AS TEXT),
            fee_min = CASE
              WHEN fee_min IS NULL THEN ?
              WHEN CAST(? AS INTEGER) < CAST(fee_min AS INTEGER) THEN ?
@@ -417,6 +421,7 @@ export class StatsDO {
              ELSE fee_max
            END
          WHERE hour = ?`,
+        fee,
         fee, fee, fee,
         fee, fee, fee,
         hourKey
@@ -619,15 +624,12 @@ export class StatsDO {
   private readHourlyData(): Array<{ hour: string; transactions: number; success: number; fees?: string; feeMin?: string; feeMax?: string; clientErrors?: number }> {
     const now = Date.now();
 
-    // Generate the 24 hour keys and their display labels
+    // Generate the 24 hour keys and ISO timestamp labels
     const hourEntries: Array<{ key: string; label: string }> = [];
     for (let i = 23; i >= 0; i--) {
       const ts = now - i * HOUR_MS;
-      const d = new Date(ts);
-      hourEntries.push({
-        key: getHourKey(ts),
-        label: d.getUTCHours().toString().padStart(2, "0") + ":00",
-      });
+      const key = getHourKey(ts);
+      hourEntries.push({ key, label: hourKeyToISO(key) });
     }
 
     const startKey = hourEntries[0].key;
@@ -690,15 +692,12 @@ export class StatsDO {
   ): Array<{ hour: string; total: number; success: number; failed: number; feeTotal: string }> {
     const now = Date.now();
 
-    // Generate the hour keys and their display labels
+    // Generate the hour keys and ISO timestamp labels
     const hourEntries: Array<{ key: string; label: string }> = [];
     for (let i = hours - 1; i >= 0; i--) {
       const ts = now - i * HOUR_MS;
-      const d = new Date(ts);
-      hourEntries.push({
-        key: getHourKey(ts),
-        label: d.getUTCHours().toString().padStart(2, "0") + ":00",
-      });
+      const key = getHourKey(ts);
+      hourEntries.push({ key, label: hourKeyToISO(key) });
     }
 
     const startKey = hourEntries[0].key;
@@ -843,15 +842,12 @@ export class StatsDO {
   private readWalletThroughput(): WalletThroughputEntry[] {
     const now = Date.now();
 
-    // Generate the 24 hour keys and labels (same logic as readWalletHourlyStats)
+    // Generate the 24 hour keys and ISO timestamp labels (same logic as readWalletHourlyStats)
     const hourEntries: Array<{ key: string; label: string }> = [];
     for (let i = 23; i >= 0; i--) {
       const ts = now - i * HOUR_MS;
-      const d = new Date(ts);
-      hourEntries.push({
-        key: getHourKey(ts),
-        label: d.getUTCHours().toString().padStart(2, "0") + ":00",
-      });
+      const key = getHourKey(ts);
+      hourEntries.push({ key, label: hourKeyToISO(key) });
     }
 
     const startKey = hourEntries[0].key;
@@ -944,7 +940,6 @@ export class StatsDO {
     const hourlyData = this.readHourlyData();
     const rolling = hourlyData.reduce(
       (acc, h) => {
-        const hasHourFee = h.fees && h.fees !== "0";
         // Rolling fee min: track the lowest fee_min across all hours in the window
         let newFeeMin = acc.feeMin;
         if (h.feeMin) {
@@ -968,12 +963,11 @@ export class StatsDO {
           success: acc.success + h.success,
           clientErrors: acc.clientErrors + (h.clientErrors ?? 0),
           fees: acc.fees + BigInt(h.fees || "0"),
-          feeCount: hasHourFee ? acc.feeCount + 1 : acc.feeCount,
           feeMin: newFeeMin,
           feeMax: newFeeMax,
         };
       },
-      { total: 0, success: 0, clientErrors: 0, fees: 0n, feeCount: 0, feeMin: null as string | null, feeMax: null as string | null }
+      { total: 0, success: 0, clientErrors: 0, fees: 0n, feeMin: null as string | null, feeMax: null as string | null }
     );
     const rollingFailed = rolling.total - rolling.success;
 
@@ -981,16 +975,20 @@ export class StatsDO {
     // Fall back to today's calendar-day fee total for backward compatibility
     // (e.g., when hourly data is absent on a fresh deployment).
     const rollingFeeTotal = rolling.fees > 0n ? rolling.fees.toString() : currentFees.total;
+    // Per-transaction fee average: use rolling.success as denominator since fees are
+    // recorded only for successful transactions. More accurate than counting hours-with-fees.
     const rollingFeeAvg =
-      rolling.feeCount > 0
-        ? (rolling.fees / BigInt(rolling.feeCount)).toString()
+      rolling.success > 0
+        ? (rolling.fees / BigInt(rolling.success)).toString()
         : avgFee;
 
     // Rolling previous 24h (24-48h ago) for rolling-vs-rolling comparison (Bug #7 fix).
     const prev24h = this.readPrevious24hTotals();
 
-    // TODO: implement previous-window fee comparison
-    const feeTrend: "up" | "down" | "stable" = rolling.fees > 0n ? "up" : "stable";
+    // Until we can compare against a real previous rolling-window fee total,
+    // return a neutral trend instead of incorrectly reporting "up" whenever
+    // any fees exist in the current window.
+    const feeTrend: "up" | "down" | "stable" = "stable";
 
     // Per-endpoint breakdown from today's daily_stats
     const endpointBreakdown = this.readEndpointBreakdown(current.date);
@@ -1046,7 +1044,7 @@ export class StatsDO {
         min: rolling.feeMin ?? currentFees.min ?? "0",
         max: rolling.feeMax ?? currentFees.max ?? "0",
         trend: feeTrend,
-        previousTotal: currentFees.total,
+        previousTotal: "0",  // placeholder until previous rolling-window fee tracking is implemented
       },
       hourlyData,
       endpointBreakdown,

--- a/src/endpoints/DashboardStats.ts
+++ b/src/endpoints/DashboardStats.ts
@@ -154,6 +154,20 @@ export class DashboardStats extends BaseEndpoint {
                     },
                   },
                 },
+                terminalReasons: {
+                  type: "object" as const,
+                  nullable: true,
+                  description:
+                    "Error counts grouped by tx-schemas terminal reason category (today's calendar-day). Additive alongside legacy errors object. Categories: validation, sender, relay, settlement, replacement, identity.",
+                  properties: {
+                    validation: { type: "number" as const, description: "invalid_transaction, not_sponsored" },
+                    sender: { type: "number" as const, description: "sender_nonce_* errors, origin_chaining_limit, sender_hand_expired" },
+                    relay: { type: "number" as const, description: "sponsor_failure, queue_unavailable, internal_error, sponsor_exhausted, sponsor_nonce_conflict" },
+                    settlement: { type: "number" as const, description: "broadcast_failure, chain_abort, broadcast_rate_limited" },
+                    replacement: { type: "number" as const, description: "nonce_replacement, superseded" },
+                    identity: { type: "number" as const, description: "expired, unknown_payment_identity" },
+                  },
+                },
                 endpointBreakdown: {
                   type: "object" as const,
                   nullable: true,

--- a/src/endpoints/DashboardStats.ts
+++ b/src/endpoints/DashboardStats.ts
@@ -52,7 +52,18 @@ export class DashboardStats extends BaseEndpoint {
                       type: "string" as const,
                       enum: ["up", "down", "stable"],
                     },
-                    previousTotal: { type: "number" as const },
+                    previousTotal: {
+                      type: "number" as const,
+                      description: "Total transactions in the previous rolling 24h window (24-48h ago) for trend comparison.",
+                    },
+                    rawSuccessRate: {
+                      type: "number" as const,
+                      description: "Raw success rate = success / total. Includes client errors in denominator. Range 0-1.",
+                    },
+                    effectiveSuccessRate: {
+                      type: "number" as const,
+                      description: "Effective success rate = success / (success + relayErrors). Excludes client errors from denominator. Range 0-1.",
+                    },
                   },
                 },
                 tokens: {
@@ -166,6 +177,45 @@ export class DashboardStats extends BaseEndpoint {
                     settlement: { type: "number" as const, description: "broadcast_failure, chain_abort, broadcast_rate_limited" },
                     replacement: { type: "number" as const, description: "nonce_replacement, superseded" },
                     identity: { type: "number" as const, description: "expired, unknown_payment_identity" },
+                  },
+                },
+                walletThroughput: {
+                  type: "array" as const,
+                  nullable: true,
+                  description: "Per-wallet 24h throughput totals with hourly spark data. Only includes wallets with at least one transaction in the last 24h.",
+                  items: {
+                    type: "object" as const,
+                    properties: {
+                      walletIndex: { type: "number" as const, description: "Sponsor wallet index (0-based)" },
+                      total24h: { type: "number" as const, description: "Total transactions in rolling 24h" },
+                      success24h: { type: "number" as const, description: "Successful transactions in rolling 24h" },
+                      failed24h: { type: "number" as const, description: "Failed transactions in rolling 24h" },
+                      feeTotal24h: { type: "string" as const, description: "Total fees paid by this wallet in microSTX (rolling 24h)" },
+                      hourly: {
+                        type: "array" as const,
+                        description: "Hourly spark data for the last 24h",
+                        items: {
+                          type: "object" as const,
+                          properties: {
+                            hour: { type: "string" as const },
+                            total: { type: "number" as const },
+                            success: { type: "number" as const },
+                            failed: { type: "number" as const },
+                            feeTotal: { type: "string" as const },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                previous24h: {
+                  type: "object" as const,
+                  nullable: true,
+                  description: "Rolling 24h totals from the previous window (24-48h ago). Used for rolling-vs-rolling trend comparison.",
+                  properties: {
+                    total: { type: "number" as const },
+                    success: { type: "number" as const },
+                    failed: { type: "number" as const },
                   },
                 },
                 endpointBreakdown: {

--- a/src/endpoints/relay.ts
+++ b/src/endpoints/relay.ts
@@ -789,6 +789,7 @@ export class Relay extends BaseEndpoint {
           recipient: verifyResult.data.recipient,
           status: broadcastResult.status,
           blockHeight: confirmedBlockHeight,
+          walletIndex: sponsorWalletIndex,
         }).catch(() => {})
       );
 

--- a/src/endpoints/relay.ts
+++ b/src/endpoints/relay.ts
@@ -213,6 +213,9 @@ export class Relay extends BaseEndpoint {
     const logger = this.getLogger(c);
     logger.info("Relay request received");
 
+    // Capture HTTP request arrival time for user-perceived settlement latency measurement.
+    const submittedAt = new Date().toISOString();
+
     const statsService = new StatsService(c.env, logger);
 
     try {
@@ -563,6 +566,7 @@ export class Relay extends BaseEndpoint {
                       senderTxHex: body.transaction,
                       senderAddress: validation.senderAddress,
                       senderNonce: Number(validation.transaction.auth.spendingCondition.nonce),
+                      submittedAt,
                     })
                   );
                 }
@@ -752,6 +756,7 @@ export class Relay extends BaseEndpoint {
             senderTxHex: body.transaction,
             senderAddress: validation.senderAddress,
             senderNonce: Number(validation.transaction.auth.spendingCondition.nonce),
+            submittedAt,
           })
         );
       }

--- a/src/endpoints/relay.ts
+++ b/src/endpoints/relay.ts
@@ -223,7 +223,7 @@ export class Relay extends BaseEndpoint {
 
       if (!body.transaction) {
         c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-        c.executionCtx.waitUntil(statsService.logFailure("relay", true).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("relay", true, undefined, "invalid_transaction").catch(() => {}));
         return this.err(c, {
           error: "Missing transaction field",
           code: "MISSING_TRANSACTION",
@@ -234,7 +234,7 @@ export class Relay extends BaseEndpoint {
 
       if (!body.settle) {
         c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-        c.executionCtx.waitUntil(statsService.logFailure("relay", true).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("relay", true, undefined, "invalid_transaction").catch(() => {}));
         return this.err(c, {
           error: "Missing settle options",
           code: "MISSING_SETTLE_OPTIONS",
@@ -248,7 +248,7 @@ export class Relay extends BaseEndpoint {
         const authError = stxVerifyService.verifySip018Auth(body.auth, "relay");
         if (authError) {
           c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-          c.executionCtx.waitUntil(statsService.logFailure("relay", true).catch(() => {}));
+          c.executionCtx.waitUntil(statsService.logFailure("relay", true, undefined, "invalid_transaction").catch(() => {}));
           return this.err(c, {
             error: authError.error,
             code: authError.code,
@@ -266,7 +266,7 @@ export class Relay extends BaseEndpoint {
       );
       if (settleValidation.valid === false) {
         c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-        c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount ?? "0" }).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount ?? "0" }, "invalid_transaction").catch(() => {}));
         return this.err(c, {
           error: settleValidation.error,
           code: "INVALID_SETTLE_OPTIONS",
@@ -288,7 +288,9 @@ export class Relay extends BaseEndpoint {
       const validation = sponsorService.validateTransaction(body.transaction);
       if (validation.valid === false) {
         c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-        c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount },
+          validation.error === "Transaction must be sponsored" ? "not_sponsored" : "invalid_transaction"
+        ).catch(() => {}));
         if (validation.error === "Malformed transaction payload") {
           const blocked = clientIp ? checkAndRecordMalformed(clientIp) : false;
           if (blocked) {
@@ -325,7 +327,7 @@ export class Relay extends BaseEndpoint {
       if (!checkRateLimit(validation.senderAddress)) {
         logger.warn("Rate limit exceeded", { sender: validation.senderAddress });
         c.executionCtx.waitUntil(statsService.recordError("rateLimit").catch(() => {}));
-        c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }, "broadcast_rate_limited").catch(() => {}));
         return this.err(c, {
           error: "Rate limit exceeded",
           code: "RATE_LIMIT_EXCEEDED",
@@ -429,6 +431,7 @@ export class Relay extends BaseEndpoint {
             }
           );
         }
+        c.executionCtx.waitUntil(statsService.logFailure("relay", false, { tokenType: body.settle.tokenType || "STX", amount: body.settle.minAmount }, "sponsor_failure").catch(() => {}));
         return this.sponsorFailureResponse(
           c,
           sponsorResult as { error: string; details: string; code?: string; retryAfter?: number },
@@ -459,7 +462,7 @@ export class Relay extends BaseEndpoint {
           );
         }
         c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-        c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }, "invalid_transaction").catch(() => {}));
         return this.err(c, {
           error: verifyResult.error,
           code: "SETTLEMENT_VERIFICATION_FAILED",
@@ -511,7 +514,7 @@ export class Relay extends BaseEndpoint {
             fee: sponsorResult.fee,
             sender: validation.senderAddress,
             recipient: body.settle.expectedRecipient,
-          }).catch(() => {})
+          }, isClientError ? "invalid_transaction" : "broadcast_failure").catch(() => {})
         );
 
         // On the sponsored path, nonce conflicts are ambiguous — the Stacks node doesn't
@@ -842,7 +845,7 @@ export class Relay extends BaseEndpoint {
         error: e instanceof Error ? e.message : "Unknown error",
       });
       c.executionCtx.waitUntil(statsService.recordError("internal").catch(() => {}));
-      c.executionCtx.waitUntil(statsService.logFailure("relay", false).catch(() => {}));
+      c.executionCtx.waitUntil(statsService.logFailure("relay", false, undefined, "internal_error").catch(() => {}));
       return this.err(c, {
         error: "Internal server error",
         code: "INTERNAL_ERROR",
@@ -906,7 +909,7 @@ export class Relay extends BaseEndpoint {
     const validation = sponsorService.validateNonSponsoredTransaction(body.transaction);
     if (validation.valid === false) {
       c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-      c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }).catch(() => {}));
+      c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }, "invalid_transaction").catch(() => {}));
       return this.err(c, {
         error: validation.error,
         code: "INVALID_TRANSACTION",
@@ -920,7 +923,7 @@ export class Relay extends BaseEndpoint {
     if (!checkRateLimit(validation.senderAddress)) {
       logger.warn("Rate limit exceeded (self-pay)", { sender: validation.senderAddress });
       c.executionCtx.waitUntil(statsService.recordError("rateLimit").catch(() => {}));
-      c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }).catch(() => {}));
+      c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }, "broadcast_rate_limited").catch(() => {}));
       return this.err(c, {
         error: "Rate limit exceeded",
         code: "RATE_LIMIT_EXCEEDED",
@@ -961,7 +964,7 @@ export class Relay extends BaseEndpoint {
     );
     if (!verifyResult.valid) {
       c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-      c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }).catch(() => {}));
+      c.executionCtx.waitUntil(statsService.logFailure("relay", true, { tokenType: body.settle.tokenType, amount: body.settle.minAmount }, "invalid_transaction").catch(() => {}));
       return this.err(c, {
         error: verifyResult.error,
         code: "SETTLEMENT_VERIFICATION_FAILED",
@@ -991,7 +994,7 @@ export class Relay extends BaseEndpoint {
           fee: "0",
           sender: validation.senderAddress,
           recipient: body.settle.expectedRecipient,
-        }).catch(() => {})
+        }, isClientError ? "invalid_transaction" : "broadcast_failure").catch(() => {})
       );
 
       // Map client-caused Stacks node rejections to distinct actionable error codes.

--- a/src/endpoints/settle.ts
+++ b/src/endpoints/settle.ts
@@ -42,6 +42,8 @@ interface BroadcastSuccessParams {
   paymentIdService: PaymentIdService;
   paymentIdentifier: string | undefined;
   paymentIdPayloadHash: string | undefined;
+  /** ISO timestamp of when the client HTTP request arrived at the relay endpoint. */
+  submittedAt: string;
 }
 
 /**
@@ -151,6 +153,7 @@ export class Settle extends BaseEndpoint {
       verifiedTx, recipient, amount,
       settleOptions, settlementService, statsService,
       paymentIdService, paymentIdentifier, paymentIdPayloadHash,
+      submittedAt,
     } = params;
 
     const payer = settlementService.senderToAddress(verifiedTx, c.env.STACKS_NETWORK);
@@ -166,6 +169,7 @@ export class Settle extends BaseEndpoint {
           senderTxHex: txHex,
           senderAddress: payer,
           senderNonce: Number(verifiedTx.auth.spendingCondition.nonce),
+          submittedAt,
         })
       );
     }
@@ -270,6 +274,9 @@ export class Settle extends BaseEndpoint {
   async handle(c: AppContext) {
     const logger = this.getLogger(c);
     logger.info("x402 V2 settle request received");
+
+    // Capture HTTP request arrival time for user-perceived settlement latency measurement.
+    const submittedAt = new Date().toISOString();
 
     const statsService = new StatsService(c.env, logger);
     const paymentIdService = new PaymentIdService(c.env.RELAY_KV, logger);
@@ -589,6 +596,7 @@ export class Settle extends BaseEndpoint {
                     amount: retryVerifyResult.data.amount,
                     settleOptions, settlementService, statsService,
                     paymentIdService, paymentIdentifier, paymentIdPayloadHash,
+                    submittedAt,
                   });
                 } else {
                   // Retry broadcast also failed — release retry nonce, fall through to error
@@ -670,6 +678,7 @@ export class Settle extends BaseEndpoint {
         amount: verifyResult.data.amount,
         settleOptions, settlementService, statsService,
         paymentIdService, paymentIdentifier, paymentIdPayloadHash,
+        submittedAt,
       });
     } catch (e) {
       logger.error("Unexpected settle error", {

--- a/src/endpoints/settle.ts
+++ b/src/endpoints/settle.ts
@@ -367,7 +367,7 @@ export class Settle extends BaseEndpoint {
         c.executionCtx.waitUntil(
           Promise.all([
             statsService.recordError("validation"),
-            statsService.logFailure("settle", true),
+            statsService.logFailure("settle", true, undefined, "invalid_transaction"),
           ]).catch(() => {})
         );
         return v2Error(X402_V2_ERROR_CODES.INVALID_TRANSACTION_STATE, 200);
@@ -388,7 +388,7 @@ export class Settle extends BaseEndpoint {
         c.executionCtx.waitUntil(
           Promise.all([
             statsService.recordError("validation"),
-            statsService.logFailure("settle", true),
+            statsService.logFailure("settle", true, undefined, "invalid_transaction"),
           ]).catch(() => {})
         );
         return v2Error(X402_V2_ERROR_CODES.INVALID_TRANSACTION_STATE, 200);
@@ -425,7 +425,7 @@ export class Settle extends BaseEndpoint {
           c.executionCtx.waitUntil(
             Promise.all([
               statsService.recordError("validation"),
-              statsService.logFailure("settle", true, failureCtx),
+              statsService.logFailure("settle", true, failureCtx, "invalid_transaction"),
             ]).catch(() => {})
           );
           return v2Error(X402_V2_ERROR_CODES.INVALID_TRANSACTION_STATE, 200);
@@ -451,7 +451,7 @@ export class Settle extends BaseEndpoint {
             c.executionCtx.waitUntil(
               Promise.all([
                 statsService.recordError("sponsoring"),
-                statsService.logFailure("settle", false, failureCtx),
+                statsService.logFailure("settle", false, failureCtx, "sender_nonce_gap"),
               ]).catch(() => {})
             );
             return c.json({
@@ -467,7 +467,7 @@ export class Settle extends BaseEndpoint {
           c.executionCtx.waitUntil(
             Promise.all([
               statsService.recordError("sponsoring"),
-              statsService.logFailure("settle", false, failureCtx),
+              statsService.logFailure("settle", false, failureCtx, "sponsor_failure"),
             ]).catch(() => {})
           );
           // Transient sponsor failures — signal retryable via BROADCAST_FAILED
@@ -513,7 +513,7 @@ export class Settle extends BaseEndpoint {
         c.executionCtx.waitUntil(
           Promise.all([
             statsService.recordError("validation"),
-            statsService.logFailure("settle", true, failureCtx),
+            statsService.logFailure("settle", true, failureCtx, "invalid_transaction"),
           ]).catch(() => {})
         );
         return v2Error(mapVerifyErrorToV2Code(verifyResult.error), 200);
@@ -548,7 +548,7 @@ export class Settle extends BaseEndpoint {
 
         // Record stats once for all error branches
         c.executionCtx.waitUntil(
-          statsService.logFailure("settle", isClientError, failureCtx).catch(() => {})
+          statsService.logFailure("settle", isClientError, failureCtx, isClientError ? "invalid_transaction" : "broadcast_failure").catch(() => {})
         );
 
         // Sponsor-side issues (nonce conflict or TooMuchChaining) → inline resync + single retry

--- a/src/endpoints/settle.ts
+++ b/src/endpoints/settle.ts
@@ -209,6 +209,7 @@ export class Settle extends BaseEndpoint {
         recipient,
         status: "pending",
         fee: sponsorFee,
+        walletIndex: sponsorWalletIndex,
       }).catch(() => {})
     );
 

--- a/src/endpoints/sponsor.ts
+++ b/src/endpoints/sponsor.ts
@@ -463,6 +463,7 @@ export class Sponsor extends BaseEndpoint {
           txid,
           sender: validation.senderAddress,
           status: "pending",
+          walletIndex: sponsorWalletIndex,
         }).catch(() => {})
       );
 

--- a/src/endpoints/sponsor.ts
+++ b/src/endpoints/sponsor.ts
@@ -158,6 +158,9 @@ export class Sponsor extends BaseEndpoint {
     const logger = this.getLogger(c);
     logger.info("Sponsor request received");
 
+    // Capture HTTP request arrival time for user-perceived settlement latency measurement.
+    const submittedAt = new Date().toISOString();
+
     const statsService = new StatsService(c.env, logger);
 
     try {
@@ -433,6 +436,7 @@ export class Sponsor extends BaseEndpoint {
             senderTxHex: body.transaction,
             senderAddress: validation.senderAddress,
             senderNonce: Number(validation.transaction.auth.spendingCondition.nonce),
+            submittedAt,
           })
         );
       }

--- a/src/endpoints/sponsor.ts
+++ b/src/endpoints/sponsor.ts
@@ -169,7 +169,7 @@ export class Sponsor extends BaseEndpoint {
 
       if (!body.transaction) {
         c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-        c.executionCtx.waitUntil(statsService.logFailure("sponsor", true).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("sponsor", true, undefined, "invalid_transaction").catch(() => {}));
         return this.err(c, {
           error: "Missing transaction field",
           code: "MISSING_TRANSACTION",
@@ -183,7 +183,7 @@ export class Sponsor extends BaseEndpoint {
         const authError = stxVerifyService.verifySip018Auth(body.auth, "sponsor");
         if (authError) {
           c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-          c.executionCtx.waitUntil(statsService.logFailure("sponsor", true).catch(() => {}));
+          c.executionCtx.waitUntil(statsService.logFailure("sponsor", true, undefined, "invalid_transaction").catch(() => {}));
           return this.err(c, {
             error: authError.error,
             code: authError.code,
@@ -199,7 +199,9 @@ export class Sponsor extends BaseEndpoint {
       const validation = sponsorService.validateTransaction(body.transaction);
       if (validation.valid === false) {
         c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-        c.executionCtx.waitUntil(statsService.logFailure("sponsor", true).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("sponsor", true, undefined,
+          validation.error === "Transaction must be sponsored" ? "not_sponsored" : "invalid_transaction"
+        ).catch(() => {}));
         if (validation.error === "Malformed transaction payload") {
           const blocked = clientIp ? checkAndRecordMalformed(clientIp) : false;
           if (blocked) {
@@ -245,7 +247,7 @@ export class Sponsor extends BaseEndpoint {
           tier: metadata.tier,
           code: rateLimitResult.code,
         });
-        c.executionCtx.waitUntil(statsService.logFailure("sponsor", true).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("sponsor", true, undefined, "broadcast_rate_limited").catch(() => {}));
         const isDaily = rateLimitResult.code === "DAILY_LIMIT_EXCEEDED";
         return this.err(c, {
           error: isDaily ? "Daily request limit exceeded" : "Rate limit exceeded",
@@ -283,7 +285,7 @@ export class Sponsor extends BaseEndpoint {
           tier: metadata.tier,
           estimatedFee: estimatedFee.toString(),
         });
-        c.executionCtx.waitUntil(statsService.logFailure("sponsor", true).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("sponsor", true, undefined, "broadcast_rate_limited").catch(() => {}));
         return this.err(c, {
           error: "Daily spending cap exceeded",
           code: "SPENDING_CAP_EXCEEDED",
@@ -307,7 +309,7 @@ export class Sponsor extends BaseEndpoint {
         // The tx was NOT added to sender_hand (mode:"immediate" prevents insertion on gap).
         if ("held" in sponsorResult && sponsorResult.held) {
           c.executionCtx.waitUntil(statsService.recordError("validation").catch(() => {}));
-          c.executionCtx.waitUntil(statsService.logFailure("sponsor", true).catch(() => {}));
+          c.executionCtx.waitUntil(statsService.logFailure("sponsor", true, undefined, "sender_nonce_gap").catch(() => {}));
           const senderNonce = Number(validation.transaction.auth.spendingCondition.nonce);
           const queue = buildQueueInfo(sponsorResult, senderNonce);
           logger.warn("Sender nonce gap — rejecting /sponsor request", {
@@ -326,6 +328,7 @@ export class Sponsor extends BaseEndpoint {
             queue,
           }, 400);
         }
+        c.executionCtx.waitUntil(statsService.logFailure("sponsor", false, undefined, "sponsor_failure").catch(() => {}));
         return this.sponsorFailureResponse(
           c,
           sponsorResult as { error: string; details: string; code?: string; retryAfter?: number },
@@ -359,7 +362,7 @@ export class Sponsor extends BaseEndpoint {
         const isClientError = clientRejection !== undefined;
 
         c.executionCtx.waitUntil(statsService.recordError(isClientError ? "validation" : "sponsoring").catch(() => {}));
-        c.executionCtx.waitUntil(statsService.logFailure("sponsor", isClientError).catch(() => {}));
+        c.executionCtx.waitUntil(statsService.logFailure("sponsor", isClientError, undefined, isClientError ? "invalid_transaction" : "broadcast_failure").catch(() => {}));
 
         // Record broadcast outcome in the intent ledger.
         // httpStatus 0 = network/timeout exception (no HTTP response received).
@@ -488,7 +491,7 @@ export class Sponsor extends BaseEndpoint {
         error: e instanceof Error ? e.message : "Unknown error",
       });
       c.executionCtx.waitUntil(statsService.recordError("internal").catch(() => {}));
-      c.executionCtx.waitUntil(statsService.logFailure("sponsor", false).catch(() => {}));
+      c.executionCtx.waitUntil(statsService.logFailure("sponsor", false, undefined, "internal_error").catch(() => {}));
       return this.err(c, {
         error: "Internal server error",
         code: "INTERNAL_ERROR",

--- a/src/endpoints/sponsor.ts
+++ b/src/endpoints/sponsor.ts
@@ -341,7 +341,7 @@ export class Sponsor extends BaseEndpoint {
 
       // Extract token type and transfer amount from the sponsored transaction for accurate
       // stats attribution. Falls back to { tokenType: "STX", amount: "0" } on any error.
-      const { tokenType: txTokenType, amount: txAmount } = extractTransferDetails(sponsoredTx);
+      const { tokenType: txTokenType, amount: txAmount } = extractTransferDetails(sponsoredTx, c.env.STACKS_NETWORK);
 
       // Extract nonce before broadcast so it's available in all failure and success paths
       const sponsorNonce = extractSponsorNonce(sponsoredTx);

--- a/src/endpoints/sponsor.ts
+++ b/src/endpoints/sponsor.ts
@@ -22,7 +22,7 @@ import {
 import { checkAndRecordMalformed, MALFORMED_BLOCK_THRESHOLD } from "../middleware";
 import type { AppContext, Env, Logger, SponsorRequest } from "../types";
 import { buildQueueInfo } from "../types";
-import { buildExplorerUrl, CLIENT_REJECTION_REASONS, getBroadcastTargets, NONCE_CONFLICT_REASONS, stripHexPrefix } from "../utils";
+import { buildExplorerUrl, CLIENT_REJECTION_REASONS, getBroadcastTargets, NONCE_CONFLICT_REASONS, stripHexPrefix, extractTransferDetails } from "../utils";
 import type { BroadcastTarget } from "../utils";
 
 const BROADCAST_MAX_ATTEMPTS = 3;
@@ -336,6 +336,10 @@ export class Sponsor extends BaseEndpoint {
       const cleanHex = stripHexPrefix(sponsorResult.sponsoredTxHex);
       const sponsoredTx = deserializeTransaction(cleanHex);
 
+      // Extract token type and transfer amount from the sponsored transaction for accurate
+      // stats attribution. Falls back to { tokenType: "STX", amount: "0" } on any error.
+      const { tokenType: txTokenType, amount: txAmount } = extractTransferDetails(sponsoredTx);
+
       // Extract nonce before broadcast so it's available in all failure and success paths
       const sponsorNonce = extractSponsorNonce(sponsoredTx);
       // walletIndex from NonceDO assignment — routes release to the correct per-wallet pool
@@ -450,8 +454,8 @@ export class Sponsor extends BaseEndpoint {
           timestamp: new Date().toISOString(),
           endpoint: "sponsor",
           success: true,
-          tokenType: "STX",
-          amount: "0",
+          tokenType: txTokenType,
+          amount: txAmount,
           fee: sponsorResult.fee,
           txid,
           sender: validation.senderAddress,
@@ -462,8 +466,8 @@ export class Sponsor extends BaseEndpoint {
       // Also record usage for the API key (for volume tracking)
       await authService.recordUsage(metadata.keyId, {
         success: true,
-        tokenType: "STX",
-        amount: "0",
+        tokenType: txTokenType,
+        amount: txAmount,
         fee: sponsorResult.fee,
       });
 

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -297,11 +297,11 @@ async function processPaymentMessage(
     // Check for retryable broadcast errors
     const isNonceConflict = broadcastResult.nonceConflict === true;
     const isTooMuchChaining = broadcastResult.tooMuchChaining === true;
+    const isOriginChaining = broadcastResult.isOriginChaining === true;
 
     if ((isNonceConflict || isTooMuchChaining) && attempt < MAX_ATTEMPTS) {
       // Release the sponsor nonce back to pool — no errorReason here so the nonce
-      // expires cleanly without feeding the circuit breaker on every retry attempt.
-      // Quarantine only happens on the terminal path when retries are exhausted.
+      // expires cleanly without penalizing sponsor wallets on every retry attempt.
       if (sponsorNonce !== null) {
         await releaseNonceDO(env, logger, sponsorNonce, undefined, walletIndex);
       }
@@ -310,9 +310,11 @@ async function processPaymentMessage(
         route: "PAYMENT_QUEUE",
         paymentId,
         status: "queued",
-        action: isTooMuchChaining
-          ? "queue_retry_too_much_chaining"
-          : "queue_retry_nonce_conflict",
+        action: isOriginChaining
+          ? "queue_retry_origin_chaining"
+          : isTooMuchChaining
+            ? "queue_retry_too_much_chaining"
+            : "queue_retry_nonce_conflict",
         checkStatusUrlPresent: false,
         compatShimUsed: false,
         attempt,
@@ -321,6 +323,7 @@ async function processPaymentMessage(
         paymentId,
         nonceConflict: isNonceConflict,
         tooMuchChaining: isTooMuchChaining,
+        isOriginChaining,
         attempt,
       });
 
@@ -334,10 +337,13 @@ async function processPaymentMessage(
       return;
     }
 
-    // Terminal broadcast failure — only quarantine for contention-specific conditions.
-    // Generic failures (node 500, timeout) release cleanly to avoid penalizing healthy wallets.
+    // Terminal broadcast failure.
+    // Origin-side TooMuchChaining: release cleanly — the agent's address is congested, not the sponsor.
+    // Sponsor-side TooMuchChaining or nonce conflict: release with error reason for tracking.
+    // Generic failures (node 500, timeout): release cleanly to avoid penalizing healthy wallets.
     if (sponsorNonce !== null) {
-      const reason = isTooMuchChaining ? "TooMuchChaining"
+      const reason = isOriginChaining ? undefined
+        : isTooMuchChaining ? "TooMuchChaining"
         : isNonceConflict ? "nonce_conflict"
         : undefined;
       await releaseNonceDO(env, logger, sponsorNonce, undefined, walletIndex, undefined, reason);
@@ -354,8 +360,9 @@ async function processPaymentMessage(
       errorCode: broadcastResult.clientRejection
         ? `CLIENT_${broadcastResult.clientRejection.toUpperCase()}`
         : "BROADCAST_FAILED",
-      terminalReason:
-        isTooMuchChaining || isNonceConflict
+      terminalReason: isOriginChaining
+        ? "origin_chaining_limit"
+        : (isTooMuchChaining || isNonceConflict)
           ? "sponsor_failure"
           : "broadcast_failure",
       retryable: broadcastResult.retryable,

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -299,7 +299,7 @@ async function processPaymentMessage(
     const isTooMuchChaining = broadcastResult.tooMuchChaining === true;
     const isOriginChaining = broadcastResult.isOriginChaining === true;
 
-    if ((isNonceConflict || isTooMuchChaining) && attempt < MAX_ATTEMPTS) {
+    if ((isNonceConflict || (isTooMuchChaining && !isOriginChaining)) && attempt < MAX_ATTEMPTS) {
       // Release the sponsor nonce back to pool — no errorReason here so the nonce
       // expires cleanly without penalizing sponsor wallets on every retry attempt.
       if (sponsorNonce !== null) {

--- a/src/routes/discovery.ts
+++ b/src/routes/discovery.ts
@@ -847,8 +847,37 @@ This is the canonical sponsor status surface. Reads do not trigger live Hiro fan
 
 ## GET /stats — Relay Statistics
 
-Returns aggregate relay statistics for the last 24h and 7 days.
-Includes transaction counts, token breakdown, fee stats, and settlement health.
+Returns aggregate relay statistics. Public endpoint, cached 15s.
+
+### Response (abridged)
+
+{
+  "success": true,
+  "period": "24h",
+  "transactions": {
+    "total": 1240,
+    "success": 1185,
+    "failed": 55,
+    "clientErrors": 12,           // client-caused (excluded from effectiveSuccessRate)
+    "trend": "up",                // rolling-vs-rolling comparison
+    "rawSuccessRate": 0.956,      // success / total
+    "effectiveSuccessRate": 0.978 // success / (success + relayErrors)
+  },
+  "settlementTimes": {            // gap-fill txs excluded from percentiles
+    "p50": 7800, "p95": 22000, "avg": 9100, "count": 1185
+  },
+  "terminalReasons": {            // tx-schemas 6-category breakdown (today)
+    "validation": 3, "sender": 18, "relay": 7,
+    "settlement": 12, "replacement": 5, "identity": 2
+  },
+  "walletThroughput": [           // per-wallet 24h totals + hourly spark data
+    { "walletIndex": 0, "total24h": 310, "success24h": 298, "feeTotal24h": "3100000",
+      "hourly": [{ "hour": "2026-04-06T11:00:00Z", "total": 14, "success": 13 }] }
+  ],
+  "previous24h": {                // 24-48h window for rolling comparison
+    "total": 1100, "success": 1050, "failed": 50
+  }
+}
 
 ---
 

--- a/src/services/settlement.ts
+++ b/src/services/settlement.ts
@@ -25,20 +25,17 @@ import type {
 } from "../types";
 import { getHiroBaseUrl, getHiroHeaders, getBroadcastTargets, NONCE_CONFLICT_REASONS, CLIENT_REJECTION_REASONS, stripHexPrefix } from "../utils";
 import type { BroadcastTarget } from "../utils";
+import {
+  SBTC_CONTRACT_MAINNET,
+  SBTC_CONTRACT_NAME,
+  USDCX_CIRCLE_CONTRACT_MAINNET,
+  USDCX_CIRCLE_CONTRACT_NAME,
+  USDCX_AEUSDC_CONTRACT_MAINNET,
+  USDCX_AEUSDC_CONTRACT_NAME,
+  SIP010_TRANSFER_FUNCTION,
+} from "../utils/token-contracts";
 import { extractSponsorNonce } from "./sponsor";
 import { waitForHiroTxConfirmationViaStream } from "./hiro-tx-stream";
-
-// Known SIP-010 token contract addresses
-const SBTC_CONTRACT_MAINNET = "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4";
-const SBTC_CONTRACT_NAME = "sbtc-token";
-
-// USDCx — two known mainnet contracts that both represent USDC on Stacks
-const USDCX_CIRCLE_CONTRACT_MAINNET = "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE";
-const USDCX_CIRCLE_CONTRACT_NAME = "usdcx";
-const USDCX_AEUSDC_CONTRACT_MAINNET = "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9";
-const USDCX_AEUSDC_CONTRACT_NAME = "token-aeusdc";
-
-const SIP010_TRANSFER_FUNCTION = "transfer";
 
 // Polling configuration
 /** Default max poll time for confirmation polling.

--- a/src/services/settlement.ts
+++ b/src/services/settlement.ts
@@ -821,15 +821,22 @@ export class SettlementService {
           let errorMessage = `HTTP ${broadcastResponse.status}`;
           let errorDetails = responseText.slice(0, 500);
 
+          // reason_data from stacks-core: includes is_origin for TooMuchChaining/BadNonce
+          type StacksReasonData = { is_origin?: boolean; principal?: string; expected?: number; actual?: number; message?: string };
+          let reasonData: StacksReasonData | undefined;
           try {
             const errorJson = JSON.parse(responseText) as {
               error?: string;
               reason?: string;
               message?: string;
+              reason_data?: StacksReasonData;
             };
             if (errorJson.error || errorJson.reason || errorJson.message) {
               errorMessage = errorJson.error ?? errorJson.message ?? errorMessage;
               errorDetails = errorJson.reason ?? errorDetails;
+            }
+            if (errorJson.reason_data) {
+              reasonData = errorJson.reason_data;
             }
           } catch {
             // Body is not JSON — use raw text as details
@@ -892,21 +899,34 @@ export class SettlementService {
             }
 
             // TooMuchChaining: the sender (sponsor or client) has too many pending txs.
+            // The node's reason_data.is_origin distinguishes origin (sender) vs sponsor triggers.
             // On sponsor-side this is relay congestion — retryable after backoff.
-            // clientRejection is intentionally omitted so stats don't attribute this to the client.
-            // On self-pay this falls through to clientRejection handling below.
+            // On origin-side this is the agent's problem — report back, don't penalize sponsor.
             if (matchedReason === "TooMuchChaining" && sponsorNonceForLog !== null) {
-              this.logger.warn("Sponsor wallet chaining limit hit (TooMuchChaining)", {
-                status: broadcastResponse.status,
-                details: errorDetails,
-                sponsorNonce: sponsorNonceForLog,
-                nodeUrl: target.baseUrl,
-              });
+              const isOrigin = reasonData?.is_origin === true;
+              this.logger.warn(
+                isOrigin
+                  ? "Origin (sender) chaining limit hit (TooMuchChaining)"
+                  : "Sponsor wallet chaining limit hit (TooMuchChaining)",
+                {
+                  status: broadcastResponse.status,
+                  details: errorDetails,
+                  sponsorNonce: sponsorNonceForLog,
+                  isOrigin,
+                  principal: reasonData?.principal,
+                  expected: reasonData?.expected,
+                  actual: reasonData?.actual,
+                  nodeUrl: target.baseUrl,
+                }
+              );
               return {
-                error: "Sponsor wallet congested — too many pending transactions",
+                error: isOrigin
+                  ? "Origin address has too many pending transactions"
+                  : "Sponsor wallet congested — too many pending transactions",
                 details: errorDetails,
-                retryable: true,
+                retryable: !isOrigin,
                 tooMuchChaining: true,
+                isOriginChaining: isOrigin,
                 nodeUrl: target.baseUrl,
                 httpStatus: broadcastResponse.status,
               };

--- a/src/services/sponsor.ts
+++ b/src/services/sponsor.ts
@@ -1551,6 +1551,9 @@ export async function nonceLifecycleOnBroadcastSuccess(
     senderTxHex: string;
     senderAddress: string;
     senderNonce: number;
+    /** ISO timestamp of when the client HTTP request arrived at the relay endpoint.
+     *  Used as the start time for settlement latency measurement. */
+    submittedAt?: string;
   }
 ): Promise<void> {
   // Record broadcast outcome FIRST so ledgerBroadcastOutcome() runs while state is
@@ -1573,7 +1576,8 @@ export async function nonceLifecycleOnBroadcastSuccess(
       env, logger, opts.walletIndex,
       opts.senderTxHex, opts.senderAddress,
       opts.senderNonce, opts.sponsorNonce,
-      opts.fee ?? null
+      opts.fee ?? null,
+      opts.submittedAt ?? null
     ),
   ]).catch((e) => {
     logger.warn("Failed nonce lifecycle after broadcast success", { error: String(e) });
@@ -1588,7 +1592,8 @@ export async function queueDispatchDO(
   senderAddress: string,
   senderNonce: number,
   sponsorNonce: number,
-  fee?: string | null
+  fee?: string | null,
+  submittedAt?: string | null
 ): Promise<void> {
   if (!env.NONCE_DO) {
     return;
@@ -1605,6 +1610,7 @@ export async function queueDispatchDO(
         senderNonce,
         sponsorNonce,
         fee: fee ?? null,
+        submittedAt: submittedAt ?? null,
       }),
     });
     if (!response.ok) {

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -8,6 +8,22 @@ import type {
   RelayEndpointName,
   TransactionLogEntry,
 } from "../types";
+import type { TerminalReason } from "@aibtc/tx-schemas/core/terminal-reasons";
+
+/**
+ * Maps a legacy 5-bucket ErrorCategory to a representative terminal reason.
+ * Used for backward-compat when the specific reason is unknown at the call site.
+ * Callers that know the specific reason should pass it directly to logFailure().
+ */
+export function legacyErrorCategoryToTerminalReason(category: ErrorCategory): TerminalReason {
+  switch (category) {
+    case "validation": return "invalid_transaction";
+    case "rateLimit": return "broadcast_rate_limited";
+    case "sponsoring": return "sponsor_failure";
+    case "settlement": return "broadcast_failure";
+    case "internal": return "internal_error";
+  }
+}
 
 /**
  * Calculate trend based on current vs previous values
@@ -142,11 +158,15 @@ export class StatsService {
   /**
    * Log a failed transaction with common defaults (timestamp, success:false, status:"failed").
    * Reduces boilerplate at each error-path call site.
+   *
+   * @param terminalReason - Optional terminal reason from @aibtc/tx-schemas TERMINAL_REASONS.
+   *   When provided, StatsDO increments the matching category column in daily_stats.
    */
   async logFailure(
     endpoint: RelayEndpointName,
     clientError: boolean,
-    opts?: { tokenType?: TokenType; amount?: string; fee?: string; sender?: string; recipient?: string }
+    opts?: { tokenType?: TokenType; amount?: string; fee?: string; sender?: string; recipient?: string },
+    terminalReason?: TerminalReason
   ): Promise<void> {
     await this.logTransaction({
       timestamp: new Date().toISOString(),
@@ -159,6 +179,7 @@ export class StatsService {
       fee: opts?.fee,
       sender: opts?.sender,
       recipient: opts?.recipient,
+      terminalReason,
     });
   }
 

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -7,6 +7,7 @@ import type {
   ErrorCategory,
   RelayEndpointName,
   TransactionLogEntry,
+  WalletHourlyPoint,
 } from "../types";
 import type { TerminalReason } from "@aibtc/tx-schemas/core/terminal-reasons";
 
@@ -264,6 +265,16 @@ export class StatsService {
     return (await this.doGet<
       Array<{ hour: string; transactions: number; success: number; fees?: string }>
     >("/hourly")) ?? [];
+  }
+
+  /**
+   * Get per-wallet hourly stats for a given wallet index and window.
+   * Useful for per-wallet throughput spark charts.
+   */
+  async getWalletHourlyStats(walletIndex: number, hours: number = 24): Promise<WalletHourlyPoint[]> {
+    return (await this.doGet<WalletHourlyPoint[]>(
+      `/wallet-hourly?walletIndex=${walletIndex}&hours=${hours}`
+    )) ?? [];
   }
 
   /**

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -7,24 +7,8 @@ import type {
   ErrorCategory,
   RelayEndpointName,
   TransactionLogEntry,
-  WalletHourlyPoint,
 } from "../types";
 import type { TerminalReason } from "@aibtc/tx-schemas/core/terminal-reasons";
-
-/**
- * Maps a legacy 5-bucket ErrorCategory to a representative terminal reason.
- * Used for backward-compat when the specific reason is unknown at the call site.
- * Callers that know the specific reason should pass it directly to logFailure().
- */
-export function legacyErrorCategoryToTerminalReason(category: ErrorCategory): TerminalReason {
-  switch (category) {
-    case "validation": return "invalid_transaction";
-    case "rateLimit": return "broadcast_rate_limited";
-    case "sponsoring": return "sponsor_failure";
-    case "settlement": return "broadcast_failure";
-    case "internal": return "internal_error";
-  }
-}
 
 /**
  * Calculate trend based on current vs previous values
@@ -265,16 +249,6 @@ export class StatsService {
     return (await this.doGet<
       Array<{ hour: string; transactions: number; success: number; fees?: string }>
     >("/hourly")) ?? [];
-  }
-
-  /**
-   * Get per-wallet hourly stats for a given wallet index and window.
-   * Useful for per-wallet throughput spark charts.
-   */
-  async getWalletHourlyStats(walletIndex: number, hours: number = 24): Promise<WalletHourlyPoint[]> {
-    return (await this.doGet<WalletHourlyPoint[]>(
-      `/wallet-hourly?walletIndex=${walletIndex}&hours=${hours}`
-    )) ?? [];
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -890,6 +890,15 @@ export interface DailyStats {
     settlement: number;
     internal: number;
   };
+  /** Terminal reason category counts for the day (tx-schemas alignment) */
+  terminalReasons?: {
+    validation: number;
+    sender: number;
+    relay: number;
+    settlement: number;
+    replacement: number;
+    identity: number;
+  };
   /** Fee statistics for the day */
   fees?: FeeStats;
 }
@@ -959,6 +968,19 @@ export interface DashboardOverview {
   apiKeys?: AggregateKeyStats;
   /** Per-endpoint transaction breakdown (today's calendar-day counters) */
   endpointBreakdown?: EndpointBreakdown;
+  /**
+   * Error counts grouped by tx-schemas terminal reason category (rolling 24h).
+   * Additive alongside legacy `errors` object — both are present for backward compat.
+   * Categories: validation, sender, relay, settlement, replacement, identity
+   */
+  terminalReasons?: {
+    validation: number;
+    sender: number;
+    relay: number;
+    settlement: number;
+    replacement: number;
+    identity: number;
+  };
 }
 
 /**
@@ -1039,6 +1061,12 @@ export interface TransactionLogEntry {
    * allowing the relay success rate to exclude client-caused failures.
    */
   clientError?: boolean;
+  /**
+   * Terminal reason for this failure from @aibtc/tx-schemas TERMINAL_REASONS.
+   * Present only on failed transactions where the reason is known.
+   * Examples: "invalid_transaction", "sponsor_failure", "broadcast_failure", "chain_abort"
+   */
+  terminalReason?: string;
 }
 
 // =============================================================================
@@ -1100,7 +1128,7 @@ export interface WalletsResponse {
 }
 
 /**
- * Error categories for metrics tracking
+ * Error categories for metrics tracking (legacy — kept for backward compatibility)
  */
 export type ErrorCategory =
   | "validation"
@@ -1108,6 +1136,19 @@ export type ErrorCategory =
   | "sponsoring"
   | "settlement"
   | "internal";
+
+/**
+ * Terminal reason categories from @aibtc/tx-schemas.
+ * Six categories that group the 19 terminal reasons.
+ * Matches TERMINAL_REASON_CATEGORIES in "@aibtc/tx-schemas/core/terminal-reasons".
+ */
+export type TerminalReasonCategory =
+  | "validation"
+  | "sender"
+  | "relay"
+  | "settlement"
+  | "replacement"
+  | "identity";
 
 // =============================================================================
 // Fee Estimation Types

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { Context } from "hono";
+import type { TerminalReason } from "@aibtc/tx-schemas/core/terminal-reasons";
 
 /**
  * LogsRPC interface (from worker-logs service)
@@ -1103,7 +1104,7 @@ export interface TransactionLogEntry {
    * Present only on failed transactions where the reason is known.
    * Examples: "invalid_transaction", "sponsor_failure", "broadcast_failure", "chain_abort"
    */
-  terminalReason?: string;
+  terminalReason?: TerminalReason;
 }
 
 // =============================================================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -1244,6 +1244,10 @@ export type BroadcastAndConfirmResult =
       nonceConflict?: boolean;
       /** Sponsor wallet hit TooMuchChaining — relay-side congestion, retryable after backoff */
       tooMuchChaining?: boolean;
+      /** True when TooMuchChaining was triggered by the origin (sender) address, not the sponsor.
+       *  Parsed from the node's `reason_data.is_origin` field. When true, the relay should NOT
+       *  penalize the sponsor wallet — the agent's address has too many pending transactions. */
+      isOriginChaining?: boolean;
       /** Matched Stacks node rejection reason (e.g. "NotEnoughFunds") when the 4xx
        *  rejection was caused by the client submitting an invalid transaction. */
       clientRejection?: string;
@@ -1263,6 +1267,7 @@ export type BroadcastOnlyResult =
       retryable: boolean;
       nonceConflict?: boolean;
       tooMuchChaining?: boolean;
+      isOriginChaining?: boolean;
       clientRejection?: string;
       nodeUrl?: string;
       httpStatus?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -993,7 +993,7 @@ export interface DashboardOverview {
   /** Per-endpoint transaction breakdown (today's calendar-day counters) */
   endpointBreakdown?: EndpointBreakdown;
   /**
-   * Error counts grouped by tx-schemas terminal reason category (rolling 24h).
+   * Error counts grouped by tx-schemas terminal reason category (today, calendar day UTC).
    * Additive alongside legacy `errors` object — both are present for backward compat.
    * Categories: validation, sender, relay, settlement, replacement, identity
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -927,6 +927,25 @@ export interface EndpointBreakdown {
   verify: { total: number };
 }
 
+/** Hourly data point for per-wallet throughput spark chart */
+export interface WalletHourlyPoint {
+  hour: string;
+  total: number;
+  success: number;
+  failed: number;
+  feeTotal: string;
+}
+
+/** Per-wallet 24h throughput summary with hourly spark data */
+export interface WalletThroughputEntry {
+  walletIndex: number;
+  total24h: number;
+  success24h: number;
+  failed24h: number;
+  feeTotal24h: string;
+  hourly: WalletHourlyPoint[];
+}
+
 export interface DashboardOverview {
   period: "24h" | "7d";
   transactions: {
@@ -937,6 +956,10 @@ export interface DashboardOverview {
     previousTotal: number;
     /** Number of failures caused by client errors in the rolling 24h window */
     clientErrors?: number;
+    /** Raw success rate = success / total (includes client errors in denominator). 0-1 range. */
+    rawSuccessRate?: number;
+    /** Effective success rate = success / (success + relayErrors) — excludes client errors from denominator. 0-1 range. */
+    effectiveSuccessRate?: number;
   };
   tokens: {
     STX: TokenStats;
@@ -980,6 +1003,20 @@ export interface DashboardOverview {
     settlement: number;
     replacement: number;
     identity: number;
+  };
+  /**
+   * Per-wallet 24h throughput totals with hourly spark data.
+   * Only includes wallets that had at least one transaction in the last 24h.
+   */
+  walletThroughput?: WalletThroughputEntry[];
+  /**
+   * Rolling 24-48h window totals for trend comparison (previous 24h period).
+   * Used for rolling-vs-rolling trend calculation instead of calendar day comparison.
+   */
+  previous24h?: {
+    total: number;
+    success: number;
+    failed: number;
   };
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,3 +13,5 @@ export type {
   PaymentLifecycleLogContext,
 } from "./payment-events";
 export { NONCE_CONFLICT_REASONS, CLIENT_REJECTION_REASONS, stripHexPrefix, decodeClarityUint } from "./stacks";
+export { extractTransferDetails } from "./tx-decode";
+export type { TransferDetails } from "./tx-decode";

--- a/src/utils/token-contracts.ts
+++ b/src/utils/token-contracts.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared SIP-010 token contract constants.
+ *
+ * Used by both settlement verification (settlement.ts) and transaction
+ * payload decoding (tx-decode.ts) to identify known token contracts.
+ */
+
+// sBTC
+export const SBTC_CONTRACT_MAINNET = "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4";
+export const SBTC_CONTRACT_NAME = "sbtc-token";
+
+// USDCx — two known mainnet contracts that both represent USDC on Stacks
+export const USDCX_CIRCLE_CONTRACT_MAINNET = "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE";
+export const USDCX_CIRCLE_CONTRACT_NAME = "usdcx";
+export const USDCX_AEUSDC_CONTRACT_MAINNET = "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9";
+export const USDCX_AEUSDC_CONTRACT_NAME = "token-aeusdc";
+
+// SIP-010 transfer function name
+export const SIP010_TRANSFER_FUNCTION = "transfer";

--- a/src/utils/tx-decode.ts
+++ b/src/utils/tx-decode.ts
@@ -15,16 +15,14 @@ import {
   type ClarityValue,
 } from "@stacks/transactions";
 import type { TokenType } from "../types";
-
-// Known SIP-010 token contract addresses (mirrors settlement.ts)
-const SBTC_CONTRACT_NAME = "sbtc-token";
-
-const USDCX_CIRCLE_CONTRACT_MAINNET = "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE";
-const USDCX_CIRCLE_CONTRACT_NAME = "usdcx";
-const USDCX_AEUSDC_CONTRACT_MAINNET = "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9";
-const USDCX_AEUSDC_CONTRACT_NAME = "token-aeusdc";
-
-const SIP010_TRANSFER_FUNCTION = "transfer";
+import {
+  SBTC_CONTRACT_NAME,
+  USDCX_CIRCLE_CONTRACT_MAINNET,
+  USDCX_CIRCLE_CONTRACT_NAME,
+  USDCX_AEUSDC_CONTRACT_MAINNET,
+  USDCX_AEUSDC_CONTRACT_NAME,
+  SIP010_TRANSFER_FUNCTION,
+} from "./token-contracts";
 
 /**
  * Result of extracting transfer details from a deserialized transaction.

--- a/src/utils/tx-decode.ts
+++ b/src/utils/tx-decode.ts
@@ -1,0 +1,135 @@
+/**
+ * Transaction payload decode utilities.
+ *
+ * Extracts token type and transfer amount from a deserialized Stacks transaction
+ * without requiring full payment verification. Used by /sponsor to record accurate
+ * token attribution in stats rather than falling back to STX/0.
+ */
+import {
+  PayloadType,
+  ClarityType,
+  addressToString,
+  type StacksTransactionWire,
+  type AddressWire,
+  type LengthPrefixedStringWire,
+  type ClarityValue,
+} from "@stacks/transactions";
+import type { TokenType } from "../types";
+
+// Known SIP-010 token contract addresses (mirrors settlement.ts)
+const SBTC_CONTRACT_NAME = "sbtc-token";
+
+const USDCX_CIRCLE_CONTRACT_MAINNET = "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE";
+const USDCX_CIRCLE_CONTRACT_NAME = "usdcx";
+const USDCX_AEUSDC_CONTRACT_MAINNET = "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9";
+const USDCX_AEUSDC_CONTRACT_NAME = "token-aeusdc";
+
+const SIP010_TRANSFER_FUNCTION = "transfer";
+
+/**
+ * Result of extracting transfer details from a deserialized transaction.
+ */
+export interface TransferDetails {
+  tokenType: TokenType;
+  amount: string;
+}
+
+/** Fallback for unrecognized or unparseable payloads. */
+const FALLBACK: TransferDetails = { tokenType: "STX", amount: "0" };
+
+/**
+ * Detect whether a contract is a known sBTC contract.
+ *
+ * On mainnet, sBTC has a fixed deployer address. On testnet, any deployer can
+ * deploy sbtc-token, so we match by contract name only (same approach as
+ * settlement.ts matchTokenContract in testnet mode).
+ */
+function isKnownSbtc(contractName: string): boolean {
+  return contractName === SBTC_CONTRACT_NAME;
+}
+
+/**
+ * Detect whether a contract is a known USDCx contract.
+ *
+ * Accepts both mainnet deployer+name pairs and testnet lookalikes by name.
+ */
+function isKnownUsdcx(address: string, contractName: string): boolean {
+  const upper = address.toUpperCase();
+  // Exact mainnet match
+  if (
+    (upper === USDCX_CIRCLE_CONTRACT_MAINNET && contractName === USDCX_CIRCLE_CONTRACT_NAME) ||
+    (upper === USDCX_AEUSDC_CONTRACT_MAINNET && contractName === USDCX_AEUSDC_CONTRACT_NAME)
+  ) {
+    return true;
+  }
+  // Testnet fallback: match by contract name only
+  return contractName === USDCX_CIRCLE_CONTRACT_NAME || contractName === USDCX_AEUSDC_CONTRACT_NAME;
+}
+
+/**
+ * Extract token type and transfer amount from a deserialized Stacks transaction.
+ *
+ * Handles:
+ * - TokenTransfer (STX): reads amount directly from payload
+ * - ContractCall with known SIP-010 transfer function: reads amount from functionArgs[0]
+ * - Fallback for unrecognized payloads: returns { tokenType: "STX", amount: "0" }
+ *
+ * Never throws — all extraction is wrapped in try/catch.
+ */
+export function extractTransferDetails(tx: StacksTransactionWire): TransferDetails {
+  try {
+    const payloadType = tx.payload.payloadType;
+
+    if (payloadType === PayloadType.TokenTransfer) {
+      // STX transfer: amount is a bigint in @stacks/transactions v7+
+      const amount = (tx.payload.amount as bigint).toString();
+      return { tokenType: "STX", amount };
+    }
+
+    if (payloadType === PayloadType.ContractCall) {
+      // Extract contract identity
+      const contractAddress = addressToString(
+        tx.payload.contractAddress as unknown as AddressWire
+      );
+      const contractName = (
+        tx.payload.contractName as unknown as LengthPrefixedStringWire
+      ).content;
+      const functionName = (
+        tx.payload.functionName as unknown as LengthPrefixedStringWire
+      ).content;
+
+      // Only support SIP-010 transfer function for token identification
+      if (functionName !== SIP010_TRANSFER_FUNCTION) {
+        return FALLBACK;
+      }
+
+      // Determine token type
+      let tokenType: TokenType;
+      if (isKnownSbtc(contractName)) {
+        tokenType = "sBTC";
+      } else if (isKnownUsdcx(contractAddress, contractName)) {
+        tokenType = "USDCx";
+      } else {
+        // Unrecognized token contract — fall back
+        return FALLBACK;
+      }
+
+      // SIP-010 transfer args: [amount (uint), from (principal), to (principal), memo (optional)]
+      const args = tx.payload.functionArgs as ClarityValue[];
+      if (!args || args.length < 1) {
+        return { tokenType, amount: "0" };
+      }
+
+      const amountCV = args[0];
+      if (amountCV.type !== ClarityType.UInt) {
+        return { tokenType, amount: "0" };
+      }
+
+      return { tokenType, amount: String(amountCV.value) };
+    }
+
+    return FALLBACK;
+  } catch {
+    return FALLBACK;
+  }
+}

--- a/src/utils/tx-decode.ts
+++ b/src/utils/tx-decode.ts
@@ -16,6 +16,7 @@ import {
 } from "@stacks/transactions";
 import type { TokenType } from "../types";
 import {
+  SBTC_CONTRACT_MAINNET,
   SBTC_CONTRACT_NAME,
   USDCX_CIRCLE_CONTRACT_MAINNET,
   USDCX_CIRCLE_CONTRACT_NAME,
@@ -38,22 +39,25 @@ const FALLBACK: TransferDetails = { tokenType: "STX", amount: "0" };
 /**
  * Detect whether a contract is a known sBTC contract.
  *
- * On mainnet, sBTC has a fixed deployer address. On testnet, any deployer can
- * deploy sbtc-token, so we match by contract name only (same approach as
- * settlement.ts matchTokenContract in testnet mode).
+ * On mainnet, sBTC has a fixed deployer address — require address+name match.
+ * On testnet, any deployer can deploy sbtc-token, so match by name only
+ * (mirrors settlement.ts matchTokenContract behavior).
  */
-function isKnownSbtc(contractName: string): boolean {
-  return contractName === SBTC_CONTRACT_NAME;
+function isKnownSbtc(address: string, contractName: string, network: "mainnet" | "testnet"): boolean {
+  if (contractName !== SBTC_CONTRACT_NAME) return false;
+  if (network === "mainnet") return address.toUpperCase() === SBTC_CONTRACT_MAINNET;
+  return true;
 }
 
 /**
  * Detect whether a contract is a known USDCx contract.
  *
- * Accepts both mainnet deployer+name pairs and testnet lookalikes by name.
+ * On mainnet, require exact deployer+name pair match.
+ * On testnet, allow name-only matching for any deployer.
  */
-function isKnownUsdcx(address: string, contractName: string): boolean {
+function isKnownUsdcx(address: string, contractName: string, network: "mainnet" | "testnet"): boolean {
   const upper = address.toUpperCase();
-  // Exact mainnet match
+  // Exact mainnet deployer+name match
   if (
     (upper === USDCX_CIRCLE_CONTRACT_MAINNET && contractName === USDCX_CIRCLE_CONTRACT_NAME) ||
     (upper === USDCX_AEUSDC_CONTRACT_MAINNET && contractName === USDCX_AEUSDC_CONTRACT_NAME)
@@ -61,7 +65,10 @@ function isKnownUsdcx(address: string, contractName: string): boolean {
     return true;
   }
   // Testnet fallback: match by contract name only
-  return contractName === USDCX_CIRCLE_CONTRACT_NAME || contractName === USDCX_AEUSDC_CONTRACT_NAME;
+  if (network === "testnet") {
+    return contractName === USDCX_CIRCLE_CONTRACT_NAME || contractName === USDCX_AEUSDC_CONTRACT_NAME;
+  }
+  return false;
 }
 
 /**
@@ -73,8 +80,11 @@ function isKnownUsdcx(address: string, contractName: string): boolean {
  * - Fallback for unrecognized payloads: returns { tokenType: "STX", amount: "0" }
  *
  * Never throws — all extraction is wrapped in try/catch.
+ *
+ * @param tx - Deserialized Stacks transaction
+ * @param network - Network context for token contract matching (mainnet requires deployer address)
  */
-export function extractTransferDetails(tx: StacksTransactionWire): TransferDetails {
+export function extractTransferDetails(tx: StacksTransactionWire, network: "mainnet" | "testnet" = "testnet"): TransferDetails {
   try {
     const payloadType = tx.payload.payloadType;
 
@@ -103,9 +113,9 @@ export function extractTransferDetails(tx: StacksTransactionWire): TransferDetai
 
       // Determine token type
       let tokenType: TokenType;
-      if (isKnownSbtc(contractName)) {
+      if (isKnownSbtc(contractAddress, contractName, network)) {
         tokenType = "sBTC";
-      } else if (isKnownUsdcx(contractAddress, contractName)) {
+      } else if (isKnownUsdcx(contractAddress, contractName, network)) {
         tokenType = "USDCx";
       } else {
         // Unrecognized token contract — fall back


### PR DESCRIPTION
## Summary

Rebuilds the relay dashboard and `/stats` API on top of `@aibtc/tx-schemas` as the canonical data model. Fixes 7 critical metric bugs that made the dashboard misleading, adds new operational visibility, and improves query performance.

### Data layer fixes (Phases 1-3)
- **Settlement time**: Added `submitted_at` column to track actual client request arrival time. Gap-fill entries tagged with `is_gap_fill` and excluded from percentiles. Fixes times showing 3-5 days instead of 10-60 seconds.
- **Token attribution**: `/sponsor` endpoint now extracts actual token type and amount from transaction payloads via new `extractTransferDetails()` utility, instead of hardcoding `STX/0`.
- **Fee time windows**: Fee min/max now derived from rolling 24h `hourly_stats` instead of mixing calendar-day `daily_stats`, ensuring consistent time windows across all fee metrics.
- **Error categorization**: Replaced 5 crude error buckets with tx-schemas' 19 terminal reasons across 6 categories. `/stats` returns `terminalReasons` alongside legacy `errors` for backward compatibility.

### New operational features (Phase 4)
- **Wallet throughput**: Per-wallet hourly transaction history (`wallet_hourly` table) with sparkline data in `/stats`.
- **Dual success rates**: Both `rawSuccessRate` (includes client errors) and `effectiveSuccessRate` (relay-only) exposed in API.
- **Rolling comparison**: Previous 24h period for trend calculation instead of calendar-day (apples-to-apples).

### Dashboard UI (Phase 5)
- Terminal reason breakdown card grouped by category with color coding
- Wallet throughput card with per-wallet sparklines
- Fees detail card with consistent rolling 24h min/max/avg/total
- Dual success rates displayed prominently

### Code quality (review pass)
- **perf**: Eliminated N+1 query patterns in StatsDO (289 queries → 4 range queries per overview)
- **fix**: Threaded `walletIndex` into success log entries (wallet throughput was empty for successes)
- **fix**: Added missing `lg:grid-cols-4` CSS breakpoint and `bg-opacity-50` utility
- **refactor**: Deduplicated token contract constants into `src/utils/token-contracts.ts`
- **refactor**: Strengthened `terminalReason` type from `string` to `TerminalReason`
- **cleanup**: Removed dead exports (`feesSpentCard`, `legacyErrorCategoryToTerminalReason`, `getWalletHourlyStats`)

## Test plan

- [ ] `npm run check` passes (verified)
- [ ] `npm run deploy:dry-run` succeeds
- [ ] Deploy to staging and verify `/stats` response includes new fields (`terminalReasons`, `walletThroughput`, `rawSuccessRate`, `effectiveSuccessRate`, `previous24h`)
- [ ] Verify `/dashboard` renders: settlement time card, terminal reason breakdown, wallet throughput sparklines, dual success rates, fees detail card
- [ ] Submit test transactions via `npm run test:relay` and `npm run test:sponsor` and verify wallet throughput populates
- [ ] Verify legacy `/stats` consumers still work (additive changes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)