### PR TITLE
feat(nonce): proactively update payment records after reconciliation

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -3527,7 +3527,7 @@ export class NonceDO {
   private ledgerMarkConfirmedByReconcile(walletIndex: number, nonce: number, txid: string): void {
     try {
       const now = new Date().toISOString();
-      this.sql.exec(
+      const updateCursor = this.sql.exec(
         `UPDATE nonce_intents
          SET state = 'confirmed', txid = ?, broadcasted_at = COALESCE(broadcasted_at, ?), confirmed_at = ?
          WHERE wallet_index = ? AND nonce = ? AND state != 'confirmed'`,
@@ -3537,14 +3537,18 @@ export class NonceDO {
         walletIndex,
         nonce
       );
-      this.sql.exec(
-        `INSERT INTO nonce_events (wallet_index, nonce, event, detail, created_at)
-         VALUES (?, ?, 'reconcile_confirmed', ?, ?)`,
-        walletIndex,
-        nonce,
-        JSON.stringify({ txid, reason: "chain_advanced_past_nonce" }),
-        now
-      );
+      // Only emit event if the UPDATE actually transitioned the intent (prevents
+      // duplicate reconcile_confirmed events when the nonce is already confirmed)
+      if (updateCursor.rowsWritten > 0) {
+        this.sql.exec(
+          `INSERT INTO nonce_events (wallet_index, nonce, event, detail, created_at)
+           VALUES (?, ?, 'reconcile_confirmed', ?, ?)`,
+          walletIndex,
+          nonce,
+          JSON.stringify({ txid, reason: "chain_advanced_past_nonce" }),
+          now
+        );
+      }
       // Also advance any matching dispatch queue entry to 'confirmed'
       this.transitionQueueEntry(walletIndex, nonce, "confirmed");
     } catch (e) {
@@ -6162,6 +6166,7 @@ export class NonceDO {
       let confirmedCount = 0;
       let abortedCount = 0;
       let skippedNoPayment = 0;
+      let skippedMissingRecord = 0;
       let skippedTerminal = 0;
 
       for (const ev of events) {
@@ -6180,7 +6185,11 @@ export class NonceDO {
         }
 
         const record = await getPaymentRecord(this.env.RELAY_KV, paymentId);
-        if (!record || TERMINAL_PAYMENT_STATUSES.has(record.status)) {
+        if (!record) {
+          skippedMissingRecord++;
+          continue;
+        }
+        if (TERMINAL_PAYMENT_STATUSES.has(record.status)) {
           skippedTerminal++;
           continue;
         }
@@ -6200,9 +6209,14 @@ export class NonceDO {
               txStatus = parsed.txStatus;
             } catch { /* detail is optional */ }
           }
+          const error = txStatus
+            ? `Transaction aborted on-chain: ${txStatus}`
+            : "Transaction aborted on-chain";
           const updated = transitionPayment(record, "failed", {
             terminalReason: "chain_abort",
-            ...(txStatus && { error: `Transaction aborted on-chain: ${txStatus}` }),
+            error,
+            errorCode: "SETTLEMENT_FAILED",
+            retryable: false,
           });
           await putPaymentRecord(this.env.RELAY_KV, updated);
           abortedCount++;
@@ -6221,6 +6235,7 @@ export class NonceDO {
         confirmed: confirmedCount,
         aborted: abortedCount,
         skippedNoPayment,
+        skippedMissingRecord,
         skippedTerminal,
       });
     } catch (e) {

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -519,6 +519,12 @@ const ALARM_WALLET_CURSOR_KEY = "alarm_wallet_cursor";
 /** nonce_state key for the round-robin sender sweep cursor */
 const ALARM_SENDER_CURSOR_KEY = "alarm_sender_cursor";
 
+/** nonce_state key for the confirmation notification cursor (nonce_events id) */
+const ALARM_CONFIRMATION_CURSOR_KEY = "alarm_confirmation_cursor";
+
+/** Maximum reconcile_confirmed/reconcile_aborted events processed per alarm tick */
+const MAX_CONFIRMATION_EVENTS_PER_TICK = 50;
+
 /**
  * Pool pressure threshold (0.80 = 80%) above which a surge event is recorded.
  * A surge is active while overall pressure stays above this threshold.
@@ -6103,6 +6109,134 @@ export class NonceDO {
   }
 
   /**
+   * Scan nonce_events for reconcile_confirmed and reconcile_aborted events since
+   * the last cursor position, then proactively transition matching payment records
+   * in RELAY_KV to confirmed or failed status.
+   *
+   * Called from alarm() after processReplacementNotifications() so all reconciliation
+   * results are visible before we push updates to RELAY_KV.
+   *
+   * Cursor: stored in nonce_state as ALARM_CONFIRMATION_CURSOR_KEY (last processed
+   * nonce_events.id). Advances after each tick.
+   *
+   * Fail-open: errors are logged but never rethrown so the alarm cycle continues.
+   */
+  private async processConfirmationNotifications(): Promise<void> {
+    if (!this.env.RELAY_KV) {
+      this.log("warn", "confirmation_notifications_skipped", {
+        reason: "RELAY_KV binding not available",
+      });
+      return;
+    }
+    try {
+      const cursor = this.getStateValue(ALARM_CONFIRMATION_CURSOR_KEY) ?? 0;
+
+      // Fetch up to MAX_CONFIRMATION_EVENTS_PER_TICK events since the cursor
+      type EventRow = { id: number; wallet_index: number; nonce: number; event: string; detail: string | null };
+      const events = this.sql
+        .exec<EventRow>(
+          `SELECT ne.id, ne.wallet_index, ne.nonce, ne.event, ne.detail
+           FROM nonce_events ne
+           WHERE ne.id > ?
+             AND ne.event IN ('reconcile_confirmed', 'reconcile_aborted')
+           ORDER BY ne.id ASC
+           LIMIT ?`,
+          cursor,
+          MAX_CONFIRMATION_EVENTS_PER_TICK
+        )
+        .toArray();
+
+      if (events.length === 0) return;
+
+      const TERMINAL_STATUSES = new Set(["confirmed", "failed", "replaced"]);
+      let confirmedCount = 0;
+      let abortedCount = 0;
+      let skippedNoPayment = 0;
+      let skippedTerminal = 0;
+      let maxId = cursor;
+
+      for (const ev of events) {
+        if (ev.id > maxId) maxId = ev.id;
+
+        // Look up txid from nonce_intents for this wallet+nonce
+        type IntentRow = { txid: string | null; block_height: number | null };
+        const intent = this.sql
+          .exec<IntentRow>(
+            "SELECT txid, block_height FROM nonce_intents WHERE wallet_index = ? AND nonce = ? LIMIT 1",
+            ev.wallet_index,
+            ev.nonce
+          )
+          .toArray()[0];
+
+        const txid = intent?.txid ?? null;
+        if (!txid) {
+          // No txid — gap-fill or intent not found; skip silently
+          skippedNoPayment++;
+          continue;
+        }
+
+        // Resolve txid → paymentId via KV map
+        const paymentId = await this.env.RELAY_KV.get(`txid_map:${txid}`, "text");
+        if (!paymentId) {
+          // Gap-fill transactions or untracked txids have no mapping
+          skippedNoPayment++;
+          continue;
+        }
+
+        const record = await getPaymentRecord(this.env.RELAY_KV, paymentId);
+        if (!record || TERMINAL_STATUSES.has(record.status)) {
+          skippedTerminal++;
+          continue;
+        }
+
+        if (ev.event === "reconcile_confirmed") {
+          const blockHeight = intent?.block_height ?? undefined;
+          const updated = transitionPayment(record, "confirmed", {
+            ...(blockHeight !== undefined && { blockHeight }),
+          });
+          await putPaymentRecord(this.env.RELAY_KV, updated);
+          confirmedCount++;
+        } else if (ev.event === "reconcile_aborted") {
+          // Extract txStatus from event detail JSON for context
+          let txStatus: string | undefined;
+          if (ev.detail) {
+            try {
+              const parsed = JSON.parse(ev.detail) as { txid?: string; txStatus?: string };
+              txStatus = parsed.txStatus;
+            } catch { /* detail is optional */ }
+          }
+          const updated = transitionPayment(record, "failed", {
+            terminalReason: "chain_abort",
+            ...(txStatus && { error: `Transaction aborted on-chain: ${txStatus}` }),
+          });
+          await putPaymentRecord(this.env.RELAY_KV, updated);
+          abortedCount++;
+        }
+      }
+
+      // Advance cursor past all events we processed
+      this.setStateValue(ALARM_CONFIRMATION_CURSOR_KEY, maxId);
+
+      const total = confirmedCount + abortedCount;
+      if (total > 0 || events.length > 0) {
+        this.log("info", "confirmation_notifications_processed", {
+          cursor,
+          newCursor: maxId,
+          eventsScanned: events.length,
+          confirmed: confirmedCount,
+          aborted: abortedCount,
+          skippedNoPayment,
+          skippedTerminal,
+        });
+      }
+    } catch (e) {
+      this.log("warn", "confirmation_notifications_error", {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  /**
    * One-shot cleanup: delete orphaned KV keys from removed degradation state machines
    * (circuit breaker, ghost degraded, cascade detection). These keys are no longer
    * read but accumulate in DO storage. Runs once; sets a flag to skip on subsequent cycles.
@@ -6973,6 +7107,10 @@ export class NonceDO {
         // Replacement notifications: scan replaced_tx:* KV entries and transition payment
         // records to "replaced" status so agents can detect via GET /payment/:id.
         await this.processReplacementNotifications();
+
+        // Confirmation notifications: scan nonce_events for reconcile_confirmed/
+        // reconcile_aborted and proactively transition payment records in RELAY_KV.
+        await this.processConfirmationNotifications();
 
         // Process old-path replay buffer: re-sponsor sender txs with fresh nonces and broadcast.
         // Runs after all wallet reconciliation is complete so flush results are visible.

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -525,6 +525,9 @@ const ALARM_CONFIRMATION_CURSOR_KEY = "alarm_confirmation_cursor";
 /** Maximum reconcile_confirmed/reconcile_aborted events processed per alarm tick */
 const MAX_CONFIRMATION_EVENTS_PER_TICK = 50;
 
+/** Payment statuses that should never be regressed by notification processors */
+const TERMINAL_PAYMENT_STATUSES = new Set(["confirmed", "failed", "replaced"]);
+
 /**
  * Pool pressure threshold (0.80 = 80%) above which a surge event is recorded.
  * A surge is active while overall pressure stays above this threshold.
@@ -6074,8 +6077,7 @@ export class NonceDO {
           if (paymentId) {
             const record = await getPaymentRecord(this.env.RELAY_KV, paymentId);
             // Skip terminal states — don't regress confirmed/failed records
-            const TERMINAL_STATUSES = new Set(["confirmed", "failed", "replaced"]);
-            if (record && !TERMINAL_STATUSES.has(record.status)) {
+            if (record && !TERMINAL_PAYMENT_STATUSES.has(record.status)) {
               const updated = transitionPayment(record, "replaced", {
                 terminalReason: inferReplacementTerminalReason(metadata.reason),
               });
@@ -6131,12 +6133,21 @@ export class NonceDO {
     try {
       const cursor = this.getStateValue(ALARM_CONFIRMATION_CURSOR_KEY) ?? 0;
 
-      // Fetch up to MAX_CONFIRMATION_EVENTS_PER_TICK events since the cursor
-      type EventRow = { id: number; wallet_index: number; nonce: number; event: string; detail: string | null };
+      // Fetch events joined with nonce_intents to get txid + block_height in one query
+      // (eliminates N per-event intent lookups)
+      type JoinedEventRow = {
+        id: number;
+        event: string;
+        detail: string | null;
+        txid: string | null;
+        block_height: number | null;
+      };
       const events = this.sql
-        .exec<EventRow>(
-          `SELECT ne.id, ne.wallet_index, ne.nonce, ne.event, ne.detail
+        .exec<JoinedEventRow>(
+          `SELECT ne.id, ne.event, ne.detail, ni.txid, ni.block_height
            FROM nonce_events ne
+           LEFT JOIN nonce_intents ni
+             ON ni.wallet_index = ne.wallet_index AND ni.nonce = ne.nonce
            WHERE ne.id > ?
              AND ne.event IN ('reconcile_confirmed', 'reconcile_aborted')
            ORDER BY ne.id ASC
@@ -6148,35 +6159,20 @@ export class NonceDO {
 
       if (events.length === 0) return;
 
-      const TERMINAL_STATUSES = new Set(["confirmed", "failed", "replaced"]);
       let confirmedCount = 0;
       let abortedCount = 0;
       let skippedNoPayment = 0;
       let skippedTerminal = 0;
-      let maxId = cursor;
 
       for (const ev of events) {
-        if (ev.id > maxId) maxId = ev.id;
-
-        // Look up txid from nonce_intents for this wallet+nonce
-        type IntentRow = { txid: string | null; block_height: number | null };
-        const intent = this.sql
-          .exec<IntentRow>(
-            "SELECT txid, block_height FROM nonce_intents WHERE wallet_index = ? AND nonce = ? LIMIT 1",
-            ev.wallet_index,
-            ev.nonce
-          )
-          .toArray()[0];
-
-        const txid = intent?.txid ?? null;
-        if (!txid) {
+        if (!ev.txid) {
           // No txid — gap-fill or intent not found; skip silently
           skippedNoPayment++;
           continue;
         }
 
         // Resolve txid → paymentId via KV map
-        const paymentId = await this.env.RELAY_KV.get(`txid_map:${txid}`, "text");
+        const paymentId = await this.env.RELAY_KV.get(`txid_map:${ev.txid}`, "text");
         if (!paymentId) {
           // Gap-fill transactions or untracked txids have no mapping
           skippedNoPayment++;
@@ -6184,15 +6180,14 @@ export class NonceDO {
         }
 
         const record = await getPaymentRecord(this.env.RELAY_KV, paymentId);
-        if (!record || TERMINAL_STATUSES.has(record.status)) {
+        if (!record || TERMINAL_PAYMENT_STATUSES.has(record.status)) {
           skippedTerminal++;
           continue;
         }
 
         if (ev.event === "reconcile_confirmed") {
-          const blockHeight = intent?.block_height ?? undefined;
           const updated = transitionPayment(record, "confirmed", {
-            ...(blockHeight !== undefined && { blockHeight }),
+            ...(ev.block_height != null && { blockHeight: ev.block_height }),
           });
           await putPaymentRecord(this.env.RELAY_KV, updated);
           confirmedCount++;
@@ -6214,21 +6209,20 @@ export class NonceDO {
         }
       }
 
-      // Advance cursor past all events we processed
+      // Advance cursor past all events we processed (events ordered by id ASC)
+      const maxId = events[events.length - 1].id;
       this.setStateValue(ALARM_CONFIRMATION_CURSOR_KEY, maxId);
 
-      const total = confirmedCount + abortedCount;
-      if (total > 0 || events.length > 0) {
-        this.log("info", "confirmation_notifications_processed", {
-          cursor,
-          newCursor: maxId,
-          eventsScanned: events.length,
-          confirmed: confirmedCount,
-          aborted: abortedCount,
-          skippedNoPayment,
-          skippedTerminal,
-        });
-      }
+      // Always log when we scanned events (early return above handles zero-event case)
+      this.log("info", "confirmation_notifications_processed", {
+        cursor,
+        newCursor: maxId,
+        eventsScanned: events.length,
+        confirmed: confirmedCount,
+        aborted: abortedCount,
+        skippedNoPayment,
+        skippedTerminal,
+      });
     } catch (e) {
       this.log("warn", "confirmation_notifications_error", {
         error: e instanceof Error ? e.message : String(e),


### PR DESCRIPTION
## Summary

Fixes #334 — payments stuck in `mempool` status until a client polls.

- Adds `processConfirmationNotifications()` to NonceDO alarm cycle, modeled on the existing `processReplacementNotifications()` pattern
- After each reconciliation tick, scans recent `reconcile_confirmed` / `reconcile_aborted` events via cursor-based pagination
- Resolves txids to payment records via `txid_map:` KV keys and transitions them to `confirmed` (with blockHeight) or `failed` (terminalReason: chain_abort)
- Fail-open, bounded at 50 events/tick, skips gap-fills and already-terminal records

Code simplifier improvements (a3b69af):
- Hoisted shared `TERMINAL_PAYMENT_STATUSES` constant (was duplicated in both notification methods)
- Replaced N+1 SQL queries with a single JOIN on `nonce_intents` primary key
- Simplified maxId tracking (ORDER BY guarantees last = max)
- Removed unreachable log guard

## Test plan

- [ ] `npm run check` passes (TypeScript)
- [ ] `npm run deploy:dry-run` passes (Cloudflare Worker build)
- [ ] After deploy to staging, check worker-logs for `confirmation_notifications_processed` events
- [ ] Verify previously-stuck mempool payments transition to `confirmed` without client poll
- [ ] Verify alarm cycle timing is not degraded (check `nonce_alarm_scheduled` logs for intervalMs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)