### PR TITLE
fix(payment): self-heal mempool payments on status poll

### DIFF
--- a/src/endpoints/payment-status.ts
+++ b/src/endpoints/payment-status.ts
@@ -3,8 +3,7 @@ import type { AppContext } from "../types";
 import {
   buildNotFoundPaymentRecord,
   getPaymentRecord,
-  putPaymentRecord,
-  transitionPayment,
+  selfHealMempoolRecord,
   projectPaymentRecord,
 } from "../services/payment-status";
 import {
@@ -12,7 +11,7 @@ import {
   emitPaymentLifecycleEvent,
   emitProjectedPaymentPollEvents,
 } from "../utils";
-import { repairSenderWedgeDO, SettlementService } from "../services";
+import { repairSenderWedgeDO } from "../services";
 
 /**
  * GET /payment/:id — Public payment status endpoint.
@@ -179,53 +178,9 @@ export class PaymentStatus extends BaseEndpoint {
     }
 
     // Self-healing: check on-chain status for payments stuck in mempool
-    if (refreshedRecord.status === "mempool" && refreshedRecord.txid) {
-      try {
-        const settlement = new SettlementService(c.env, logger);
-        const hiroStatus = await settlement.fetchHiroTxStatus(refreshedRecord.txid);
-
-        let healedStatus: "confirmed" | "failed" | undefined;
-        let healAction: string | undefined;
-        let healEventExtra: Record<string, unknown> = {};
-
-        if (hiroStatus?.txStatus === "success" && typeof hiroStatus.blockHeight === "number") {
-          refreshedRecord = transitionPayment(refreshedRecord, "confirmed", {
-            blockHeight: hiroStatus.blockHeight,
-          });
-          healedStatus = "confirmed";
-          healAction = "mempool_to_confirmed";
-          healEventExtra = { blockHeight: hiroStatus.blockHeight };
-        } else if (hiroStatus?.txStatus.startsWith("abort_")) {
-          refreshedRecord = transitionPayment(refreshedRecord, "failed", {
-            error: "Transaction aborted on-chain",
-            errorCode: "SETTLEMENT_FAILED",
-            terminalReason: "chain_abort",
-            retryable: false,
-          });
-          healedStatus = "failed";
-          healAction = "mempool_to_failed";
-          healEventExtra = { terminalReason: "chain_abort" };
-        }
-
-        if (healedStatus) {
-          await putPaymentRecord(kv, refreshedRecord);
-          emitPaymentLifecycleEvent(logger, "payment.self_healed", {
-            route: "GET /payment/:id",
-            paymentId,
-            status: healedStatus,
-            action: healAction!,
-            checkStatusUrlPresent: true,
-            compatShimUsed: false,
-            ...healEventExtra,
-          });
-        }
-      } catch (e) {
-        logger.warn("Self-healing check failed, returning stale status", {
-          paymentId,
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
-    }
+    refreshedRecord = await selfHealMempoolRecord(
+      refreshedRecord, kv, c.env, logger, "GET /payment/:id"
+    );
 
     const projected = projectPaymentRecord(refreshedRecord);
     const checkStatusUrl = buildPaymentCheckStatusUrl(c.env, projected.paymentId);

--- a/src/endpoints/payment-status.ts
+++ b/src/endpoints/payment-status.ts
@@ -3,6 +3,8 @@ import type { AppContext } from "../types";
 import {
   buildNotFoundPaymentRecord,
   getPaymentRecord,
+  putPaymentRecord,
+  transitionPayment,
   projectPaymentRecord,
 } from "../services/payment-status";
 import {
@@ -10,7 +12,7 @@ import {
   emitPaymentLifecycleEvent,
   emitProjectedPaymentPollEvents,
 } from "../utils";
-import { repairSenderWedgeDO } from "../services";
+import { repairSenderWedgeDO, SettlementService } from "../services";
 
 /**
  * GET /payment/:id — Public payment status endpoint.
@@ -174,6 +176,55 @@ export class PaymentStatus extends BaseEndpoint {
     ) {
       senderWedge = await repairSenderWedgeDO(c.env, logger, record.senderAddress);
       refreshedRecord = (await getPaymentRecord(kv, paymentId)) ?? record;
+    }
+
+    // Self-healing: check on-chain status for payments stuck in mempool
+    if (refreshedRecord.status === "mempool" && refreshedRecord.txid) {
+      try {
+        const settlement = new SettlementService(c.env, logger);
+        const hiroStatus = await settlement.fetchHiroTxStatus(refreshedRecord.txid);
+
+        let healedStatus: "confirmed" | "failed" | undefined;
+        let healAction: string | undefined;
+        let healEventExtra: Record<string, unknown> = {};
+
+        if (hiroStatus?.txStatus === "success" && typeof hiroStatus.blockHeight === "number") {
+          refreshedRecord = transitionPayment(refreshedRecord, "confirmed", {
+            blockHeight: hiroStatus.blockHeight,
+          });
+          healedStatus = "confirmed";
+          healAction = "mempool_to_confirmed";
+          healEventExtra = { blockHeight: hiroStatus.blockHeight };
+        } else if (hiroStatus?.txStatus.startsWith("abort_")) {
+          refreshedRecord = transitionPayment(refreshedRecord, "failed", {
+            error: "Transaction aborted on-chain",
+            errorCode: "SETTLEMENT_FAILED",
+            terminalReason: "chain_abort",
+            retryable: false,
+          });
+          healedStatus = "failed";
+          healAction = "mempool_to_failed";
+          healEventExtra = { terminalReason: "chain_abort" };
+        }
+
+        if (healedStatus) {
+          await putPaymentRecord(kv, refreshedRecord);
+          emitPaymentLifecycleEvent(logger, "payment.self_healed", {
+            route: "GET /payment/:id",
+            paymentId,
+            status: healedStatus,
+            action: healAction!,
+            checkStatusUrlPresent: true,
+            compatShimUsed: false,
+            ...healEventExtra,
+          });
+        }
+      } catch (e) {
+        logger.warn("Self-healing check failed, returning stale status", {
+          paymentId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
     }
 
     const projected = projectPaymentRecord(refreshedRecord);

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -46,6 +46,7 @@ import {
   type SenderNonceInfo,
   putPaymentArtifact,
   putPaymentRecord,
+  selfHealMempoolRecord,
   transitionPayment,
 } from "./services/payment-status";
 import {
@@ -447,6 +448,11 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
       senderWedge = await repairSenderWedgeDO(this.env, logger, record.senderAddress);
       refreshedRecord = (await getPaymentRecord(kv, paymentId)) ?? record;
     }
+
+    // Self-healing: check on-chain status for payments stuck in mempool
+    refreshedRecord = await selfHealMempoolRecord(
+      refreshedRecord, kv, this.env, logger, "rpc.checkPayment"
+    );
 
     const projected = projectPaymentRecord(refreshedRecord);
     const compatShimUsed = refreshedRecord.status === "submitted";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -61,6 +61,7 @@ export {
   projectPaymentRecord,
   putPaymentArtifact,
   putPaymentRecord,
+  selfHealMempoolRecord,
   transitionPayment,
 } from "./payment-status";
 export type {

--- a/src/services/payment-status.ts
+++ b/src/services/payment-status.ts
@@ -12,8 +12,9 @@ import type {
   TerminalReason,
   TrackedPaymentState,
 } from "@aibtc/tx-schemas/core";
-import type { SettleOptions } from "../types";
-import { buildExplorerUrl, stripHexPrefix } from "../utils";
+import type { Env, Logger, SettleOptions } from "../types";
+import { buildExplorerUrl, emitPaymentLifecycleEvent, stripHexPrefix } from "../utils";
+import { SettlementService } from "./settlement";
 
 // KV key prefix and TTL
 const PAYMENT_KEY_PREFIX = "payment:";
@@ -406,4 +407,82 @@ export function transitionPayment(
  */
 export function generatePaymentId(): string {
   return `pay_${crypto.randomUUID().replace(/-/g, "")}`;
+}
+
+/** Minimum age (ms) a record must be in mempool before we check Hiro. */
+const SELF_HEAL_MIN_AGE_MS = 10_000;
+
+/**
+ * Self-healing for payments stuck in mempool.
+ *
+ * When a record has status "mempool" with a txid, queries Hiro for actual
+ * on-chain status and transitions to confirmed or failed if terminal.
+ * Throttled: skips records that entered mempool less than 10s ago.
+ *
+ * Shared by GET /payment/:id and RPC checkPayment to keep both paths aligned.
+ * Returns the (possibly updated) record. Never throws — logs and returns
+ * the original record on any failure.
+ */
+export async function selfHealMempoolRecord(
+  record: PaymentRecord,
+  kv: KVNamespace,
+  env: Env,
+  logger: Logger,
+  route: string
+): Promise<PaymentRecord> {
+  if (record.status !== "mempool" || !record.txid) return record;
+
+  // Throttle: don't hit Hiro for records that just entered the mempool
+  if (record.mempoolAt) {
+    const ageMs = Date.now() - new Date(record.mempoolAt).getTime();
+    if (ageMs < SELF_HEAL_MIN_AGE_MS) return record;
+  }
+
+  try {
+    const settlement = new SettlementService(env, logger);
+    const hiroStatus = await settlement.fetchHiroTxStatus(record.txid);
+    if (!hiroStatus) return record;
+
+    let healed: PaymentRecord | undefined;
+    let action: string | undefined;
+
+    if (hiroStatus.txStatus === "success" && typeof hiroStatus.blockHeight === "number") {
+      healed = transitionPayment(record, "confirmed", {
+        blockHeight: hiroStatus.blockHeight,
+      });
+      action = "mempool_to_confirmed";
+    } else if (hiroStatus.txStatus.startsWith("abort_")) {
+      healed = transitionPayment(record, "failed", {
+        error: "Transaction aborted on-chain",
+        errorCode: "SETTLEMENT_FAILED",
+        terminalReason: "chain_abort",
+        retryable: false,
+      });
+      action = "mempool_to_failed";
+    }
+
+    if (healed) {
+      await putPaymentRecord(kv, healed);
+      emitPaymentLifecycleEvent(logger, "payment.self_healed", {
+        route,
+        paymentId: healed.paymentId,
+        status: healed.status,
+        action,
+        txid: healed.txid,
+        hiroTxStatus: hiroStatus.txStatus,
+        ...(healed.blockHeight && { blockHeight: healed.blockHeight }),
+        ...(healed.terminalReason && { terminalReason: healed.terminalReason }),
+        checkStatusUrlPresent: true,
+        compatShimUsed: false,
+      });
+      return healed;
+    }
+  } catch (e) {
+    logger.warn("Self-healing check failed, returning stale status", {
+      paymentId: record.paymentId,
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  return record;
 }

--- a/src/services/payment-status.ts
+++ b/src/services/payment-status.ts
@@ -451,7 +451,7 @@ export async function selfHealMempoolRecord(
         blockHeight: hiroStatus.blockHeight,
       });
       action = "mempool_to_confirmed";
-    } else if (hiroStatus.txStatus.startsWith("abort_")) {
+    } else if (hiroStatus.txStatus?.startsWith("abort_")) {
       healed = transitionPayment(record, "failed", {
         error: "Transaction aborted on-chain",
         errorCode: "SETTLEMENT_FAILED",

--- a/src/utils/payment-events.ts
+++ b/src/utils/payment-events.ts
@@ -7,7 +7,8 @@ export type PaymentLifecycleEvent =
   | "payment.poll"
   | "payment.finalized"
   | "payment.retry_decision"
-  | "payment.fallback_used";
+  | "payment.fallback_used"
+  | "payment.self_healed";
 
 type PaymentLogLevel = "info" | "warn" | "error" | "debug";
 


### PR DESCRIPTION
## Summary

Fixes #334 — payments processed through the queue consumer get stuck in `mempool` status because the consumer acks without confirmation polling and chainhook was never configured.

- Adds a self-healing check to `GET /payment/:id`: when a record has `status === "mempool"` with a `txid`, queries Hiro API for actual on-chain status
- If confirmed on-chain → transitions to `confirmed` and persists
- If aborted on-chain (`abort_*`) → transitions to `failed` with `SETTLEMENT_FAILED` error code
- If Hiro is unreachable or tx still pending → returns cached status unchanged (graceful degradation via try/catch)
- Adds `payment.self_healed` lifecycle event for observability

The 22 currently stuck payments will auto-resolve on their next poll from downstream consumers.

## Test plan

- [ ] `npm run check` passes (verified locally)
- [ ] `npm run deploy:dry-run` passes (verified locally)
- [ ] Deploy to staging, confirm stuck mempool payments transition to confirmed on poll
- [ ] Verify `payment.self_healed` events appear in worker-logs
- [ ] Verify abort case works (submit a tx that will abort, poll for status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)