### PR TITLE
fix(deps): pin lodash transitive dependency to 4.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "vitest": "^4.0.18",
     "wrangler": "^4.75.0"
   },
+  "overrides": {
+    "lodash": "4.18.1"
+  },
   "dependencies": {
     "@aibtc/tx-schemas": "^0.4.0",
     "@noble/curves": "^2.0.1",


### PR DESCRIPTION
## Summary

- Adds `overrides.lodash` in `package.json` to pin the transitive dep at 4.18.1
- Ensures future `npm install` won't regress below the CVE-2026-4800 fix
- Extracted from #300 (updated to 4.18.1 to match Dependabot's #299)

## Test plan

- [ ] `npm install` resolves lodash to 4.18.1
- [ ] `npm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)