### PR TITLE
fix(nonce): reconcile stale sender gaps before queueing

### DIFF
--- a/src/__tests__/nonce-do-sponsor-status.test.ts
+++ b/src/__tests__/nonce-do-sponsor-status.test.ts
@@ -342,6 +342,61 @@ describe("NonceDO stale sender repair helpers", () => {
     expect(conservativeBumpSenderFrontier).toHaveBeenCalledWith("ST999", 7);
   });
 
+  it("lets on-demand sender repair bypass the stale-age gate", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-03-31T20:10:00.000Z"));
+
+    const repair = (NonceDO as any).prototype.repairSenderWedge;
+    const fetchNonceInfo = vi.fn().mockResolvedValue({
+      possible_next_nonce: 7,
+      last_executed_tx_nonce: 6,
+      last_mempool_tx_nonce: null,
+      detected_missing_nonces: [],
+      detected_mempool_nonces: [],
+    });
+    const conservativeBumpSenderFrontier = vi.fn().mockReturnValue({
+      advanced: true,
+      previousFrontier: 3,
+      prunedCount: 1,
+    });
+    const checkAndAssignRun = vi.fn();
+
+    const status = await repair.call({
+      getSenderState: () => ({
+        next_expected_nonce: 3,
+        last_refresh_attempt_at: null,
+        last_refresh_failure_at: null,
+      }),
+      getHand: () => [
+        {
+          sender_nonce: 7,
+          received_at: "2026-03-31T20:09:30.000Z",
+          expires_at: "2026-03-31T20:20:00.000Z",
+          payment_id: "pay_young_gap",
+        },
+      ],
+      evaluateStaleSenderRepairCandidate: (NonceDO as any).prototype.evaluateStaleSenderRepairCandidate,
+      maybeRepairStaleSenderFrontier: (NonceDO as any).prototype.maybeRepairStaleSenderFrontier,
+      recordSenderRefreshAttempt: vi.fn(),
+      recordSenderRefreshFailure: vi.fn(),
+      fetchNonceInfo,
+      conservativeBumpSenderFrontier,
+      checkAndAssignRun,
+      buildSenderWedgeStatus: (NonceDO as any).prototype.buildSenderWedgeStatus,
+      log: vi.fn(),
+    }, "STYOUNG");
+
+    expect(fetchNonceInfo).toHaveBeenCalledWith("STYOUNG");
+    expect(conservativeBumpSenderFrontier).toHaveBeenCalledWith("STYOUNG", 7);
+    expect(checkAndAssignRun).toHaveBeenCalledWith("STYOUNG");
+    expect(status).toEqual(
+      expect.objectContaining({
+        senderAddress: "STYOUNG",
+        repairTriggered: true,
+        repairAdvanced: true,
+      })
+    );
+  });
+
   it("applies a short failure backoff after a Hiro refresh error", () => {
     const nowMs = Date.parse("2026-03-31T20:10:00.000Z");
     const evaluate = (NonceDO as any).prototype.evaluateStaleSenderRepairCandidate;

--- a/src/__tests__/payment-status.test.ts
+++ b/src/__tests__/payment-status.test.ts
@@ -4,7 +4,12 @@ import {
   RpcCheckPaymentResultSchema,
   RpcSubmitPaymentResultSchema,
 } from "@aibtc/tx-schemas";
-import { AnchorMode, makeRandomPrivKey, makeSTXTokenTransfer } from "@stacks/transactions";
+import {
+  AnchorMode,
+  deserializeTransaction,
+  makeRandomPrivKey,
+  makeSTXTokenTransfer,
+} from "@stacks/transactions";
 
 vi.mock("cloudflare:workers", () => ({
   WorkerEntrypoint: class {
@@ -314,6 +319,7 @@ describe("submitPayment duplicate reuse", () => {
   it("reconciles stale sender gap cache from Hiro before accepting a new payment", async () => {
     const kv = new MemoryKV();
     const txHex = await getSubmitPaymentTxHex(26n);
+    const signerHash = deserializeTransaction(txHex).auth.spendingCondition.signer;
     const queueSend = vi.fn(async () => {});
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({
@@ -324,7 +330,7 @@ describe("submitPayment duplicate reuse", () => {
     );
 
     await kv.put(
-      "sender_nonce:f6d5c77b5384e0c4c22bd705c8066842b8ff6dda",
+      `sender_nonce:${signerHash}`,
       JSON.stringify({
         lastSeen: 24,
         lastConfirmed: 24,

--- a/src/__tests__/payment-status.test.ts
+++ b/src/__tests__/payment-status.test.ts
@@ -65,6 +65,21 @@ async function getDuplicateReuseTxHex(): Promise<string> {
   return duplicateReuseTxHexPromise;
 }
 
+async function getSubmitPaymentTxHex(nonce: bigint): Promise<string> {
+  const transaction = await makeSTXTokenTransfer({
+    recipient: "ST37NMC4HGFQ1H2JSFP4H3TMNQBF4PY0MVSD1GV7Z",
+    amount: 1n,
+    senderKey: makeRandomPrivKey(),
+    network: "testnet",
+    memo: `submit-${nonce.toString()}`,
+    anchorMode: AnchorMode.Any,
+    sponsored: true,
+    fee: 0n,
+    nonce,
+  });
+  return transaction.serialize();
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -294,6 +309,56 @@ describe("submitPayment duplicate reuse", () => {
     await putPaymentArtifact(kv, txArtifactHash, terminalRecord.paymentId);
     expect(await getReusablePaymentRecord(kv, txArtifactHash)).toBeNull();
     expect(await getPaymentIdByArtifact(kv, txArtifactHash)).toBeNull();
+  });
+
+  it("reconciles stale sender gap cache from Hiro before accepting a new payment", async () => {
+    const kv = new MemoryKV();
+    const txHex = await getSubmitPaymentTxHex(26n);
+    const queueSend = vi.fn(async () => {});
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        last_executed_tx_nonce: 25,
+        possible_next_nonce: 26,
+        detected_missing_nonces: [],
+      }), { status: 200 })
+    );
+
+    await kv.put(
+      "sender_nonce:f6d5c77b5384e0c4c22bd705c8066842b8ff6dda",
+      JSON.stringify({
+        lastSeen: 24,
+        lastConfirmed: 24,
+        updatedAt: new Date().toISOString(),
+      })
+    );
+
+    const env = {
+      RELAY_KV: kv,
+      STACKS_NETWORK: "testnet",
+      RELAY_BASE_URL: "https://x402-relay.aibtc.dev",
+      PAYMENT_QUEUE: {
+        send: queueSend,
+      },
+    } as unknown as Env;
+
+    const rpc = new RelayRPC(executionContext, env);
+    const result = RpcSubmitPaymentResultSchema.parse(
+      await rpc.submitPayment(txHex)
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      accepted: true,
+      paymentId: expect.stringMatching(/^pay_/),
+      status: "queued",
+      senderNonce: {
+        provided: 26,
+        expected: 26,
+        healthy: true,
+      },
+      checkStatusUrl: expect.stringMatching(/^https:\/\/x402-relay\.aibtc\.dev\/payment\/pay_/),
+    });
+    expect(queueSend).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/__tests__/sender-nonce.test.ts
+++ b/src/__tests__/sender-nonce.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { checkSenderNonce, markInFlight } from "../services/sender-nonce";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  checkSenderNonce,
+  markInFlight,
+  seedSenderNonceFromHiro,
+} from "../services/sender-nonce";
 import { MemoryKV } from "./helpers/memory-kv";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("sender nonce recovery boundaries", () => {
   it("treats stale sender nonces as sender-owned recovery", async () => {
@@ -71,6 +79,41 @@ describe("sender nonce recovery boundaries", () => {
       outcome: "duplicate",
       provided: 12,
       lastSeen: 12,
+    });
+  });
+
+  it("keeps Hiro refresh monotonic when cached sender state is newer", async () => {
+    const kv = new MemoryKV();
+    await kv.put(
+      "sender_nonce:signer_refresh",
+      JSON.stringify({
+        lastSeen: 12,
+        lastConfirmed: 11,
+        lastTxid: "0xabc123",
+        updatedAt: new Date().toISOString(),
+      })
+    );
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        last_executed_tx_nonce: 9,
+        possible_next_nonce: 10,
+        detected_missing_nonces: [],
+      }), { status: 200 })
+    );
+
+    const seeded = await seedSenderNonceFromHiro(
+      kv,
+      "signer_refresh",
+      "STTESTREFRESH000000000000000000000000",
+      "testnet"
+    );
+
+    expect(seeded).toEqual({
+      lastSeen: 12,
+      lastConfirmed: 11,
+      lastTxid: "0xabc123",
+      updatedAt: expect.any(String),
     });
   });
 });

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -1615,7 +1615,12 @@ export class NonceDO {
   private evaluateStaleSenderRepairCandidate(
     stateRow: Pick<SenderStateRow, "next_expected_nonce" | "last_refresh_attempt_at" | "last_refresh_failure_at"> | null,
     hand: Array<Pick<SenderHandRow, "sender_nonce" | "received_at" | "expires_at">>,
-    nowMs: number
+    nowMs: number,
+    opts?: {
+      ignoreAgeThreshold?: boolean;
+      ignoreAttemptCooldown?: boolean;
+      ignoreFailureBackoff?: boolean;
+    }
   ): StaleSenderRepairCandidate | null {
     if (!stateRow || hand.length === 0) {
       return null;
@@ -1642,7 +1647,7 @@ export class NonceDO {
     }
 
     const oldestHeldAgeMs = Math.max(0, nowMs - oldestHeldAt);
-    if (oldestHeldAgeMs < STALE_SENDER_REPAIR_HOLD_AGE_MS) {
+    if (!opts?.ignoreAgeThreshold && oldestHeldAgeMs < STALE_SENDER_REPAIR_HOLD_AGE_MS) {
       return null;
     }
 
@@ -1650,6 +1655,7 @@ export class NonceDO {
       ? new Date(stateRow.last_refresh_attempt_at).getTime()
       : null;
     if (
+      !opts?.ignoreAttemptCooldown &&
       lastRefreshAttemptMs !== null &&
       Number.isFinite(lastRefreshAttemptMs) &&
       nowMs - lastRefreshAttemptMs < SENDER_REFRESH_COOLDOWN_MS
@@ -1661,6 +1667,7 @@ export class NonceDO {
       ? new Date(stateRow.last_refresh_failure_at).getTime()
       : null;
     if (
+      !opts?.ignoreFailureBackoff &&
       lastRefreshFailureMs !== null &&
       Number.isFinite(lastRefreshFailureMs) &&
       nowMs - lastRefreshFailureMs < SENDER_REFRESH_FAILURE_BACKOFF_MS
@@ -1752,13 +1759,21 @@ export class NonceDO {
     return { advanced: true, previousFrontier, prunedCount };
   }
 
-  private async maybeRepairStaleSenderFrontier(senderAddress: string): Promise<boolean> {
+  private async maybeRepairStaleSenderFrontier(
+    senderAddress: string,
+    opts?: {
+      ignoreAgeThreshold?: boolean;
+      ignoreAttemptCooldown?: boolean;
+      ignoreFailureBackoff?: boolean;
+    }
+  ): Promise<boolean> {
     const nowMs = Date.now();
     const stateRow = this.getSenderState(senderAddress);
     const candidate = this.evaluateStaleSenderRepairCandidate(
       stateRow,
       this.getHand(senderAddress),
-      nowMs
+      nowMs,
+      opts
     );
     if (!candidate) {
       return false;
@@ -1871,7 +1886,11 @@ export class NonceDO {
   }
 
   private async repairSenderWedge(senderAddress: string): Promise<SenderWedgeStatus> {
-    const repairAdvanced = await this.maybeRepairStaleSenderFrontier(senderAddress);
+    // On-demand repair is allowed to bypass the stale-age gate so an already-confirmed
+    // low nonce can immediately release a newly-held sender payment.
+    const repairAdvanced = await this.maybeRepairStaleSenderFrontier(senderAddress, {
+      ignoreAgeThreshold: true,
+    });
     if (repairAdvanced) {
       await this.checkAndAssignRun(senderAddress);
     }

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -1618,8 +1618,6 @@ export class NonceDO {
     nowMs: number,
     opts?: {
       ignoreAgeThreshold?: boolean;
-      ignoreAttemptCooldown?: boolean;
-      ignoreFailureBackoff?: boolean;
     }
   ): StaleSenderRepairCandidate | null {
     if (!stateRow || hand.length === 0) {
@@ -1655,7 +1653,6 @@ export class NonceDO {
       ? new Date(stateRow.last_refresh_attempt_at).getTime()
       : null;
     if (
-      !opts?.ignoreAttemptCooldown &&
       lastRefreshAttemptMs !== null &&
       Number.isFinite(lastRefreshAttemptMs) &&
       nowMs - lastRefreshAttemptMs < SENDER_REFRESH_COOLDOWN_MS
@@ -1667,7 +1664,6 @@ export class NonceDO {
       ? new Date(stateRow.last_refresh_failure_at).getTime()
       : null;
     if (
-      !opts?.ignoreFailureBackoff &&
       lastRefreshFailureMs !== null &&
       Number.isFinite(lastRefreshFailureMs) &&
       nowMs - lastRefreshFailureMs < SENDER_REFRESH_FAILURE_BACKOFF_MS
@@ -1763,8 +1759,6 @@ export class NonceDO {
     senderAddress: string,
     opts?: {
       ignoreAgeThreshold?: boolean;
-      ignoreAttemptCooldown?: boolean;
-      ignoreFailureBackoff?: boolean;
     }
   ): Promise<boolean> {
     const nowMs = Date.now();

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -224,6 +224,25 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
       );
     }
 
+    // Stale-low frontier — refresh from Hiro once before treating this as a real gap.
+    // This mirrors the cold-cache path for senders who advanced outside the relay.
+    if (nonceCheck.outcome === "gap") {
+      await seedSenderNonceFromHiro(
+        kv,
+        signerHash,
+        senderAddress,
+        network,
+        this.env.HIRO_API_KEY
+      );
+      nonceCheck = await checkSenderNonce(
+        kv,
+        signerHash,
+        senderNonce,
+        senderAddress,
+        network
+      );
+    }
+
     // Stale nonce — reject immediately, no sponsor slot wasted
     if (nonceCheck.outcome === "stale") {
       return {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -205,6 +205,7 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
       senderAddress,
       network
     );
+    let seededSenderNonce = false;
 
     // Cold cache — seed from Hiro and re-check
     if (nonceCheck.outcome === "unknown") {
@@ -215,6 +216,7 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
         network,
         this.env.HIRO_API_KEY
       );
+      seededSenderNonce = true;
       nonceCheck = await checkSenderNonce(
         kv,
         signerHash,
@@ -226,7 +228,7 @@ export class RelayRPC extends WorkerEntrypoint<Env> {
 
     // Stale-low frontier — refresh from Hiro once before treating this as a real gap.
     // This mirrors the cold-cache path for senders who advanced outside the relay.
-    if (nonceCheck.outcome === "gap") {
+    if (nonceCheck.outcome === "gap" && !seededSenderNonce) {
       await seedSenderNonceFromHiro(
         kv,
         signerHash,

--- a/src/services/sender-nonce.ts
+++ b/src/services/sender-nonce.ts
@@ -327,13 +327,19 @@ export async function seedSenderNonceFromHiro(
       detected_missing_nonces?: number[];
     };
 
-    const lastConfirmed = data.last_executed_tx_nonce ?? -1;
+    const existing = await getCache(kv, signerHash);
+    const lastConfirmed = Math.max(
+      existing?.lastConfirmed ?? -1,
+      data.last_executed_tx_nonce ?? -1
+    );
     // possible_next_nonce accounts for pending txs in mempool
-    const lastSeen = Math.max(lastConfirmed, data.possible_next_nonce - 1);
+    const fetchedLastSeen = Math.max(lastConfirmed, data.possible_next_nonce - 1);
+    const lastSeen = Math.max(existing?.lastSeen ?? -1, fetchedLastSeen);
 
     const cache: SenderNonceCache = {
       lastSeen,
       lastConfirmed,
+      lastTxid: existing?.lastTxid,
       updatedAt: new Date().toISOString(),
     };
 


### PR DESCRIPTION
## Summary

This patch closes the stale sender-gap hole in two places:

- `rpc.submitPayment()` now re-seeds sender nonce state from Hiro when a cached `gap` may just be a stale relay frontier, then re-checks before queueing.
- explicit sender-wedge repair in `NonceDO` now bypasses the 5-minute stale-age gate so a newly-held payment can be released immediately when chain truth already shows the low nonce executed.

## Why

Closes `#348`.

The current failure mode is clear: the chain has already advanced, but the relay still holds the payment on a stale gap and the caller is stuck polling.

There is also already an unmerged PR `#293` covering the first half of this problem. This patch carries that behavior into `main` and adds the on-demand wedge repair path needed for already-held payments.

## Changes

- refresh sender nonce cache on `gap` outcomes before treating them as real sender-owned gaps
- allow on-demand sender repair to ignore only the stale-age threshold
- add focused tests for both behaviors

## Verification

- `npx vitest run src/__tests__/payment-status.test.ts src/__tests__/nonce-do-sponsor-status.test.ts src/__tests__/queue-consumer.test.ts src/__tests__/sender-nonce.test.ts`
- `npm run check`

## Notes

This should reduce the staged-but-stuck classifieds/inbox symptoms downstream, but it does not replace the app-side reconciliation work tracked in `agent-news#572`.
