### PR TITLE
fix(reconcile): reduce mempool query limit to 50 (Hiro max)

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -2559,13 +2559,14 @@ export class NonceDO {
     // principal appears as sender OR sponsor. Required because sponsored txs have
     // the user (not the relay) as origin sender, so ?sender_address=<sponsor> on
     // /extended/v1/tx/mempool would miss them entirely.
-    const url = `${base}/extended/v1/address/${encodeURIComponent(sponsorAddress)}/mempool?limit=200&offset=0`;
+    const url = `${base}/extended/v1/address/${encodeURIComponent(sponsorAddress)}/mempool?limit=50&offset=0`;
     const response = await fetch(url, {
       headers,
       signal: AbortSignal.timeout(HIRO_NONCE_FETCH_TIMEOUT_MS),
     });
     if (!response.ok) {
-      throw new Error(`Hiro mempool fetch failed: ${response.status} ${response.statusText}`);
+      const body = await response.text().catch(() => "");
+      throw new Error(`Hiro mempool fetch failed: ${response.status} ${response.statusText} url=${url} body=${body}`);
     }
     const data = (await response.json()) as { results?: unknown[]; total?: number };
     const results = Array.isArray(data?.results) ? data.results : [];


### PR DESCRIPTION
## Summary

- Fix `fetchMempoolForSponsor()` requesting `limit=200` when the Hiro `/extended/v1/address/{principal}/mempool` endpoint caps at 50 — every call was returning 400 Bad Request, blinding reconciliation across all sponsor wallets since PR #339 deployed
- Include request URL and response body in error messages for faster future diagnosis

## Root Cause

PR #339's review fix commit correctly switched from `/extended/v1/tx/mempool?sender_address=<sponsor>` to `/extended/v1/address/<sponsor>/mempool`, but carried over `limit=200` from the old endpoint. The per-address endpoint enforces `limit <= 50`.

## Test plan

- [ ] `npm run check` passes
- [ ] Deploy to staging and verify `reconcile_skipped_api_blind` events stop within one alarm cycle (~30s)
- [ ] Confirm `mempool_snapshot_truncated` warning fires correctly if a wallet ever exceeds 50 mempool txs (unlikely with chaining limit of 20)

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)