### PR TITLE
feat(relay): complete canonical payment lifecycle ownership

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "x402-sponsor-relay",
       "version": "1.27.5",
       "dependencies": {
-        "@aibtc/tx-schemas": "^0.4.0",
+        "@aibtc/tx-schemas": "^0.7.0",
         "@noble/curves": "^2.0.1",
         "@scure/btc-signer": "^2.0.1",
         "@stacks/common": "^7.3.1",
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@aibtc/tx-schemas": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.4.0.tgz",
-      "integrity": "sha512-51z8O+mNGnqwoisKZCvvC8ZNBv0Z+RIfSTQ2CV99NFk4Z4ySp+KX+kPEpwlbLLul3AySn/AD9EHWXrjcGaAYAg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.7.0.tgz",
+      "integrity": "sha512-6q8FnEuwRV1OZ3b9uQ831vSdi7a2LdwS9twoSld5r8UIR2T/wH9WO5iTGsDlFmsP//4GtEUjX5HYX/KsKd+NsQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "wrangler": "^4.75.0"
   },
   "overrides": {
-    "lodash": "4.18.1"
+    "vite": "7.3.2"
   },
   "dependencies": {
-    "@aibtc/tx-schemas": "^0.4.0",
+    "@aibtc/tx-schemas": "^0.7.0",
     "@noble/curves": "^2.0.1",
     "@scure/btc-signer": "^2.0.1",
     "@stacks/common": "^7.3.1",
@@ -44,8 +44,5 @@
     "chanfana": "^3.0.0",
     "hono": "^4.12.12",
     "x402-stacks": "github:whoabuddy/x402Stacks#feat/sponsored-transactions"
-  },
-  "overrides": {
-    "vite": "7.3.2"
   }
 }

--- a/src/__tests__/nonce-do-sponsor-status.test.ts
+++ b/src/__tests__/nonce-do-sponsor-status.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { NonceDO } from "../durable-objects/nonce-do";
+import { createPaymentRecord, getPaymentRecord, putPaymentRecord, transitionPayment } from "../services/payment-status";
+import { MemoryKV } from "./helpers/memory-kv";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -429,5 +431,43 @@ describe("NonceDO stale sender repair helpers", () => {
         error: "hiro unavailable",
       })
     );
+  });
+
+  it("clears held metadata when a repaired run is re-queued under the same canonical payment", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_repaired", "testnet"),
+      "queued",
+      {
+        holdReason: "gap",
+        nextExpectedNonce: 4,
+        missingNonces: [4, 5],
+        holdExpiresAt: "2026-04-09T12:30:00.000Z",
+      }
+    );
+    record.relayState = "held";
+    await putPaymentRecord(kv, record);
+
+    const sync = (NonceDO as any).prototype.syncPaymentsAfterQueueAssignment;
+    await sync.call(
+      { env: { RELAY_KV: kv } },
+      [{ senderNonce: 6, paymentId: "pay_repaired" }],
+      [{ senderNonce: 6, walletIndex: 2, sponsorNonce: 55 }]
+    );
+
+    const updated = await getPaymentRecord(kv, "pay_repaired");
+    expect(updated).toEqual(
+      expect.objectContaining({
+        status: "queued",
+        relayState: "queued",
+        sponsorWalletIndex: 2,
+        sponsorNonce: 55,
+      })
+    );
+    expect(updated).not.toHaveProperty("holdReason");
+    expect(updated).not.toHaveProperty("nextExpectedNonce");
+    expect(updated).not.toHaveProperty("missingNonces");
+    expect(updated).not.toHaveProperty("holdExpiresAt");
+    expect(updated).not.toHaveProperty("error");
   });
 });

--- a/src/__tests__/nonce-do-sponsor-status.test.ts
+++ b/src/__tests__/nonce-do-sponsor-status.test.ts
@@ -470,4 +470,47 @@ describe("NonceDO stale sender repair helpers", () => {
     expect(updated).not.toHaveProperty("holdExpiresAt");
     expect(updated).not.toHaveProperty("error");
   });
+
+  it("does not fail run assignment when post-assignment payment sync throws", async () => {
+    const checkAndAssignRun = (NonceDO as any).prototype.checkAndAssignRun;
+    const log = vi.fn();
+
+    const result = await checkAndAssignRun.call({
+      getHandGapInfo: () => ({
+        hand: [
+          {
+            sender_nonce: 4,
+            tx_hex: "0xabc",
+            payment_id: "pay_sync_fail",
+            expires_at: "2099-01-01T00:00:00.000Z",
+          },
+        ],
+        missingNonces: [],
+        nextExpected: 4,
+        handSize: 1,
+      }),
+      assignRunToWallet: () => ({
+        assigned: [{ senderNonce: 4, walletIndex: 1, sponsorNonce: 44 }],
+        held: [],
+      }),
+      syncPaymentsAfterQueueAssignment: vi.fn().mockRejectedValue(new Error("kv unavailable")),
+      log,
+    }, "STSYNC");
+
+    expect(result).toEqual({
+      dispatched: true,
+      sponsorNonce: 44,
+      walletIndex: 1,
+      sponsorAddress: "",
+    });
+    expect(log).toHaveBeenCalledWith(
+      "warn",
+      "payment_sync_after_assign_failed",
+      expect.objectContaining({
+        senderAddress: "STSYNC",
+        assignedCount: 1,
+        error: "kv unavailable",
+      })
+    );
+  });
 });

--- a/src/__tests__/payment-status.test.ts
+++ b/src/__tests__/payment-status.test.ts
@@ -172,6 +172,31 @@ describe("payment status projection", () => {
     expect(queuedProjection.status).toBe("queued");
     expect(queuedProjection.terminalReason).toBeUndefined();
   });
+
+  it("clears held diagnostics when a held payment transitions to a non-held status", () => {
+    const heldRecord = transitionPayment(
+      createPaymentRecord("pay_hold_clear", "testnet"),
+      "queued",
+      {
+        holdReason: "capacity",
+        nextExpectedNonce: 7,
+        missingNonces: [7],
+        holdExpiresAt: "2026-04-09T12:30:00.000Z",
+      }
+    );
+
+    const failedRecord = transitionPayment(heldRecord, "failed", {
+      error: "relay failed",
+      terminalReason: "sponsor_failure",
+      retryable: false,
+    });
+
+    expect(failedRecord.relayState).toBeUndefined();
+    expect(failedRecord.holdReason).toBeUndefined();
+    expect(failedRecord.nextExpectedNonce).toBeUndefined();
+    expect(failedRecord.missingNonces).toBeUndefined();
+    expect(failedRecord.holdExpiresAt).toBeUndefined();
+  });
 });
 
 describe("submitPayment duplicate reuse", () => {

--- a/src/__tests__/payment-status.test.ts
+++ b/src/__tests__/payment-status.test.ts
@@ -417,6 +417,81 @@ describe("payment polling runtime alignment", () => {
     expect(rpcResult.terminalReason).toBe("unknown_payment_identity");
     expect(httpResult.terminalReason).toBe("unknown_payment_identity");
   });
+
+  it("surfaces held sender-wedge diagnostics consistently from RPC and HTTP polling", async () => {
+    const kv = new MemoryKV();
+    const heldRecord = transitionPayment(
+      createPaymentRecord("pay_held", "testnet"),
+      "queued",
+      {
+        holdReason: "gap",
+        nextExpectedNonce: 4,
+        missingNonces: [4, 5],
+        holdExpiresAt: "2026-04-09T12:30:00.000Z",
+      }
+    );
+    heldRecord.senderAddress = "STHOLD000000000000000000000000000000000";
+    heldRecord.relayState = "held";
+    await putPaymentRecord(kv, heldRecord);
+
+    const env = {
+      RELAY_KV: kv,
+      STACKS_NETWORK: "testnet",
+      RELAY_BASE_URL: "https://x402-relay.aibtc.dev",
+      NONCE_DO: {
+        idFromName: () => "sponsor",
+        get: () => ({
+          fetch: vi.fn(async () => new Response(JSON.stringify({
+            senderAddress: "STHOLD000000000000000000000000000000000",
+            blocked: true,
+            blockedOnFrontierMismatch: true,
+            adminRecoveryLikely: false,
+            nextExpectedNonce: 4,
+            lowestHeldNonce: 6,
+            missingNonces: [4, 5],
+            heldCount: 1,
+            oldestHeldAgeMs: 120000,
+            lastRepairAttemptAt: null,
+            lastRepairFailureAt: null,
+            repairEligible: false,
+            repairTriggered: true,
+            repairAdvanced: false,
+            activePaymentIds: ["pay_held"],
+          }))),
+        }),
+      },
+    } as unknown as Env;
+
+    const rpc = new RelayRPC(executionContext, env);
+    const rpcResult = await rpc.checkPayment("pay_held");
+
+    const response = await worker.fetch(
+      new Request("https://x402-relay.aibtc.dev/payment/pay_held"),
+      env,
+      executionContext
+    );
+    const httpBody = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(rpcResult.status).toBe("queued");
+    expect(httpBody.status).toBe("queued");
+    expect((rpcResult as Record<string, unknown>).relayState).toBe("held");
+    expect((rpcResult as Record<string, unknown>).holdReason).toBe("gap");
+    expect((rpcResult as Record<string, unknown>).nextExpectedNonce).toBe(4);
+    expect((rpcResult as Record<string, unknown>).missingNonces).toEqual([4, 5]);
+    expect((rpcResult as Record<string, unknown>).senderWedge).toEqual(
+      expect.objectContaining({
+        blockedOnFrontierMismatch: true,
+        repairTriggered: true,
+      })
+    );
+    expect(httpBody.senderWedge).toEqual(
+      expect.objectContaining({
+        senderAddress: "STHOLD000000000000000000000000000000000",
+        missingNonces: [4, 5],
+      })
+    );
+  });
 });
 
 describe("PaymentStatus endpoint schema", () => {

--- a/src/__tests__/queue-consumer.test.ts
+++ b/src/__tests__/queue-consumer.test.ts
@@ -387,4 +387,54 @@ describe("queue consumer recovery boundaries", () => {
       })
     );
   });
