### PR TITLE
fix(nonce): move Hiro fetches outside blockConcurrencyWhile to prevent cold start crashes (closes #324)

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -3785,6 +3785,54 @@ export class NonceDO {
       throw new Error("Missing sponsor address");
     }
 
+    // -------------------------------------------------------------------------
+    // Phase 1 (outside lock): Pre-fetch Hiro nonce data for any wallets that
+    // need initialization or whose lookahead-guard cache has expired. Hiro I/O
+    // must NOT happen inside blockConcurrencyWhile — with N wallets, sequential
+    // fetches inside the lock can exceed Cloudflare's ~30 s limit.
+    // -------------------------------------------------------------------------
+
+    // Compute effectiveWalletCount from in-memory SQL state (no I/O).
+    const storedDynamicPre = this.getStateValue("dynamic_wallet_count");
+    const effectiveWalletCountPre = Math.max(
+      1,
+      Math.min(
+        Math.max(walletCount, storedDynamicPre ?? 0),
+        this.getSponsorWalletMax()
+      )
+    );
+    const resolveAddressPre = (wi: number): string =>
+      addresses?.[String(wi)] ?? sponsorAddress;
+
+    // Collect wallet indices that need a fresh Hiro fetch:
+    //   - unseeded (ledgerGetWalletHead === null): must fetch to initialize
+    //   - lookahead cache expired or missing: needed for stale-head / cap guards
+    const walletsFetchNeeded: number[] = [];
+    for (let i = 0; i < effectiveWalletCountPre; i++) {
+      const needsSeed = this.ledgerGetWalletHead(i) === null;
+      const cached = this.hiroNonceCache.get(i);
+      const cacheExpired = !cached || Date.now() >= cached.expiresAt;
+      if (needsSeed || cacheExpired) {
+        walletsFetchNeeded.push(i);
+      }
+    }
+
+    // Pre-fetch in parallel — null entry means Hiro was unreachable for that wallet.
+    const prefetchMap = new Map<number, HiroNonceInfo | null>();
+    await Promise.all(
+      walletsFetchNeeded.map(async (wi) => {
+        try {
+          const info = await this.fetchNonceInfo(resolveAddressPre(wi));
+          prefetchMap.set(wi, info);
+        } catch (_e) {
+          prefetchMap.set(wi, null);
+        }
+      })
+    );
+
+    // -------------------------------------------------------------------------
+    // Phase 2 (inside lock): All state reads and mutations. No Hiro I/O.
+    // -------------------------------------------------------------------------
     return this.state.blockConcurrencyWhile(async () => {
       const currentAlarm = await this.state.storage.getAlarm();
       if (currentAlarm === null) {
@@ -3809,13 +3857,44 @@ export class NonceDO {
       const resolveAddress = (wi: number): string =>
         addresses?.[String(wi)] ?? sponsorAddress;
 
+      // Seed any uninitialized wallets from the pre-fetched data (no Hiro I/O here).
+      // If a wallet's pre-fetch failed (null), initWalletHeadFromHiro will attempt a live
+      // fetch as a fallback — this is intentional; cold-start is the rare path.
+      for (let i = 0; i < effectiveWalletCount; i++) {
+        if (this.ledgerGetWalletHead(i) === null) {
+          const prefetched = prefetchMap.get(i);
+          if (prefetched) {
+            // Apply pre-fetched seed directly without a Hiro call.
+            this.ledgerAdvanceWalletHead(i, prefetched.possible_next_nonce);
+            this.advanceChainFrontier(i, prefetched.possible_next_nonce);
+            this.hiroNonceCache.set(i, {
+              value: prefetched.possible_next_nonce,
+              expiresAt: Date.now() + HIRO_NONCE_CACHE_TTL_MS,
+            });
+          } else {
+            // Pre-fetch failed or was not attempted — fall back to live fetch.
+            // This path only triggers on genuine cold-start with Hiro unreachable.
+            await this.initWalletHeadFromHiro(i, resolveAddress(i));
+          }
+        } else {
+          // Wallet already seeded — update cache from pre-fetched data if available.
+          const prefetched = prefetchMap.get(i);
+          if (prefetched) {
+            this.hiroNonceCache.set(i, {
+              value: prefetched.possible_next_nonce,
+              expiresAt: Date.now() + HIRO_NONCE_CACHE_TTL_MS,
+            });
+            this.advanceChainFrontier(i, prefetched.possible_next_nonce);
+          }
+        }
+      }
+
       // Scan all wallets and select the one with the most available headroom.
       // No degradation flags — per-nonce occupied tracking handles conflicts.
       let totalMempoolDepth = 0;
       const eligibleWallets: Array<{ walletIndex: number; headroom: number }> = [];
 
       for (let i = 0; i < effectiveWalletCount; i++) {
-        await this.initWalletHeadFromHiro(i, resolveAddress(i));
         const headroom = this.walletHeadroom(i);
         if (headroom > 0) {
           eligibleWallets.push({ walletIndex: i, headroom });
@@ -3851,8 +3930,9 @@ export class NonceDO {
       // Store the per-wallet sponsor address (used by alarm reconciliation)
       await this.setStoredSponsorAddressForWallet(walletIndex, resolveAddress(walletIndex));
 
-      // Fetch current Hiro possible_next_nonce (with 30s cache) for stale-head guard.
-      // Also used by lookahead cap guard below. Fail-open: null means Hiro unreachable.
+      // Retrieve current Hiro possible_next_nonce from cache (populated during pre-fetch).
+      // fetchNextNonceForWallet checks the cache first and avoids a live Hiro call when
+      // the cache is warm (pre-fetched above). Fail-open: null means Hiro unreachable.
       const walletAddr = resolveAddress(walletIndex);
       const hiroNextNonce = await this.fetchNextNonceForWallet(walletIndex, walletAddr);
 
@@ -4993,12 +5073,19 @@ export class NonceDO {
   private async reconcileNonceForWallet(
     walletIndex: number,
     sponsorAddress: string,
+    prefetchedNonceInfo?: HiroNonceInfo | null,
   ): Promise<ReconcileResult | null> {
     let nonceInfo: HiroNonceInfo;
-    try {
-      nonceInfo = await this.fetchNonceInfo(sponsorAddress);
-    } catch (_e) {
-      return null;
+    if (prefetchedNonceInfo !== undefined) {
+      // Called with a pre-fetched result: null means Hiro was unreachable — skip silently.
+      if (prefetchedNonceInfo === null) return null;
+      nonceInfo = prefetchedNonceInfo;
+    } else {
+      try {
+        nonceInfo = await this.fetchNonceInfo(sponsorAddress);
+      } catch (_e) {
+        return null;
+      }
     }
 
     this.setStateValue(STATE_KEYS.lastHiroSync, Date.now());
@@ -6630,6 +6717,41 @@ export class NonceDO {
   }
 
   async alarm(): Promise<void> {
+    // ---------------------------------------------------------------------------
+    // Phase 1 (outside lock): Determine which wallets to reconcile and pre-fetch
+    // their nonce info from Hiro in parallel. Hiro I/O must NOT happen inside
+    // blockConcurrencyWhile — with N wallets, sequential fetches inside the lock
+    // can exceed Cloudflare's ~30 s limit, crashing the DO and all queued requests.
+    // ---------------------------------------------------------------------------
+    const initializedWallets = await this.getInitializedWallets();
+
+    // Compute the reconcile slice before taking the lock so we can pre-fetch.
+    // walletCursor is read from SQL (fast, no I/O) — safe to read outside the lock.
+    const walletCursorPre = this.getStateValue(ALARM_WALLET_CURSOR_KEY) ?? 0;
+    const walletCountPre = initializedWallets.length;
+    const reconcileWalletsPre: Array<{ walletIndex: number; address: string }> = [];
+    for (let i = 0; i < MAX_RECONCILE_WALLETS && i < walletCountPre; i++) {
+      const idx = (walletCursorPre + i) % walletCountPre;
+      const wallet = initializedWallets[idx];
+      if (wallet) reconcileWalletsPre.push(wallet);
+    }
+
+    // Pre-fetch nonce infos in parallel — null means Hiro was unreachable for that wallet.
+    const prefetchedNonceInfos = new Map<number, HiroNonceInfo | null>();
+    await Promise.all(
+      reconcileWalletsPre.map(async ({ walletIndex, address }) => {
+        try {
+          const info = await this.fetchNonceInfo(address);
+          prefetchedNonceInfos.set(walletIndex, info);
+        } catch (_e) {
+          prefetchedNonceInfos.set(walletIndex, null);
+        }
+      })
+    );
+
+    // ---------------------------------------------------------------------------
+    // Phase 2 (inside lock): All state mutations happen here. No Hiro I/O.
+    // ---------------------------------------------------------------------------
     await this.state.blockConcurrencyWhile(async () => {
       try {
         // --- Preamble: migration, cleanup, replay recycling, seed upgrades ---
@@ -6658,8 +6780,6 @@ export class NonceDO {
           });
         }
 
-        const initializedWallets = await this.getInitializedWallets();
-
         // ---------------------------------------------------------------------------
         // Bounded reconciliation: process MAX_RECONCILE_WALLETS wallets per tick.
         // Round-robin cursor advances each tick so all wallets reconcile over time.
@@ -6668,7 +6788,7 @@ export class NonceDO {
         const walletCursor = this.getStateValue(ALARM_WALLET_CURSOR_KEY) ?? 0;
         const walletCount = initializedWallets.length;
 
-        // Determine which wallets to reconcile this tick
+        // Determine which wallets to reconcile this tick (same slice as pre-fetch)
         const reconcileWallets: Array<{ walletIndex: number; address: string }> = [];
         for (let i = 0; i < MAX_RECONCILE_WALLETS && i < walletCount; i++) {
           const idx = (walletCursor + i) % walletCount;
@@ -6677,8 +6797,13 @@ export class NonceDO {
         }
 
         for (const { walletIndex, address } of reconcileWallets) {
-          // reconcileNonceForWallet returns null when Hiro is unreachable — skip silently
-          await this.reconcileNonceForWallet(walletIndex, address);
+          // Pass pre-fetched nonce info — reconcileNonceForWallet skips Hiro fetch when provided.
+          // If walletIndex is missing from map (shouldn't happen), fall back to live fetch.
+          // null means Hiro was unreachable; reconcile returns null and is skipped silently.
+          const prefetched: HiroNonceInfo | null | undefined = prefetchedNonceInfos.has(walletIndex)
+            ? prefetchedNonceInfos.get(walletIndex)
+            : undefined;
+          await this.reconcileNonceForWallet(walletIndex, address, prefetched);
 
           // Clean up StuckTxState entries for nonces that have been confirmed on-chain.
           const cached = this.hiroNonceCache.get(walletIndex);

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -6798,11 +6798,9 @@ export class NonceDO {
 
         for (const { walletIndex, address } of reconcileWallets) {
           // Pass pre-fetched nonce info — reconcileNonceForWallet skips Hiro fetch when provided.
-          // If walletIndex is missing from map (shouldn't happen), fall back to live fetch.
-          // null means Hiro was unreachable; reconcile returns null and is skipped silently.
-          const prefetched: HiroNonceInfo | null | undefined = prefetchedNonceInfos.has(walletIndex)
-            ? prefetchedNonceInfos.get(walletIndex)
-            : undefined;
+          // Map.get returns undefined for absent keys (fall back to live fetch) and null for
+          // wallets where Hiro was unreachable (reconcile returns null and is skipped silently).
+          const prefetched = prefetchedNonceInfos.get(walletIndex);
           await this.reconcileNonceForWallet(walletIndex, address, prefetched);
 
           // Clean up StuckTxState entries for nonces that have been confirmed on-chain.


### PR DESCRIPTION
## Problem

`NonceDO` crashes intermittently on cold start (and during alarm reconciliation) because `assignNonce()` and `alarm()` both hold a `blockConcurrencyWhile` lock while making sequential HTTP calls to the Hiro API. With `SPONSOR_WALLET_COUNT=10`, up to 10 sequential Hiro fetches can occur inside a single lock window — easily exceeding Cloudflare's ~30 s `blockConcurrencyWhile` limit and crashing the DO, dropping all queued requests.

## Changes

### `reconcileNonceForWallet()`
Added an optional `prefetchedNonceInfo?: HiroNonceInfo | null` parameter:
- `HiroNonceInfo` → use the pre-fetched result, skip HTTP call
- `null` → Hiro was unreachable during pre-fetch, return null silently (existing "skip" behavior)
- `undefined` → no pre-fetch (backward-compatible; falls back to live fetch)

### `alarm()`
Split into two phases:
1. **Outside lock (Phase 1):** fetch the list of initialized wallets, compute the reconcile slice, then pre-fetch all wallet nonce infos in **parallel** via `Promise.all` before entering `blockConcurrencyWhile`.
2. **Inside lock (Phase 2):** all state mutations. Pass pre-fetched `HiroNonceInfo` into `reconcileNonceForWallet` — no Hiro I/O occurs inside the lock.

### `assignNonce()`
Split into two phases:
1. **Outside lock (Phase 1):** identify wallets that need initialization (no head seeded) or whose lookahead-guard cache has expired. Pre-fetch their nonce infos in **parallel** via `Promise.all`.
2. **Inside lock (Phase 2):** apply the pre-fetched seeds directly (no HTTP). Also updates the `hiroNonceCache` from pre-fetched data so the subsequent `fetchNextNonceForWallet` call is served from cache (no additional Hiro call). Falls back to a live fetch only when the pre-fetch genuinely failed (e.g., Hiro down at cold-start on a brand-new DO).

## Result

- `blockConcurrencyWhile` callbacks in both `alarm()` and `assignNonce()` no longer make any Hiro HTTP calls in the normal (post-first-tick) path.
- Cold-start with N=10 wallets: 10 parallel Hiro fetches complete well within 30 s, then the lock is taken for a brief SQL-only mutation window.
- Hiro unreachability is handled fail-open: wallets that couldn't be pre-fetched either skip reconciliation (alarm) or fall back to a single live fetch (assignNonce) as before.

## Testing

TypeScript check passes with no new errors (`tsc --noEmit --skipLibCheck`). The pre-existing `worker-configuration.d.ts` error is unrelated to this change and exists on `main`.

closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)