### PR TITLE
fix(deps): pin axios>=1.15.0 to patch CVE-2025-62718 (SSRF)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1961,14 +1961,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/base-x": {
@@ -2710,10 +2710,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "wrangler": "^4.75.0"
   },
   "overrides": {
-    "vite": "7.3.2"
+    "vite": "7.3.2",
+    "axios": ">=1.15.0"
   },
   "dependencies": {
     "@aibtc/tx-schemas": "^0.7.0",


### PR DESCRIPTION
## Summary

- Pins `axios` to `>=1.15.0` via npm `overrides` to patch CVE-2025-62718
- axios was a transitive dependency via `x402-stacks` at version 1.13.6 (vulnerable)
- After override: package-lock.json resolves axios to 1.15.0

## Vulnerability

**CVE-2025-62718** — axios NO_PROXY Hostname Normalization Bypass (SSRF)

Axios did not correctly handle hostname normalization when checking `NO_PROXY` rules. Requests to loopback addresses like `localhost.` (trailing dot) or `[::1]` (IPv6 literal) could skip `NO_PROXY` matching and route through a configured proxy.

**Impact on this service**: Low — this runs as a Cloudflare Worker where NO_PROXY settings don't apply. However, patching is correct practice and resolves the Dependabot critical alert.

## Test plan

- [x] `npm install --package-lock-only` regenerated lock file cleanly
- [x] `package-lock.json` confirms axios resolves to `1.15.0`
- [ ] CI type-check passes

Closes #31 (Dependabot alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)