### PR TITLE
fix(health): derive status from nonce pool health

### DIFF
--- a/src/__tests__/health.test.ts
+++ b/src/__tests__/health.test.ts
@@ -12,4 +12,36 @@ describe("Health schema", () => {
     expect(properties).toHaveProperty("version");
     expect(properties).not.toHaveProperty("nonce");
   });
+
+  it("status field documents ok and degraded enum values", () => {
+    const endpoint = new Health();
+    const statusProp =
+      endpoint.schema.responses["200"].content["application/json"].schema.properties.status;
+    expect(statusProp.enum).toEqual(["ok", "degraded"]);
+  });
+});
+
+/**
+ * Tests for the status derivation logic used in Health.handle().
+ *
+ * The handler derives status from poolHealthy (boolean | null):
+ * - poolHealthy === false → "degraded"
+ * - poolHealthy === true or null (unavailable) → "ok"
+ */
+describe("Health status derivation", () => {
+  function deriveStatus(poolHealthy: boolean | null): "ok" | "degraded" {
+    return poolHealthy === false ? "degraded" : "ok";
+  }
+
+  it("returns 'ok' when pool is healthy", () => {
+    expect(deriveStatus(true)).toBe("ok");
+  });
+
+  it("returns 'degraded' when pool is unhealthy", () => {
+    expect(deriveStatus(false)).toBe("degraded");
+  });
+
+  it("returns 'ok' when pool state is unavailable (null)", () => {
+    expect(deriveStatus(null)).toBe("ok");
+  });
 });

--- a/src/endpoints/health.ts
+++ b/src/endpoints/health.ts
@@ -5,6 +5,10 @@ import { VERSION } from "../version";
 /**
  * Health check endpoint
  * GET /health
+ *
+ * Top-level `status` reflects nonce pool health so consumers checking
+ * `status === "ok"` correctly detect an unhealthy relay without digging
+ * into /nonce/state fields.
  */
 export class Health extends BaseEndpoint {
   schema = {
@@ -26,7 +30,15 @@ export class Health extends BaseEndpoint {
                   format: "uuid",
                   description: "Unique request identifier for tracking",
                 },
-                status: { type: "string" as const, example: "ok" },
+                status: {
+                  type: "string" as const,
+                  enum: ["ok", "degraded"],
+                  description:
+                    "'ok' when the nonce pool is healthy, 'degraded' when the pool reports unhealthy " +
+                    "(circuit breaker open, gaps detected, or low capacity). " +
+                    "Consumers should treat any non-'ok' value as unhealthy.",
+                  example: "ok",
+                },
                 network: { type: "string" as const, example: "testnet" },
                 version: { type: "string" as const, example: VERSION },
               },
@@ -38,8 +50,25 @@ export class Health extends BaseEndpoint {
   };
 
   async handle(c: AppContext) {
+    let poolHealthy: boolean | null = null;
+
+    if (c.env.NONCE_DO) {
+      try {
+        const stub = c.env.NONCE_DO.get(c.env.NONCE_DO.idFromName("sponsor"));
+        const response = await stub.fetch("https://nonce-do/nonce-state");
+        if (response.ok) {
+          const state = (await response.json()) as { healthy?: boolean };
+          poolHealthy = state.healthy ?? null;
+        }
+      } catch {
+        // Coordinator unreachable — stay "ok", logged separately by /nonce/state
+      }
+    }
+
+    const status = poolHealthy === false ? "degraded" : "ok";
+
     return this.ok(c, {
-      status: "ok",
+      status,
       network: c.env.STACKS_NETWORK,
       version: VERSION,
     });


### PR DESCRIPTION
## Summary

- `/health` status now reflects actual nonce pool health instead of hardcoded `"ok"`
- Returns `"degraded"` when the pool reports unhealthy (circuit breaker, gaps, low capacity)
- Gracefully stays `"ok"` when the coordinator is unreachable
- Adds tests for status derivation logic and schema enum documentation

Extracted from #300 (health endpoint changes only, separated from the lodash fix).

## Test plan

- [x] `npm run check` passes
- [x] All 92 tests pass (5 health tests including 3 new derivation tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)