+
+  it("does not fabricate an empty sender identity when correlating broadcast success", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_legacy", "testnet"),
+      "queued"
+    );
+    await putPaymentRecord(kv, record);
+
+    const originalTx = {
+      auth: { spendingCondition: { signer: "signer_legacy", nonce: 3n } },
+    };
+    const sponsoredTx = { id: "sponsored_legacy_tx" };
+
+    mocks.deserializeTransaction.mockImplementation((txHex: string) => {
+      if (txHex === "legacy_tx") return originalTx;
+      if (txHex === "sponsored_legacy") return sponsoredTx;
+      throw new Error(`unexpected tx hex ${txHex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_legacy",
+      walletIndex: 0,
+      fee: "1200",
+    });
+    mocks.broadcastOnly.mockResolvedValue({ txid: "0xlegacy" });
+
+    const message = createMessage({
+      paymentId: "pay_legacy",
+      txHex: "legacy_tx",
+      network: "testnet",
+      attempt: 1,
+    });
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    expect(mocks.nonceLifecycleOnBroadcastSuccess).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        paymentId: "pay_legacy",
+        senderAddress: undefined,
+        senderNonce: undefined,
+      })
+    );
+  });
 });

--- a/src/__tests__/queue-consumer.test.ts
+++ b/src/__tests__/queue-consumer.test.ts
@@ -10,9 +10,9 @@ const mocks = vi.hoisted(() => ({
   clearInFlight: vi.fn(),
   updateSenderNonceOnBroadcast: vi.fn(),
   extractSponsorNonce: vi.fn(),
-  recordNonceTxid: vi.fn(),
   releaseNonceDO: vi.fn(),
-  recordBroadcastOutcomeDO: vi.fn(),
+  nonceLifecycleOnBroadcastSuccess: vi.fn(),
+  repairSenderWedgeDO: vi.fn(),
 }));
 
 vi.mock("@stacks/transactions", () => ({
@@ -39,9 +39,9 @@ vi.mock("../services", async () => {
       }
     },
     extractSponsorNonce: mocks.extractSponsorNonce,
-    recordNonceTxid: mocks.recordNonceTxid,
     releaseNonceDO: mocks.releaseNonceDO,
-    recordBroadcastOutcomeDO: mocks.recordBroadcastOutcomeDO,
+    nonceLifecycleOnBroadcastSuccess: mocks.nonceLifecycleOnBroadcastSuccess,
+    repairSenderWedgeDO: mocks.repairSenderWedgeDO,
   };
 });
 
@@ -70,9 +70,9 @@ describe("queue consumer recovery boundaries", () => {
     mocks.extractSponsorNonce.mockReturnValue(55);
     mocks.clearInFlight.mockResolvedValue(undefined);
     mocks.updateSenderNonceOnBroadcast.mockResolvedValue(undefined);
-    mocks.recordNonceTxid.mockResolvedValue(undefined);
     mocks.releaseNonceDO.mockResolvedValue(undefined);
-    mocks.recordBroadcastOutcomeDO.mockResolvedValue(undefined);
+    mocks.nonceLifecycleOnBroadcastSuccess.mockResolvedValue(undefined);
+    mocks.repairSenderWedgeDO.mockResolvedValue(null);
   });
 
   it("keeps mixed x402 and non-x402 queued traffic moving when one sender hits a nonce gap", async () => {
@@ -155,7 +155,7 @@ describe("queue consumer recovery boundaries", () => {
       executionContext
     );
 
-    const failedGapRecord = await getPaymentRecord(kv, "pay_gap");
+    const heldGapRecord = await getPaymentRecord(kv, "pay_gap");
     const successfulRecord = await getPaymentRecord(kv, "pay_ok");
 
     expect(gapMessage.ack).toHaveBeenCalledTimes(1);
@@ -163,11 +163,13 @@ describe("queue consumer recovery boundaries", () => {
     expect(gapMessage.retry).not.toHaveBeenCalled();
     expect(okMessage.retry).not.toHaveBeenCalled();
 
-    expect(failedGapRecord).toEqual(
+    expect(heldGapRecord).toEqual(
       expect.objectContaining({
-        status: "failed",
-        errorCode: "SENDER_NONCE_GAP",
-        terminalReason: "sender_nonce_gap",
+        status: "queued",
+        relayState: "held",
+        holdReason: "gap",
+        nextExpectedNonce: 5,
+        missingNonces: [5, 6, 7],
       })
     );
     expect(successfulRecord).toEqual(
@@ -176,7 +178,12 @@ describe("queue consumer recovery boundaries", () => {
         txid: "0xabc",
       })
     );
-    expect(mocks.clearInFlight).toHaveBeenCalledWith(kv, "signer_gap", 8);
+    expect(mocks.clearInFlight).not.toHaveBeenCalledWith(kv, "signer_gap", 8);
+    expect(mocks.repairSenderWedgeDO).toHaveBeenCalledWith(
+      expect.objectContaining({ RELAY_KV: kv, STACKS_NETWORK: "testnet" }),
+      expect.anything(),
+      "STGAP000000000000000000000000000000000"
+    );
   });
 
   it("keeps sponsor recovery relay-owned for temporary capacity failures", async () => {
@@ -220,6 +227,8 @@ describe("queue consumer recovery boundaries", () => {
       expect.objectContaining({
         status: "queued",
         error: "Sponsor pool temporarily has no dispatch capacity",
+        relayState: "held",
+        holdReason: "capacity",
       })
     );
     expect(mocks.clearInFlight).not.toHaveBeenCalled();
@@ -321,5 +330,61 @@ describe("queue consumer recovery boundaries", () => {
       compat_shim_used: false,
       repo_version: expect.any(String),
     }));
+  });
+
+  it("writes unified payment correlation on normal broadcast success", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_owner", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 12;
+    record.senderAddress = "STOWNER00000000000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    const originalTx = {
+      auth: { spendingCondition: { signer: "signer_owner", nonce: 12n } },
+    };
+    const sponsoredTx = { id: "sponsored_owner_tx" };
+
+    mocks.deserializeTransaction.mockImplementation((txHex: string) => {
+      if (txHex === "owner_tx") return originalTx;
+      if (txHex === "sponsored_owner") return sponsoredTx;
+      throw new Error(`unexpected tx hex ${txHex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_owner",
+      walletIndex: 2,
+      fee: "3000",
+    });
+    mocks.broadcastOnly.mockResolvedValue({ txid: "0xowner" });
+
+    const message = createMessage({
+      paymentId: "pay_owner",
+      txHex: "owner_tx",
+      network: "testnet",
+      attempt: 1,
+    });
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    expect(mocks.nonceLifecycleOnBroadcastSuccess).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        paymentId: "pay_owner",
+        senderTxHex: "owner_tx",
+        senderAddress: "STOWNER00000000000000000000000000000000",
+        senderNonce: 12,
+        sponsorNonce: 55,
+        walletIndex: 2,
+        txid: "0xowner",
+      })
+    );
   });
 });

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -1894,7 +1894,15 @@ export class NonceDO {
       nextSenderNonce: nextExpected + dispatchResult.assigned.length,
     });
 
-    await this.syncPaymentsAfterQueueAssignment(run, dispatchResult.assigned);
+    try {
+      await this.syncPaymentsAfterQueueAssignment(run, dispatchResult.assigned);
+    } catch (error) {
+      this.log("warn", "payment_sync_after_assign_failed", {
+        senderAddress,
+        assignedCount: dispatchResult.assigned.length,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
 
     // sponsor_address is in async KV storage — return empty string.
     // SponsorService derives the correct key from walletIndex + mnemonic.

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -12,6 +12,7 @@ import type {
   Env,
   LogsRPC,
   PoolHealthResponse,
+  SenderWedgeStatus,
   SponsorStatusResult,
   WalletHealthSnapshot,
   HandSubmitResult,
@@ -182,6 +183,7 @@ interface SenderHandRow {
   sender_address: string;
   sender_nonce: number;
   tx_hex: string;
+  payment_id: string | null;
   source: string;
   received_at: string;
   expires_at: string;
@@ -718,6 +720,7 @@ export class NonceDO {
       CREATE TABLE IF NOT EXISTS dispatch_queue (
         wallet_index    INTEGER NOT NULL,
         position        INTEGER NOT NULL DEFAULT 0,
+        payment_id      TEXT,
         sender_tx_hex   TEXT    NOT NULL,
         sender_address  TEXT    NOT NULL,
         sender_nonce    INTEGER NOT NULL,
@@ -752,6 +755,15 @@ export class NonceDO {
 
     // Migration: add original_fee column to dispatch_queue (nullable, text for bigint safety).
     // The standard SQLite ADD COLUMN IF NOT EXISTS is not supported — use try/catch instead.
+    try {
+      const cols = this.sql
+        .exec<{ name: string }>("SELECT name FROM pragma_table_info('dispatch_queue') WHERE name = 'payment_id'")
+        .toArray();
+      if (cols.length === 0) {
+        this.sql.exec("ALTER TABLE dispatch_queue ADD COLUMN payment_id TEXT");
+      }
+    } catch { /* already present or error — fail-open */ }
+
     try {
       const cols = this.sql
         .exec<{ name: string }>("SELECT name FROM pragma_table_info('dispatch_queue') WHERE name = 'original_fee'")
@@ -830,6 +842,7 @@ export class NonceDO {
       CREATE TABLE IF NOT EXISTS replay_buffer (
         id                    INTEGER PRIMARY KEY AUTOINCREMENT,
         wallet_index          INTEGER NOT NULL,
+        payment_id            TEXT,
         sender_tx_hex         TEXT    NOT NULL,
         sender_address        TEXT    NOT NULL,
         sender_nonce          INTEGER NOT NULL,
@@ -848,6 +861,15 @@ export class NonceDO {
       CREATE INDEX IF NOT EXISTS idx_replay_buffer_sender
         ON replay_buffer(sender_address);
     `);
+
+    try {
+      const cols = this.sql
+        .exec<{ name: string }>("SELECT name FROM pragma_table_info('replay_buffer') WHERE name = 'payment_id'")
+        .toArray();
+      if (cols.length === 0) {
+        this.sql.exec("ALTER TABLE replay_buffer ADD COLUMN payment_id TEXT");
+      }
+    } catch { /* already present or error — fail-open */ }
 
     // Probe queue: alarm-driven backward probe for ghost mempool eviction.
     // When flush-wallet detects an empty forward range + probeDepth, nonces are
@@ -926,12 +948,22 @@ export class NonceDO {
         sender_address  TEXT    NOT NULL,
         sender_nonce    INTEGER NOT NULL,
         tx_hex          TEXT    NOT NULL,
+        payment_id      TEXT,
         source          TEXT    NOT NULL DEFAULT 'agent',
         received_at     TEXT    NOT NULL,
         expires_at      TEXT    NOT NULL,
         PRIMARY KEY (sender_address, sender_nonce)
       );
     `);
+
+    try {
+      const cols = this.sql
+        .exec<{ name: string }>("SELECT name FROM pragma_table_info('sender_hand') WHERE name = 'payment_id'")
+        .toArray();
+      if (cols.length === 0) {
+        this.sql.exec("ALTER TABLE sender_hand ADD COLUMN payment_id TEXT");
+      }
+    } catch { /* already present or error — fail-open */ }
 
     // sender_expiry_log: records recently expired sender_hand entries for agent feedback
     // TTL: entries older than 30 minutes are pruned each alarm cycle
@@ -980,6 +1012,7 @@ export class NonceDO {
     senderAddress: string,
     senderNonce: number,
     sponsorNonce: number,
+    paymentId: string | null = null,
     fee: string | null = null,
     submittedAt: string | null = null,
     isGapFill: boolean = false
@@ -996,12 +1029,13 @@ export class NonceDO {
 
     this.sql.exec(
       `INSERT OR REPLACE INTO dispatch_queue
-         (wallet_index, position, sender_tx_hex, sender_address, sender_nonce,
+         (wallet_index, position, payment_id, sender_tx_hex, sender_address, sender_nonce,
           sponsor_nonce, original_fee, state, queued_at, dispatched_at, confirmed_at,
           submitted_at, is_gap_fill)
-       VALUES (?, ?, ?, ?, ?, ?, ?, 'dispatched', ?, ?, NULL, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'dispatched', ?, ?, NULL, ?, ?)`,
       walletIndex,
       position,
+      paymentId,
       senderTxHex,
       senderAddress,
       senderNonce,
@@ -1223,15 +1257,17 @@ export class NonceDO {
     senderTxHex: string,
     senderAddress: string,
     senderNonce: number,
-    originalSponsorNonce: number
+    originalSponsorNonce: number,
+    paymentId: string | null = null
   ): void {
     const now = new Date().toISOString();
     this.sql.exec(
       `INSERT INTO replay_buffer
-         (wallet_index, sender_tx_hex, sender_address, sender_nonce,
+         (wallet_index, payment_id, sender_tx_hex, sender_address, sender_nonce,
           original_sponsor_nonce, queued_at)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
       walletIndex,
+      paymentId,
       senderTxHex,
       senderAddress,
       senderNonce,
@@ -1246,6 +1282,7 @@ export class NonceDO {
    */
   private getReplayBuffer(walletIndex: number): Array<{
     id: number;
+    payment_id: string | null;
     sender_tx_hex: string;
     sender_address: string;
     sender_nonce: number;
@@ -1255,13 +1292,14 @@ export class NonceDO {
     return this.sql
       .exec<{
         id: number;
+        payment_id: string | null;
         sender_tx_hex: string;
         sender_address: string;
         sender_nonce: number;
         original_sponsor_nonce: number;
         queued_at: string;
       }>(
-        `SELECT id, sender_tx_hex, sender_address, sender_nonce,
+        `SELECT id, payment_id, sender_tx_hex, sender_address, sender_nonce,
                 original_sponsor_nonce, queued_at
          FROM replay_buffer
          WHERE wallet_index = ?
@@ -1338,29 +1376,32 @@ export class NonceDO {
     senderAddress: string,
     senderNonce: number,
     txHex: string,
-    source: "agent" | "replay"
+    source: "agent" | "replay",
+    paymentId: string | null = null
   ): void {
     const now = new Date().toISOString();
     const expiresAt = new Date(Date.now() + HAND_HOLD_TIMEOUT_MS).toISOString();
     if (source === "agent") {
       this.sql.exec(
         `INSERT OR REPLACE INTO sender_hand
-           (sender_address, sender_nonce, tx_hex, source, received_at, expires_at)
-         VALUES (?, ?, ?, 'agent', ?, ?)`,
+           (sender_address, sender_nonce, tx_hex, payment_id, source, received_at, expires_at)
+         VALUES (?, ?, ?, ?, 'agent', ?, ?)`,
         senderAddress,
         senderNonce,
         txHex,
+        paymentId,
         now,
         expiresAt
       );
     } else {
       this.sql.exec(
         `INSERT OR IGNORE INTO sender_hand
-           (sender_address, sender_nonce, tx_hex, source, received_at, expires_at)
-         VALUES (?, ?, ?, 'replay', ?, ?)`,
+           (sender_address, sender_nonce, tx_hex, payment_id, source, received_at, expires_at)
+         VALUES (?, ?, ?, ?, 'replay', ?, ?)`,
         senderAddress,
         senderNonce,
         txHex,
+        paymentId,
         now,
         expiresAt
       );
@@ -1376,11 +1417,12 @@ export class NonceDO {
         sender_address: string;
         sender_nonce: number;
         tx_hex: string;
+        payment_id: string | null;
         source: string;
         received_at: string;
         expires_at: string;
       }>(
-        `SELECT sender_address, sender_nonce, tx_hex, source, received_at, expires_at
+        `SELECT sender_address, sender_nonce, tx_hex, payment_id, source, received_at, expires_at
          FROM sender_hand
          WHERE sender_address = ?
          ORDER BY sender_nonce ASC`,
@@ -1674,12 +1716,84 @@ export class NonceDO {
     }
   }
 
+  private buildSenderWedgeStatus(
+    senderAddress: string,
+    opts?: { repairTriggered?: boolean; repairAdvanced?: boolean }
+  ): SenderWedgeStatus {
+    const nowMs = Date.now();
+    const stateRow = this.getSenderState(senderAddress);
+    const activeHand = this.getHand(senderAddress)
+      .filter((entry) => new Date(entry.expires_at).getTime() > nowMs)
+      .sort((a, b) => a.sender_nonce - b.sender_nonce);
+
+    const lowestHeldNonce = activeHand[0]?.sender_nonce ?? null;
+    const nextExpectedNonce = stateRow?.next_expected_nonce ?? null;
+    const blockedOnFrontierMismatch =
+      lowestHeldNonce !== null &&
+      nextExpectedNonce !== null &&
+      lowestHeldNonce > nextExpectedNonce;
+    const candidate = this.evaluateStaleSenderRepairCandidate(stateRow, activeHand, nowMs);
+    const missingNonces: number[] = [];
+
+    if (blockedOnFrontierMismatch && nextExpectedNonce !== null && lowestHeldNonce !== null) {
+      for (let nonce = nextExpectedNonce; nonce < lowestHeldNonce && missingNonces.length < 10; nonce++) {
+        missingNonces.push(nonce);
+      }
+    }
+
+    const oldestHeldAgeMs = activeHand.length > 0
+      ? activeHand.reduce((min, entry) => {
+          const receivedAtMs = new Date(entry.received_at).getTime();
+          return Number.isFinite(receivedAtMs) ? Math.min(min, receivedAtMs) : min;
+        }, Number.MAX_SAFE_INTEGER)
+      : Number.MAX_SAFE_INTEGER;
+    const resolvedOldestHeldAgeMs =
+      oldestHeldAgeMs === Number.MAX_SAFE_INTEGER ? null : Math.max(0, nowMs - oldestHeldAgeMs);
+    const recentRepairFailure = stateRow?.last_refresh_failure_at != null;
+    const nearExpiry =
+      resolvedOldestHeldAgeMs !== null &&
+      resolvedOldestHeldAgeMs >= Math.floor(HAND_HOLD_TIMEOUT_MS * 0.75);
+
+    return {
+      senderAddress,
+      blocked: activeHand.length > 0,
+      blockedOnFrontierMismatch,
+      adminRecoveryLikely:
+        blockedOnFrontierMismatch && Boolean(recentRepairFailure || nearExpiry),
+      nextExpectedNonce,
+      lowestHeldNonce,
+      missingNonces,
+      heldCount: activeHand.length,
+      oldestHeldAgeMs: resolvedOldestHeldAgeMs,
+      lastRepairAttemptAt: stateRow?.last_refresh_attempt_at ?? null,
+      lastRepairFailureAt: stateRow?.last_refresh_failure_at ?? null,
+      repairEligible: candidate !== null,
+      repairTriggered: opts?.repairTriggered,
+      repairAdvanced: opts?.repairAdvanced,
+      activePaymentIds: activeHand
+        .map((entry) => entry.payment_id)
+        .filter((paymentId): paymentId is string => typeof paymentId === "string"),
+    };
+  }
+
+  private async repairSenderWedge(senderAddress: string): Promise<SenderWedgeStatus> {
+    const repairAdvanced = await this.maybeRepairStaleSenderFrontier(senderAddress);
+    if (repairAdvanced) {
+      await this.checkAndAssignRun(senderAddress);
+    }
+
+    return this.buildSenderWedgeStatus(senderAddress, {
+      repairTriggered: true,
+      repairAdvanced,
+    });
+  }
+
   /**
    * Gather the sender's active hand entries and detect gaps relative to next_expected_nonce.
    * Shared by checkAndAssignRun() and checkWouldDispatch() to avoid duplicating gap detection logic.
    */
   private getHandGapInfo(senderAddress: string): {
-    hand: Array<{ sender_nonce: number; tx_hex: string; expires_at: string }>;
+    hand: Array<{ sender_nonce: number; tx_hex: string; payment_id: string | null; expires_at: string }>;
     missingNonces: number[];
     nextExpected: number;
     handSize: number;
@@ -1717,15 +1831,19 @@ export class NonceDO {
    * - dispatched:true with sponsorNonce/walletIndex/sponsorAddress for the first tx
    * - dispatched:false with missingNonces when a gap exists
    */
-  private checkAndAssignRun(senderAddress: string): HandSubmitResult {
+  private async checkAndAssignRun(senderAddress: string): Promise<HandSubmitResult> {
     const { hand, missingNonces, nextExpected, handSize } = this.getHandGapInfo(senderAddress);
 
     // Build the gapless run starting at nextExpected
-    const run: Array<{ senderNonce: number; txHex: string }> = [];
+    const run: Array<{ senderNonce: number; txHex: string; paymentId: string | null }> = [];
     let expectedNonce = nextExpected;
     for (const entry of hand) {
       if (entry.sender_nonce === expectedNonce) {
-        run.push({ senderNonce: entry.sender_nonce, txHex: entry.tx_hex });
+        run.push({
+          senderNonce: entry.sender_nonce,
+          txHex: entry.tx_hex,
+          paymentId: entry.payment_id,
+        });
         expectedNonce++;
       } else {
         break; // gap detected
@@ -1775,6 +1893,8 @@ export class NonceDO {
       heldCount: dispatchResult.held.length,
       nextSenderNonce: nextExpected + dispatchResult.assigned.length,
     });
+
+    await this.syncPaymentsAfterQueueAssignment(run, dispatchResult.assigned);
 
     // sponsor_address is in async KV storage — return empty string.
     // SponsorService derives the correct key from walletIndex + mnemonic.
@@ -3618,7 +3738,7 @@ export class NonceDO {
    */
   private assignRunToWallet(
     senderAddress: string,
-    run: Array<{ senderNonce: number; txHex: string }>
+    run: Array<{ senderNonce: number; txHex: string; paymentId: string | null }>
   ): RunDispatchResult {
     const now = new Date().toISOString();
 
@@ -3689,11 +3809,12 @@ export class NonceDO {
       // Insert into dispatch_queue
       this.sql.exec(
         `INSERT OR REPLACE INTO dispatch_queue
-           (wallet_index, position, sender_tx_hex, sender_address, sender_nonce,
+           (wallet_index, position, payment_id, sender_tx_hex, sender_address, sender_nonce,
             sponsor_nonce, state, queued_at, dispatched_at, confirmed_at)
-         VALUES (?, ?, ?, ?, ?, ?, 'queued', ?, NULL, NULL)`,
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', ?, NULL, NULL)`,
         walletIndex,
         position,
+        entry.paymentId,
         entry.txHex,
         senderAddress,
         entry.senderNonce,
@@ -3734,6 +3855,48 @@ export class NonceDO {
     });
 
     return { assigned, held };
+  }
+
+  private async syncPaymentsAfterQueueAssignment(
+    run: Array<{ senderNonce: number; paymentId: string | null }>,
+    assigned: RunDispatchResult["assigned"]
+  ): Promise<void> {
+    if (!this.env.RELAY_KV || assigned.length === 0) {
+      return;
+    }
+
+    const paymentIdsBySenderNonce = new Map(
+      run
+        .filter((entry) => entry.paymentId)
+        .map((entry) => [entry.senderNonce, entry.paymentId as string])
+    );
+
+    await Promise.all(
+      assigned.map(async (entry) => {
+        const paymentId = paymentIdsBySenderNonce.get(entry.senderNonce);
+        if (!paymentId) {
+          return;
+        }
+
+        const record = await getPaymentRecord(this.env.RELAY_KV!, paymentId);
+        if (!record || new Set(["confirmed", "failed", "replaced"]).has(record.status)) {
+          return;
+        }
+
+        record.sponsorWalletIndex = entry.walletIndex;
+        record.sponsorNonce = entry.sponsorNonce;
+        record.relayState = "queued";
+        record.holdReason = undefined;
+        record.nextExpectedNonce = undefined;
+        record.missingNonces = undefined;
+        record.holdExpiresAt = undefined;
+        record.error = undefined;
+        record.errorCode = undefined;
+        record.retryable = undefined;
+
+        await putPaymentRecord(this.env.RELAY_KV!, record);
+      })
+    );
   }
 
   /**
@@ -4557,12 +4720,13 @@ export class NonceDO {
       const stuckCutoff = new Date(Date.now() - stuckAgeMs).toISOString();
       const stuckEntries = this.sql
         .exec<{
+          payment_id: string | null;
           sender_tx_hex: string;
           sender_address: string;
           sender_nonce: number;
           sponsor_nonce: number;
         }>(
-          `SELECT sender_tx_hex, sender_address, sender_nonce, sponsor_nonce
+          `SELECT payment_id, sender_tx_hex, sender_address, sender_nonce, sponsor_nonce
            FROM dispatch_queue
            WHERE wallet_index = ? AND state = 'dispatched'
              AND COALESCE(dispatched_at, queued_at) <= ?
@@ -4639,7 +4803,8 @@ export class NonceDO {
             entry.sender_tx_hex,
             entry.sender_address,
             entry.sender_nonce,
-            entry.sponsor_nonce
+            entry.sponsor_nonce,
+            (entry as { payment_id?: string | null }).payment_id ?? null
           );
 
           flushed++;
@@ -4801,6 +4966,7 @@ export class NonceDO {
       const entries: Array<{
         id: number;
         wallet_index: number;
+        payment_id: string | null;
         sender_tx_hex: string;
         sender_address: string;
         sender_nonce: number;
@@ -4916,6 +5082,7 @@ export class NonceDO {
               entry.sender_address,
               entry.sender_nonce,
               freshNonce,
+              entry.payment_id ?? null,
               GAP_FILL_FEE.toString(),
               null,  // submitted_at: not available after replay
               true   // is_gap_fill: exclude from settlement percentiles
@@ -4926,6 +5093,13 @@ export class NonceDO {
             this.ledgerBroadcastOutcome(
               targetWallet.walletIndex, freshNonce, result.txid, 200, undefined, undefined
             );
+            await this.syncPaymentAfterBroadcast({
+              paymentId: entry.payment_id ?? null,
+              txid: result.txid,
+              walletIndex: targetWallet.walletIndex,
+              sponsorNonce: freshNonce,
+              fee: GAP_FILL_FEE.toString(),
+            });
             // Remove from replay buffer
             this.removeFromReplayBuffer(entry.id);
 
@@ -6120,12 +6294,13 @@ export class NonceDO {
     const entries = this.sql
       .exec<{
         id: number;
+        payment_id: string | null;
         sender_address: string;
         sender_nonce: number;
         sender_tx_hex: string;
         queued_at: string;
       }>(
-        `SELECT id, sender_address, sender_nonce, sender_tx_hex, queued_at
+        `SELECT id, payment_id, sender_address, sender_nonce, sender_tx_hex, queued_at
          FROM replay_buffer
          ORDER BY queued_at ASC
          LIMIT 5`
@@ -6137,11 +6312,12 @@ export class NonceDO {
       // INSERT OR IGNORE — never overwrite a fresher agent submission for the same nonce
       this.sql.exec(
         `INSERT OR IGNORE INTO sender_hand
-           (sender_address, sender_nonce, tx_hex, source, received_at, expires_at)
-         VALUES (?, ?, ?, 'replay', ?, ?)`,
+           (sender_address, sender_nonce, tx_hex, payment_id, source, received_at, expires_at)
+         VALUES (?, ?, ?, ?, 'replay', ?, ?)`,
         entry.sender_address,
         entry.sender_nonce,
         entry.sender_tx_hex,
+        (entry as { payment_id?: string | null }).payment_id ?? null,
         now,
         expiresAt
       );
@@ -6197,7 +6373,7 @@ export class NonceDO {
     for (const { sender_address } of senders) {
       try {
         await this.maybeRepairStaleSenderFrontier(sender_address);
-        this.checkAndAssignRun(sender_address);
+        await this.checkAndAssignRun(sender_address);
         swept++;
       } catch (e) {
         this.log("warn", "sweep_hand_error", {
@@ -6311,6 +6487,37 @@ export class NonceDO {
     };
   }
 
+  private async syncPaymentAfterBroadcast(params: {
+    paymentId: string | null;
+    txid: string;
+    walletIndex: number;
+    sponsorNonce: number;
+    fee: string;
+  }): Promise<void> {
+    if (!params.paymentId || !this.env.RELAY_KV) {
+      return;
+    }
+
+    const record = await getPaymentRecord(this.env.RELAY_KV, params.paymentId);
+    if (record && !new Set(["confirmed", "failed", "replaced"]).has(record.status)) {
+      const updated = transitionPayment(record, "mempool", {
+        txid: params.txid,
+        sponsorWalletIndex: params.walletIndex,
+        sponsorNonce: params.sponsorNonce,
+        sponsorFee: params.fee,
+        holdReason: undefined,
+        nextExpectedNonce: undefined,
+        missingNonces: undefined,
+        holdExpiresAt: undefined,
+      });
+      await putPaymentRecord(this.env.RELAY_KV, updated);
+    }
+
+    await this.env.RELAY_KV.put(`txid_map:${params.txid}`, params.paymentId, {
+      expirationTtl: 86_400,
+    });
+  }
+
   /**
    * Broadcast up to MAX_BROADCASTS_PER_TICK queued dispatch_queue entries across all wallets.
    * Processes entries ordered by wallet_index ASC, sponsor_nonce ASC to maintain ordering.
@@ -6332,12 +6539,13 @@ export class NonceDO {
     const queued = this.sql
       .exec<{
         wallet_index: number;
+        payment_id: string | null;
         sender_tx_hex: string;
         sender_address: string;
         sender_nonce: number;
         sponsor_nonce: number;
       }>(
-        `SELECT wallet_index, sender_tx_hex, sender_address, sender_nonce, sponsor_nonce
+        `SELECT wallet_index, payment_id, sender_tx_hex, sender_address, sender_nonce, sponsor_nonce
          FROM dispatch_queue
          WHERE state = 'queued'
          ORDER BY wallet_index ASC, sponsor_nonce ASC
@@ -6415,6 +6623,13 @@ export class NonceDO {
           this.ledgerBroadcastOutcome(
             entry.wallet_index, entry.sponsor_nonce, result.txid, 200, undefined, undefined
           );
+          await this.syncPaymentAfterBroadcast({
+            paymentId: entry.payment_id,
+            txid: result.txid,
+            walletIndex: entry.wallet_index,
+            sponsorNonce: entry.sponsor_nonce,
+            fee: GAP_FILL_FEE.toString(),
+          });
           broadcasts++;
           this.log("debug", "bounded_broadcast_ok", {
             walletIndex: entry.wallet_index,
@@ -6502,12 +6717,13 @@ export class NonceDO {
     // Get the failed dispatch_queue entry to identify the sender
     const failedEntry = this.sql
       .exec<{
+        payment_id: string | null;
         sender_address: string;
         sender_nonce: number;
         sender_tx_hex: string;
         original_fee: string | null;
       }>(
-        `SELECT sender_address, sender_nonce, sender_tx_hex, original_fee
+        `SELECT payment_id, sender_address, sender_nonce, sender_tx_hex, original_fee
          FROM dispatch_queue
          WHERE wallet_index = ? AND sponsor_nonce = ? LIMIT 1`,
         walletIndex,
@@ -6564,12 +6780,13 @@ export class NonceDO {
       // Get ALL higher entries from the same sender's run on this wallet
       const higherEntries = this.sql
         .exec<{
+          payment_id: string | null;
           sponsor_nonce: number;
           sender_nonce: number;
           sender_tx_hex: string;
           original_fee: string | null;
         }>(
-          `SELECT sponsor_nonce, sender_nonce, sender_tx_hex, original_fee
+          `SELECT payment_id, sponsor_nonce, sender_nonce, sender_tx_hex, original_fee
            FROM dispatch_queue
            WHERE wallet_index = ? AND sender_address = ? AND sponsor_nonce >= ?
            ORDER BY sponsor_nonce ASC`,
@@ -6604,11 +6821,12 @@ export class NonceDO {
         if (higher.sender_nonce > failedSenderNonce) {
           this.sql.exec(
             `INSERT OR IGNORE INTO sender_hand
-               (sender_address, sender_nonce, tx_hex, source, received_at, expires_at)
-             VALUES (?, ?, ?, 'replay', ?, ?)`,
+               (sender_address, sender_nonce, tx_hex, payment_id, source, received_at, expires_at)
+             VALUES (?, ?, ?, ?, 'replay', ?, ?)`,
             sender_address,
             higher.sender_nonce,
             higher.sender_tx_hex,
+            (higher as { payment_id?: string | null }).payment_id ?? null,
             now,
             expiresAt
           );
@@ -7185,12 +7403,13 @@ export class NonceDO {
       // -------------------------------------------------------------------------
       const activeEntries = this.sql
         .exec<{
+          payment_id: string | null;
           sender_tx_hex: string;
           sender_address: string;
           sender_nonce: number;
           sponsor_nonce: number;
         }>(
-          `SELECT sender_tx_hex, sender_address, sender_nonce, sponsor_nonce
+          `SELECT payment_id, sender_tx_hex, sender_address, sender_nonce, sponsor_nonce
            FROM dispatch_queue
            WHERE wallet_index = ? AND state IN ('queued', 'dispatched')
            ORDER BY sponsor_nonce ASC`,
@@ -7254,7 +7473,8 @@ export class NonceDO {
                     entry.sender_tx_hex,
                     entry.sender_address,
                     entry.sender_nonce,
-                    entry.sponsor_nonce
+                    entry.sponsor_nonce,
+                    (entry as { payment_id?: string | null }).payment_id ?? null
                   );
                   retracted++;
                 } catch (e) {
@@ -7528,6 +7748,7 @@ export class NonceDO {
           senderAddress: string;
           senderNonce: number;
           sponsorNonce: number;
+          paymentId?: string | null;
           fee?: string | null;
           submittedAt?: string | null;
         }>(request);
@@ -7547,6 +7768,7 @@ export class NonceDO {
           body.senderAddress,
           body.senderNonce ?? 0,
           body.sponsorNonce,
+          typeof body.paymentId === "string" ? body.paymentId : null,
           typeof body.fee === "string" ? body.fee : null,
           typeof body.submittedAt === "string" ? body.submittedAt : null
         );
@@ -7714,16 +7936,18 @@ export class NonceDO {
     if (request.method === "GET" && queueSenderMatch) {
       const senderAddress = decodeURIComponent(queueSenderMatch[1]);
       try {
+        const senderWedge = this.buildSenderWedgeStatus(senderAddress);
         const queueRows = this.sql
           .exec<{
             wallet_index: number;
+            payment_id: string | null;
             sponsor_nonce: number;
             sender_nonce: number;
             state: string;
             queued_at: string;
             dispatched_at: string | null;
           }>(
-            `SELECT wallet_index, sponsor_nonce, sender_nonce, state,
+            `SELECT wallet_index, payment_id, sponsor_nonce, sender_nonce, state,
                     queued_at, dispatched_at
              FROM dispatch_queue
              WHERE sender_address = ? AND state NOT IN ('confirmed', 'retired')
@@ -7733,15 +7957,34 @@ export class NonceDO {
           )
           .toArray();
 
+        const heldRows = this.sql
+          .exec<{
+            payment_id: string | null;
+            sender_nonce: number;
+            source: string;
+            received_at: string;
+            expires_at: string;
+          }>(
+            `SELECT payment_id, sender_nonce, source, received_at, expires_at
+             FROM sender_hand
+             WHERE sender_address = ? AND expires_at > ?
+             ORDER BY sender_nonce ASC
+             LIMIT 100`,
+            senderAddress,
+            new Date().toISOString()
+          )
+          .toArray();
+
         const replayRows = this.sql
           .exec<{
             id: number;
             wallet_index: number;
+            payment_id: string | null;
             sender_nonce: number;
             original_sponsor_nonce: number;
             queued_at: string;
           }>(
-            `SELECT id, wallet_index, sender_nonce, original_sponsor_nonce, queued_at
+            `SELECT id, wallet_index, payment_id, sender_nonce, original_sponsor_nonce, queued_at
              FROM replay_buffer
              WHERE sender_address = ?
              ORDER BY queued_at ASC
@@ -7754,6 +7997,7 @@ export class NonceDO {
           .filter((r) => r.state === "queued")
           .map((r) => ({
             walletIndex: r.wallet_index,
+            ...(r.payment_id && { paymentId: r.payment_id }),
             sponsorNonce: r.sponsor_nonce,
             senderNonce: r.sender_nonce,
             queuedAt: r.queued_at,
@@ -7763,6 +8007,7 @@ export class NonceDO {
           .filter((r) => r.state === "dispatched")
           .map((r) => ({
             walletIndex: r.wallet_index,
+            ...(r.payment_id && { paymentId: r.payment_id }),
             sponsorNonce: r.sponsor_nonce,
             senderNonce: r.sender_nonce,
             queuedAt: r.queued_at,
@@ -7773,29 +8018,54 @@ export class NonceDO {
           .filter((r) => r.state === "replaying")
           .map((r) => ({
             walletIndex: r.wallet_index,
+            ...(r.payment_id && { paymentId: r.payment_id }),
             sponsorNonce: r.sponsor_nonce,
             senderNonce: r.sender_nonce,
             queuedAt: r.queued_at,
           }));
 
+        const held = heldRows.map((r) => ({
+          ...(r.payment_id && { paymentId: r.payment_id }),
+          senderNonce: r.sender_nonce,
+          source: r.source,
+          receivedAt: r.received_at,
+          expiresAt: r.expires_at,
+        }));
+
         const replayBuffer = replayRows.map((r) => ({
           id: r.id,
           walletIndex: r.wallet_index,
+          ...(r.payment_id && { paymentId: r.payment_id }),
           originalSponsorNonce: r.original_sponsor_nonce,
           senderNonce: r.sender_nonce,
           queuedAt: r.queued_at,
         }));
 
         return this.jsonResponse({
+          senderWedge,
           queued,
           dispatched,
           replaying,
+          held,
           replayBuffer,
-          total: queued.length + dispatched.length + replaying.length + replayBuffer.length,
+          total: queued.length + dispatched.length + replaying.length + held.length + replayBuffer.length,
         });
       } catch (error) {
         return this.internalError(error);
       }
+    }
+
+    const senderRepairMatch = url.pathname.match(/^\/sender-repair\/([^/]+)$/);
+    if (request.method === "POST" && senderRepairMatch) {
+      const senderAddress = decodeURIComponent(senderRepairMatch[1]);
+      return this.state.blockConcurrencyWhile(async () => {
+        try {
+          const senderWedge = await this.repairSenderWedge(senderAddress);
+          return this.jsonResponse(senderWedge);
+        } catch (error) {
+          return this.internalError(error);
+        }
+      });
     }
 
     // DELETE /queue-sender/:address/:walletIndex/:sponsorNonce — agent self-service cancellation.
@@ -7929,6 +8199,7 @@ export class NonceDO {
         senderNonce: number;
         txHex: string;
         mode?: "hold" | "immediate";
+        paymentId?: string;
       }>(request);
       if (errorResponse) return errorResponse;
       if (!body?.senderAddress || typeof body.senderNonce !== "number" || !body.txHex) {
@@ -7963,10 +8234,16 @@ export class NonceDO {
           }
 
           // 4. Add to hand (agent submission — INSERT OR REPLACE)
-          this.addToHand(body.senderAddress, body.senderNonce, body.txHex, "agent");
+          this.addToHand(
+            body.senderAddress,
+            body.senderNonce,
+            body.txHex,
+            "agent",
+            body.paymentId ?? null
+          );
 
           // 5. Check for a gapless run and dispatch if found
-          const result = this.checkAndAssignRun(body.senderAddress);
+          const result = await this.checkAndAssignRun(body.senderAddress);
 
           // 6. Attach recentlyExpired info when entries expired before this submission.
           //    Helps agents understand why previously-submitted nonces disappeared.

--- a/src/durable-objects/stats-do.ts
+++ b/src/durable-objects/stats-do.ts
@@ -832,6 +832,44 @@ export class StatsDO {
     };
   }
 
+  private readRolling24hTokenStats(): DashboardOverview["tokens"] {
+    const cutoff = Date.now() - DAY_MS;
+    const rows = this.sql
+      .exec<{ token: string; count: number; volume: string | null }>(
+        `SELECT token,
+                COUNT(*) as count,
+                CAST(COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS TEXT) as volume
+         FROM tx_log
+         WHERE timestamp >= ?
+         GROUP BY token`,
+        cutoff
+      )
+      .toArray();
+
+    const totals = {
+      STX: { count: 0, volume: "0", percentage: 0 },
+      sBTC: { count: 0, volume: "0", percentage: 0 },
+      USDCx: { count: 0, volume: "0", percentage: 0 },
+    } satisfies DashboardOverview["tokens"];
+
+    for (const row of rows) {
+      if (row.token === "STX" || row.token === "sBTC" || row.token === "USDCx") {
+        totals[row.token].count = row.count ?? 0;
+        totals[row.token].volume = row.volume ?? "0";
+      }
+    }
+
+    const totalCount = totals.STX.count + totals.sBTC.count + totals.USDCx.count;
+    const pct = (count: number) =>
+      totalCount > 0 ? Math.round((count / totalCount) * 100) : 0;
+
+    totals.STX.percentage = pct(totals.STX.count);
+    totals.sBTC.percentage = pct(totals.sBTC.count);
+    totals.USDCx.percentage = pct(totals.USDCx.count);
+
+    return totals;
+  }
+
   /**
    * Build per-wallet 24h throughput entries from wallet_hourly data.
    * Only includes wallets with at least one transaction in the last 24h.
@@ -913,17 +951,10 @@ export class StatsDO {
   }
 
   private buildOverview(): DashboardOverview {
-    // readDailyStats(1) returns [today] — used for calendar-day token and fee breakdown.
+    // readDailyStats(1) returns [today] — still used for calendar-day endpoint/error breakdown.
     const todayArr = this.readDailyStats(1);
     const current = todayArr[0];
-
-    // Token percentages (from today's daily_stats — calendar-day token breakdown)
-    const totalTokenTx =
-      current.tokens.STX.count +
-      current.tokens.sBTC.count +
-      current.tokens.USDCx.count;
-    const pct = (count: number) =>
-      totalTokenTx > 0 ? Math.round((count / totalTokenTx) * 100) : 0;
+    const rollingTokens = this.readRolling24hTokenStats();
 
     // Fee aggregates (from today's daily_stats)
     const currentFees = current.fees ?? { total: "0", count: 0, min: "0", max: "0" };
@@ -1021,23 +1052,7 @@ export class StatsDO {
         rawSuccessRate,
         effectiveSuccessRate,
       },
-      tokens: {
-        STX: {
-          count: current.tokens.STX.count,
-          volume: current.tokens.STX.volume,
-          percentage: pct(current.tokens.STX.count),
-        },
-        sBTC: {
-          count: current.tokens.sBTC.count,
-          volume: current.tokens.sBTC.volume,
-          percentage: pct(current.tokens.sBTC.count),
-        },
-        USDCx: {
-          count: current.tokens.USDCx.count,
-          volume: current.tokens.USDCx.volume,
-          percentage: pct(current.tokens.USDCx.count),
-        },
-      },
+      tokens: rollingTokens,
       fees: {
         total: rollingFeeTotal,
         average: rollingFeeAvg,

--- a/src/endpoints/payment-status.ts
+++ b/src/endpoints/payment-status.ts
@@ -10,6 +10,7 @@ import {
   emitPaymentLifecycleEvent,
   emitProjectedPaymentPollEvents,
 } from "../utils";
+import { repairSenderWedgeDO } from "../services";
 
 /**
  * GET /payment/:id — Public payment status endpoint.
@@ -60,6 +61,12 @@ export class PaymentStatus extends BaseEndpoint {
                 replacementTxid: { type: "string" as const },
                 resubmittable: { type: "boolean" as const },
                 senderNonceInfo: { type: "object" as const },
+                relayState: { type: "string" as const },
+                holdReason: { type: "string" as const },
+                nextExpectedNonce: { type: "number" as const },
+                missingNonces: { type: "array" as const, items: { type: "number" as const } },
+                holdExpiresAt: { type: "string" as const },
+                senderWedge: { type: "object" as const },
               },
             },
           },
@@ -157,9 +164,21 @@ export class PaymentStatus extends BaseEndpoint {
       );
     }
 
-    const projected = projectPaymentRecord(record);
+    let refreshedRecord = record;
+    let senderWedge;
+    if (
+      record.status === "queued" &&
+      record.relayState === "held" &&
+      record.holdReason === "gap" &&
+      record.senderAddress
+    ) {
+      senderWedge = await repairSenderWedgeDO(c.env, logger, record.senderAddress);
+      refreshedRecord = (await getPaymentRecord(kv, paymentId)) ?? record;
+    }
+
+    const projected = projectPaymentRecord(refreshedRecord);
     const checkStatusUrl = buildPaymentCheckStatusUrl(c.env, projected.paymentId);
-    const compatShimUsed = record.status === "submitted";
+    const compatShimUsed = refreshedRecord.status === "submitted";
 
     emitProjectedPaymentPollEvents(
       logger,
@@ -190,6 +209,14 @@ export class PaymentStatus extends BaseEndpoint {
       ...(projected.senderNonceInfo && {
         senderNonceInfo: projected.senderNonceInfo,
       }),
+      ...(projected.relayState && { relayState: projected.relayState }),
+      ...(projected.holdReason && { holdReason: projected.holdReason }),
+      ...(projected.nextExpectedNonce !== undefined && {
+        nextExpectedNonce: projected.nextExpectedNonce,
+      }),
+      ...(projected.missingNonces && { missingNonces: projected.missingNonces }),
+      ...(projected.holdExpiresAt && { holdExpiresAt: projected.holdExpiresAt }),
+      ...(senderWedge && { senderWedge }),
       submittedAt: projected.submittedAt,
       ...(projected.queuedAt && { queuedAt: projected.queuedAt }),
       ...(projected.mempoolAt && { mempoolAt: projected.mempoolAt }),

--- a/src/endpoints/queue-read.ts
+++ b/src/endpoints/queue-read.ts
@@ -74,6 +74,19 @@ export class QueueRead extends BaseEndpoint {
                         },
                       },
                     },
+                    held: {
+                      type: "array" as const,
+                      items: {
+                        type: "object" as const,
+                        properties: {
+                          paymentId: { type: "string" as const },
+                          senderNonce: { type: "number" as const },
+                          source: { type: "string" as const },
+                          receivedAt: { type: "string" as const },
+                          expiresAt: { type: "string" as const },
+                        },
+                      },
+                    },
                     replayBuffer: {
                       type: "array" as const,
                       items: {
@@ -81,10 +94,31 @@ export class QueueRead extends BaseEndpoint {
                         properties: {
                           id: { type: "number" as const },
                           walletIndex: { type: "number" as const },
+                          paymentId: { type: "string" as const },
                           originalSponsorNonce: { type: "number" as const },
                           senderNonce: { type: "number" as const },
                           queuedAt: { type: "string" as const },
                         },
+                      },
+                    },
+                    senderWedge: {
+                      type: "object" as const,
+                      properties: {
+                        senderAddress: { type: "string" as const },
+                        blocked: { type: "boolean" as const },
+                        blockedOnFrontierMismatch: { type: "boolean" as const },
+                        adminRecoveryLikely: { type: "boolean" as const },
+                        nextExpectedNonce: { type: "number" as const, nullable: true },
+                        lowestHeldNonce: { type: "number" as const, nullable: true },
+                        missingNonces: { type: "array" as const, items: { type: "number" as const } },
+                        heldCount: { type: "number" as const },
+                        oldestHeldAgeMs: { type: "number" as const, nullable: true },
+                        lastRepairAttemptAt: { type: "string" as const, nullable: true },
+                        lastRepairFailureAt: { type: "string" as const, nullable: true },
+                        repairEligible: { type: "boolean" as const },
+                        repairTriggered: { type: "boolean" as const },
+                        repairAdvanced: { type: "boolean" as const },
+                        activePaymentIds: { type: "array" as const, items: { type: "string" as const } },
                       },
                     },
                     total: { type: "number" as const },

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -30,7 +30,14 @@ import {
   type PaymentRecord,
 } from "./services/payment-status";
 import { clearInFlight, updateSenderNonceOnBroadcast } from "./services/sender-nonce";
-import { SponsorService, extractSponsorNonce, recordNonceTxid, releaseNonceDO, recordBroadcastOutcomeDO, SettlementService } from "./services";
+import {
+  SponsorService,
+  extractSponsorNonce,
+  releaseNonceDO,
+  SettlementService,
+  nonceLifecycleOnBroadcastSuccess,
+  repairSenderWedgeDO,
+} from "./services";
 
 /** Max retries before dead-lettering */
 const MAX_ATTEMPTS = 5;
@@ -154,7 +161,12 @@ async function processPaymentMessage(
 
   // Sponsor the transaction (assigns nonce from NonceDO, signs with sponsor key)
   const sponsorService = new SponsorService(env, logger);
-  const sponsorResult = await sponsorService.sponsorTransaction(transaction);
+  const sponsorResult = await sponsorService.sponsorTransaction(
+    transaction,
+    txHex,
+    "hold",
+    paymentId
+  );
 
   if (!sponsorResult.success) {
     if ("held" in sponsorResult && sponsorResult.held) {
@@ -165,27 +177,25 @@ async function processPaymentMessage(
         missingNonces: sponsorResult.missingNonces,
       });
       if (sponsorResult.holdReason === "gap") {
-        if (record.senderNonce !== undefined) {
-          await clearInFlight(kv, signerHash, record.senderNonce).catch((e) =>
-            logger.warn("Failed to clear in-flight marker on sender gap", {
-              error: String(e),
-            })
-          );
-        }
-
-        record = transitionPayment(record, "failed", {
+        record = transitionPayment(record, "queued", {
           error: `Sender nonce gap: waiting for nonce ${sponsorResult.nextExpected}`,
-          errorCode: "SENDER_NONCE_GAP",
-          terminalReason: "sender_nonce_gap",
-          retryable: false,
+          errorCode: undefined,
+          terminalReason: undefined,
+          retryable: undefined,
+          holdReason: "gap",
+          nextExpectedNonce: sponsorResult.nextExpected,
+          missingNonces: sponsorResult.missingNonces,
+          holdExpiresAt: sponsorResult.expiresAt,
         });
         await putPaymentRecord(kv, record);
-        emitPaymentLifecycleEvent(logger, "payment.finalized", {
+        if (record.senderAddress) {
+          await repairSenderWedgeDO(env, logger, record.senderAddress);
+        }
+        emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
           route: "PAYMENT_QUEUE",
           paymentId,
           status: record.status,
-          terminalReason: record.terminalReason,
-          action: "sender_nonce_gap_terminal",
+          action: "sender_nonce_gap_held",
           checkStatusUrlPresent: false,
           compatShimUsed: false,
           attempt,
@@ -196,6 +206,10 @@ async function processPaymentMessage(
 
       record = transitionPayment(record, "queued", {
         error: "Sponsor pool temporarily has no dispatch capacity",
+        holdReason: "capacity",
+        nextExpectedNonce: sponsorResult.nextExpected,
+        missingNonces: sponsorResult.missingNonces,
+        holdExpiresAt: sponsorResult.expiresAt,
       });
       await putPaymentRecord(kv, record);
       emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
@@ -289,6 +303,10 @@ async function processPaymentMessage(
   record.sponsorWalletIndex = walletIndex;
   record.sponsorNonce = sponsorNonce !== null ? sponsorNonce : undefined;
   record.sponsorFee = sponsorResult.fee;
+  record.holdReason = undefined;
+  record.nextExpectedNonce = undefined;
+  record.missingNonces = undefined;
+  record.holdExpiresAt = undefined;
 
   const settlementService = new SettlementService(env, logger);
   const broadcastResult = await settlementService.broadcastOnly(sponsoredTx);
@@ -387,17 +405,17 @@ async function processPaymentMessage(
 
   // Record txid with NonceDO and release the reserved nonce slot
   if (sponsorNonce !== null) {
-    await Promise.all([
-      recordNonceTxid(env, logger, txid, sponsorNonce).catch(
-        (e) => logger.warn("Failed to record nonce txid", { error: String(e) })
-      ),
-      releaseNonceDO(env, logger, sponsorNonce, txid, walletIndex, sponsorResult.fee).catch(
-        (e) => logger.warn("Failed to release nonce", { error: String(e) })
-      ),
-      recordBroadcastOutcomeDO(env, logger, sponsorNonce, walletIndex, txid, 200, undefined, undefined).catch(
-        (e) => logger.warn("Failed to record broadcast outcome", { error: String(e) })
-      ),
-    ]);
+    await nonceLifecycleOnBroadcastSuccess(env, logger, {
+      sponsorNonce,
+      walletIndex,
+      txid,
+      fee: sponsorResult.fee,
+      paymentId,
+      senderTxHex: txHex,
+      senderAddress: record.senderAddress ?? "",
+      senderNonce: record.senderNonce ?? Number(transaction.auth.spendingCondition.nonce),
+      submittedAt: record.submittedAt,
+    });
   }
 
   // Update payment record

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -412,8 +412,8 @@ async function processPaymentMessage(
       fee: sponsorResult.fee,
       paymentId,
       senderTxHex: txHex,
-      senderAddress: record.senderAddress ?? "",
-      senderNonce: record.senderNonce ?? Number(transaction.auth.spendingCondition.nonce),
+      senderAddress: record.senderAddress,
+      senderNonce: record.senderNonce,
       submittedAt: record.submittedAt,
     });
   }

--- a/src/routes/discovery.ts
+++ b/src/routes/discovery.ts
@@ -76,7 +76,7 @@ If the relay rejects before canonical acceptance, sender nonce gap can still be 
 }
 
 If the payment was already accepted and later wedges in sender hand, it remains canonical
-`queued` work on the same paymentId and polling returns additive hold diagnostics instead
+"queued" work on the same paymentId and polling returns additive hold diagnostics instead
 of terminalizing it:
 {
   "success": true,

--- a/src/routes/discovery.ts
+++ b/src/routes/discovery.ts
@@ -63,7 +63,7 @@ Terminal outcomes include terminalReason when known:
 - expired
 - unknown_payment_identity
 
-Example terminal response:
+If the relay rejects before canonical acceptance, sender nonce gap can still be terminal:
 {
   "success": true,
   "requestId": "req_123",
@@ -73,6 +73,21 @@ Example terminal response:
   "error": "Sender nonce gap: waiting for nonce 5",
   "retryable": false,
   "checkStatusUrl": "${BASE_URL_PLACEHOLDER}/payment/pay_01J..."
+}
+
+If the payment was already accepted and later wedges in sender hand, it remains canonical
+`queued` work on the same paymentId and polling returns additive hold diagnostics instead
+of terminalizing it:
+{
+  "success": true,
+  "requestId": "req_124",
+  "paymentId": "pay_01J...held",
+  "status": "queued",
+  "relayState": "held",
+  "holdReason": "gap",
+  "nextExpectedNonce": 5,
+  "missingNonces": [5],
+  "checkStatusUrl": "${BASE_URL_PLACEHOLDER}/payment/pay_01J...held"
 }
 
 ${includeArtifactDedupeDetail ? `Duplicate submission of the same payment artifact reuses the same paymentId until

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -58,6 +58,15 @@ import { repairSenderWedgeDO } from "./services";
 
 export type { SubmitPaymentResult, CheckPaymentResult };
 
+type RelayCheckPaymentResult = CheckPaymentResult & {
+  relayState?: "held" | "queued" | "broadcasting" | "mempool";
+  holdReason?: "gap" | "capacity";
+  nextExpectedNonce?: number;
+  missingNonces?: number[];
+  holdExpiresAt?: string;
+  senderWedge?: import("./types").SenderWedgeStatus;
+};
+
 type PublicRpcErrorCode = (typeof RPC_ERROR_CODES)[number];
 
 function projectRpcErrorCode(errorCode?: string): PublicRpcErrorCode | undefined {
@@ -390,7 +399,7 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
   /**
    * Check the status of a previously submitted payment.
    */
-  async checkPayment(paymentId: string): Promise<CheckPaymentResult> {
+  async checkPayment(paymentId: string): Promise<RelayCheckPaymentResult> {
     const logger = createWorkerLogger(this.env.LOGS, this.ctx, {
       component: "rpc",
       route: "rpc.checkPayment",
@@ -440,7 +449,7 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
     }
 
     const projected = projectPaymentRecord(refreshedRecord);
-    const compatShimUsed = record.status === "submitted";
+    const compatShimUsed = refreshedRecord.status === "submitted";
 
     emitProjectedPaymentPollEvents(
       logger,
@@ -470,7 +479,7 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
       ...(projected.holdExpiresAt && { holdExpiresAt: projected.holdExpiresAt }),
       ...(senderWedge && { senderWedge }),
       checkStatusUrl,
-    } as CheckPaymentResult;
+    };
   }
 
   /**

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -54,6 +54,7 @@ import {
   markInFlight,
   seedSenderNonceFromHiro,
 } from "./services/sender-nonce";
+import { repairSenderWedgeDO } from "./services";
 
 export type { SubmitPaymentResult, CheckPaymentResult };
 
@@ -426,7 +427,19 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
       };
     }
 
-    const projected = projectPaymentRecord(record);
+    let refreshedRecord = record;
+    let senderWedge;
+    if (
+      record.status === "queued" &&
+      record.relayState === "held" &&
+      record.holdReason === "gap" &&
+      record.senderAddress
+    ) {
+      senderWedge = await repairSenderWedgeDO(this.env, logger, record.senderAddress);
+      refreshedRecord = (await getPaymentRecord(kv, paymentId)) ?? record;
+    }
+
+    const projected = projectPaymentRecord(refreshedRecord);
     const compatShimUsed = record.status === "submitted";
 
     emitProjectedPaymentPollEvents(
@@ -448,8 +461,16 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
       errorCode: projectRpcErrorCode(projected.errorCode),
       retryable: projected.retryable,
       senderNonceInfo: projected.senderNonceInfo,
+      ...(projected.relayState && { relayState: projected.relayState }),
+      ...(projected.holdReason && { holdReason: projected.holdReason }),
+      ...(projected.nextExpectedNonce !== undefined && {
+        nextExpectedNonce: projected.nextExpectedNonce,
+      }),
+      ...(projected.missingNonces && { missingNonces: projected.missingNonces }),
+      ...(projected.holdExpiresAt && { holdExpiresAt: projected.holdExpiresAt }),
+      ...(senderWedge && { senderWedge }),
       checkStatusUrl,
-    };
+    } as CheckPaymentResult;
   }
 
   /**

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,15 @@
-export { SponsorService, hasSponsorSignature, extractSponsorNonce, recordNonceTxid, releaseNonceDO, recordBroadcastOutcomeDO, queueDispatchDO, nonceLifecycleOnBroadcastSuccess } from "./sponsor";
+export {
+  SponsorService,
+  hasSponsorSignature,
+  extractSponsorNonce,
+  recordNonceTxid,
+  releaseNonceDO,
+  recordBroadcastOutcomeDO,
+  queueDispatchDO,
+  nonceLifecycleOnBroadcastSuccess,
+  getSenderWedgeDO,
+  repairSenderWedgeDO,
+} from "./sponsor";
 export type {
   TransactionValidationResult,
   TransactionValidationSuccess,

--- a/src/services/payment-status.ts
+++ b/src/services/payment-status.ts
@@ -136,6 +136,13 @@ export interface PublicPaymentRecord
   terminalReason?: TerminalReason;
 }
 
+function clearHoldMetadata(record: PaymentRecord): void {
+  record.holdReason = undefined;
+  record.nextExpectedNonce = undefined;
+  record.missingNonces = undefined;
+  record.holdExpiresAt = undefined;
+}
+
 /**
  * Queue message body for PAYMENT_QUEUE.
  */
@@ -350,32 +357,34 @@ export function transitionPayment(
       updated.queuedAt = now;
       updated.relayState = extra?.holdReason ? "held" : "queued";
       if (!extra?.holdReason) {
-        updated.holdReason = undefined;
-        updated.nextExpectedNonce = undefined;
-        updated.missingNonces = undefined;
-        updated.holdExpiresAt = undefined;
+        clearHoldMetadata(updated);
       }
       break;
     case "broadcasting":
       updated.broadcastingAt = now;
       updated.attempts = (record.attempts ?? 0) + 1;
       updated.relayState = "broadcasting";
+      clearHoldMetadata(updated);
       break;
     case "mempool":
       updated.mempoolAt = now;
       updated.relayState = "mempool";
+      clearHoldMetadata(updated);
       break;
     case "confirmed":
       updated.confirmedAt = now;
       updated.relayState = undefined;
+      clearHoldMetadata(updated);
       break;
     case "failed":
       updated.failedAt = now;
       updated.relayState = undefined;
+      clearHoldMetadata(updated);
       break;
     case "replaced":
       updated.replacedAt = now;
       updated.relayState = undefined;
+      clearHoldMetadata(updated);
       break;
   }
 

--- a/src/services/payment-status.ts
+++ b/src/services/payment-status.ts
@@ -118,6 +118,16 @@ export interface PaymentRecord {
   network: "mainnet" | "testnet";
   /** Number of queue processing attempts */
   attempts?: number;
+  /** Internal relay ownership step for queued sender-hand / dispatch tracking */
+  relayState?: "held" | "queued" | "broadcasting" | "mempool";
+  /** Why the payment is currently held before dispatch ownership can advance */
+  holdReason?: "gap" | "capacity";
+  /** The next sender nonce needed before dispatch can advance */
+  nextExpectedNonce?: number;
+  /** Missing sender nonces currently blocking dispatch */
+  missingNonces?: number[];
+  /** ISO timestamp when the current held sender-hand entry expires */
+  holdExpiresAt?: string;
 }
 
 export interface PublicPaymentRecord
@@ -338,22 +348,34 @@ export function transitionPayment(
   switch (status) {
     case "queued":
       updated.queuedAt = now;
+      updated.relayState = extra?.holdReason ? "held" : "queued";
+      if (!extra?.holdReason) {
+        updated.holdReason = undefined;
+        updated.nextExpectedNonce = undefined;
+        updated.missingNonces = undefined;
+        updated.holdExpiresAt = undefined;
+      }
       break;
     case "broadcasting":
       updated.broadcastingAt = now;
       updated.attempts = (record.attempts ?? 0) + 1;
+      updated.relayState = "broadcasting";
       break;
     case "mempool":
       updated.mempoolAt = now;
+      updated.relayState = "mempool";
       break;
     case "confirmed":
       updated.confirmedAt = now;
+      updated.relayState = undefined;
       break;
     case "failed":
       updated.failedAt = now;
+      updated.relayState = undefined;
       break;
     case "replaced":
       updated.replacedAt = now;
+      updated.relayState = undefined;
       break;
   }
 

--- a/src/services/sponsor.ts
+++ b/src/services/sponsor.ts
@@ -1568,8 +1568,8 @@ export async function nonceLifecycleOnBroadcastSuccess(
     fee?: string;
     paymentId?: string;
     senderTxHex: string;
-    senderAddress: string;
-    senderNonce: number;
+    senderAddress?: string;
+    senderNonce?: number;
     /** ISO timestamp of when the client HTTP request arrived at the relay endpoint.
      *  Used as the start time for settlement latency measurement. */
     submittedAt?: string;
@@ -1588,18 +1588,34 @@ export async function nonceLifecycleOnBroadcastSuccess(
   }
 
   // Now release nonce and queue dispatch in parallel (order-independent)
-  await Promise.all([
+  const lifecycleTasks: Promise<void>[] = [
     releaseNonceDO(env, logger, opts.sponsorNonce, opts.txid, opts.walletIndex, opts.fee),
     recordNonceTxid(env, logger, opts.txid, opts.sponsorNonce),
-    queueDispatchDO(
-      env, logger, opts.walletIndex,
-      opts.senderTxHex, opts.senderAddress,
-      opts.senderNonce, opts.sponsorNonce,
-      opts.paymentId,
-      opts.fee ?? null,
-      opts.submittedAt ?? null
-    ),
-  ]).catch((e) => {
+  ];
+
+  if (opts.senderAddress && opts.senderNonce !== undefined) {
+    lifecycleTasks.push(
+      queueDispatchDO(
+        env, logger, opts.walletIndex,
+        opts.senderTxHex, opts.senderAddress,
+        opts.senderNonce, opts.sponsorNonce,
+        opts.paymentId,
+        opts.fee ?? null,
+        opts.submittedAt ?? null
+      )
+    );
+  } else {
+    logger.warn("Skipping queue-dispatch correlation after broadcast success", {
+      paymentId: opts.paymentId,
+      txid: opts.txid,
+      walletIndex: opts.walletIndex,
+      sponsorNonce: opts.sponsorNonce,
+      senderAddressPresent: Boolean(opts.senderAddress),
+      senderNoncePresent: opts.senderNonce !== undefined,
+    });
+  }
+
+  await Promise.all(lifecycleTasks).catch((e) => {
     logger.warn("Failed nonce lifecycle after broadcast success", { error: String(e) });
   });
 }

--- a/src/services/sponsor.ts
+++ b/src/services/sponsor.ts
@@ -16,7 +16,17 @@ import {
   generateWallet,
 } from "@stacks/wallet-sdk";
 import { SERVICE_DEGRADED_RETRY_AFTER_S } from "../types";
-import type { Env, Logger, FeeTransactionType, FeePriority, WalletStatus, WalletsResponse, HandSubmitResult, SponsorHeld } from "../types";
+import type {
+  Env,
+  Logger,
+  FeeTransactionType,
+  FeePriority,
+  WalletStatus,
+  WalletsResponse,
+  HandSubmitResult,
+  SenderWedgeStatus,
+  SponsorHeld,
+} from "../types";
 import { getHiroBaseUrl, getHiroHeaders, stripHexPrefix, decodeClarityUint } from "../utils";
 import { FeeService } from "./fee";
 
@@ -568,7 +578,8 @@ export class SponsorService {
     senderAddress: string,
     senderNonce: number,
     txHex: string,
-    mode: "hold" | "immediate" = "hold"
+    mode: "hold" | "immediate" = "hold",
+    paymentId?: string
   ): Promise<HandSubmitResult | null> {
     if (!this.env.NONCE_DO) return null;
     try {
@@ -576,7 +587,7 @@ export class SponsorService {
       const response = await stub.fetch("https://nonce-do/hand-submit", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ senderAddress, senderNonce, txHex, mode }),
+        body: JSON.stringify({ senderAddress, senderNonce, txHex, mode, paymentId }),
       });
 
       if (!response.ok) {
@@ -777,7 +788,8 @@ export class SponsorService {
   async sponsorTransaction(
     transaction: StacksTransactionWire,
     originalTxHex?: string,
-    mode: "hold" | "immediate" = "hold"
+    mode: "hold" | "immediate" = "hold",
+    paymentId?: string
   ): Promise<SponsorResult> {
     const network = this.getNetwork();
 
@@ -807,7 +819,13 @@ export class SponsorService {
 
       let handResult: HandSubmitResult | null;
       try {
-        handResult = await this.submitToHand(senderAddress, senderNonce, txHexForHand, mode);
+        handResult = await this.submitToHand(
+          senderAddress,
+          senderNonce,
+          txHexForHand,
+          mode,
+          paymentId
+        );
       } catch (e) {
         if (isHandSubmitValidationError(e)) {
           // DO returned a 4xx validation rejection (e.g., STALE_SENDER_NONCE).
@@ -1548,6 +1566,7 @@ export async function nonceLifecycleOnBroadcastSuccess(
     walletIndex: number;
     txid: string;
     fee?: string;
+    paymentId?: string;
     senderTxHex: string;
     senderAddress: string;
     senderNonce: number;
@@ -1576,6 +1595,7 @@ export async function nonceLifecycleOnBroadcastSuccess(
       env, logger, opts.walletIndex,
       opts.senderTxHex, opts.senderAddress,
       opts.senderNonce, opts.sponsorNonce,
+      opts.paymentId,
       opts.fee ?? null,
       opts.submittedAt ?? null
     ),
@@ -1592,6 +1612,7 @@ export async function queueDispatchDO(
   senderAddress: string,
   senderNonce: number,
   sponsorNonce: number,
+  paymentId?: string,
   fee?: string | null,
   submittedAt?: string | null
 ): Promise<void> {
@@ -1609,6 +1630,7 @@ export async function queueDispatchDO(
         senderAddress,
         senderNonce,
         sponsorNonce,
+        paymentId,
         fee: fee ?? null,
         submittedAt: submittedAt ?? null,
       }),
@@ -1628,5 +1650,77 @@ export async function queueDispatchDO(
       walletIndex,
       sponsorNonce,
     });
+  }
+}
+
+export async function getSenderWedgeDO(
+  env: Env,
+  logger: Logger,
+  senderAddress: string
+): Promise<SenderWedgeStatus | null> {
+  if (!env.NONCE_DO) {
+    return null;
+  }
+
+  try {
+    const stub = env.NONCE_DO.get(env.NONCE_DO.idFromName("sponsor"));
+    const response = await stub.fetch(
+      `https://nonce-do/queue-sender/${encodeURIComponent(senderAddress)}`
+    );
+
+    if (!response.ok) {
+      const body = await response.text();
+      logger.warn("Nonce DO queue-sender wedge read failed", {
+        status: response.status,
+        body,
+        senderAddress,
+      });
+      return null;
+    }
+
+    const body = await response.json() as { senderWedge?: SenderWedgeStatus };
+    return body.senderWedge ?? null;
+  } catch (e) {
+    logger.warn("Failed to fetch sender wedge status", {
+      error: e instanceof Error ? e.message : String(e),
+      senderAddress,
+    });
+    return null;
+  }
+}
+
+export async function repairSenderWedgeDO(
+  env: Env,
+  logger: Logger,
+  senderAddress: string
+): Promise<SenderWedgeStatus | null> {
+  if (!env.NONCE_DO) {
+    return null;
+  }
+
+  try {
+    const stub = env.NONCE_DO.get(env.NONCE_DO.idFromName("sponsor"));
+    const response = await stub.fetch(
+      `https://nonce-do/sender-repair/${encodeURIComponent(senderAddress)}`,
+      { method: "POST" }
+    );
+
+    if (!response.ok) {
+      const body = await response.text();
+      logger.warn("Nonce DO sender repair failed", {
+        status: response.status,
+        body,
+        senderAddress,
+      });
+      return null;
+    }
+
+    return await response.json() as SenderWedgeStatus;
+  } catch (e) {
+    logger.warn("Failed to trigger sender wedge repair", {
+      error: e instanceof Error ? e.message : String(e),
+      senderAddress,
+    });
+    return null;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1399,6 +1399,28 @@ export interface RecentExpiryInfo {
 }
 
 /**
+ * Sender-side wedge diagnostics for held transactions that are blocked
+ * behind a sender frontier mismatch inside NonceDO.
+ */
+export interface SenderWedgeStatus {
+  senderAddress: string;
+  blocked: boolean;
+  blockedOnFrontierMismatch: boolean;
+  adminRecoveryLikely: boolean;
+  nextExpectedNonce: number | null;
+  lowestHeldNonce: number | null;
+  missingNonces: number[];
+  heldCount: number;
+  oldestHeldAgeMs: number | null;
+  lastRepairAttemptAt: string | null;
+  lastRepairFailureAt: string | null;
+  repairEligible: boolean;
+  repairTriggered?: boolean;
+  repairAdvanced?: boolean;
+  activePaymentIds?: string[];
+}
+
+/**
  * A single entry in a sender's hand queue (sender_hand table row).
  * Each entry represents an agent-submitted or replay transaction waiting
  * to be dispatched.


### PR DESCRIPTION
## Summary
- finish Phase 2 of the boring payment state machine in the relay by keeping one canonical payment record aligned with NonceDO sender-hand, queue, replay, and poll behavior
- add eager sender-frontier repair plus explicit sender-wedge introspection so agents can understand when to keep polling, when to rebuild/re-sign, and when admin recovery is likely
- align `/stats` token cards with the same rolling 24h window as the headline and add lifecycle continuity coverage for the new failure classes

## What Changed
- thread canonical payment continuity through queue/DO ownership so held work can later be re-queued or broadcast without drifting away from the original payment record
- expose held-state and sender-wedge diagnostics on canonical payment polling and sender queue introspection
- trigger bounded sender-frontier reconciliation on fresh sender-gap wedge and on fresh polls of held canonical payments
- keep non-terminal held payments clearly recoverable on the same payment and avoid terminalizing live sender-gap work
- add tests for held-gap continuity, unified payment correlation, held poll diagnostics, and canonical re-queue sync

## Verification
- `npm test -- src/__tests__/queue-consumer.test.ts src/__tests__/payment-status.test.ts src/__tests__/nonce-do-sponsor-status.test.ts`
- `npm run check`
- `npm test`

## Quest Context
- Phase 1 in `tx-schemas` is submitted as `aibtcdev/tx-schemas#19`
- Phase 3 in `landing-page` is submitted as `aibtcdev/landing-page#582`
- this PR completes the relay critical path for Phase 2 in `x402-sponsor-relay`
- downstream follow-up remains Phase 4 in `aibtc-mcp-server`, Phase 5 in `skills`, and Phase 6 cross-repo verification