### PR TITLE
fix(nonce): move fetchMempoolForSponsor outside alarm() blockConcurrencyWhile

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -8218,6 +8218,22 @@ export class NonceDO {
       })
     );
 
+    // Pre-fetch mempool snapshots in parallel — null means Hiro was unreachable for that wallet.
+    // Must stay outside blockConcurrencyWhile; sequential I/O inside the lock risks the 30 s budget.
+    const prefetchedMempoolSnapshots = new Map<number, Record<number, HiroSponsorTxView> | null>();
+    if (this.isWalletCapacityEnabled()) {
+      await Promise.all(
+        reconcileWalletsPre.map(async ({ walletIndex, address }) => {
+          try {
+            const snapshot = await this.fetchMempoolForSponsor(address);
+            prefetchedMempoolSnapshots.set(walletIndex, snapshot);
+          } catch (_e) {
+            prefetchedMempoolSnapshots.set(walletIndex, null);
+          }
+        })
+      );
+    }
+
     // ---------------------------------------------------------------------------
     // Phase 2 (inside lock): All state mutations happen here. No Hiro I/O.
     // ---------------------------------------------------------------------------
@@ -8270,8 +8286,8 @@ export class NonceDO {
         }
 
         // ---------------------------------------------------------------------------
-        // Phase 4: Pre-fetch address-filtered mempool snapshots for schema reconcile.
-        // One Hiro call per wallet being reconciled (not per-txid).
+        // Phase 4: Consume pre-fetched mempool snapshots for schema reconcile.
+        // Snapshots were fetched in parallel outside the lock (prefetchedMempoolSnapshots).
         // Fail-open: API blindness logs reconcile_skipped_api_blind and skips that wallet.
         // Only runs when USE_WALLET_CAPACITY_STATE flag is enabled.
         // ---------------------------------------------------------------------------
@@ -8281,15 +8297,13 @@ export class NonceDO {
         >();
         if (this.isWalletCapacityEnabled()) {
           for (const { walletIndex, address } of reconcileWallets) {
-            try {
-              const snapshot = await this.fetchMempoolForSponsor(address);
-              walletMempoolSnapshots.set(walletIndex, snapshot);
-            } catch (mempoolErr) {
-              walletMempoolSnapshots.set(walletIndex, null);
+            const snapshot = prefetchedMempoolSnapshots.get(walletIndex) ?? null;
+            walletMempoolSnapshots.set(walletIndex, snapshot);
+            if (snapshot === null) {
               this.log("warn", "reconcile_skipped_api_blind", {
                 walletIndex,
                 address,
-                reason: mempoolErr instanceof Error ? mempoolErr.message : String(mempoolErr),
+                reason: "mempool pre-fetch failed",
               });
             }
           }


### PR DESCRIPTION
## Summary

Closes #350. Extends the Phase 1 / Phase 2 pattern from PR #326 to the `fetchMempoolForSponsor` call added by PR #339 inside `alarm()`.

**The problem:** `fetchMempoolForSponsor` was called sequentially inside `blockConcurrencyWhile`, one per reconciled wallet. With `MAX_RECONCILE_WALLETS=3` wallets per tick, sequential Hiro calls under latency can push the lock past Cloudflare's ~30 s budget, crashing the DO.

**The fix (three changes):**

1. **Pre-fetch outside the lock** — parallel `Promise.all` over `reconcileWalletsPre` fetches all mempool snapshots before `blockConcurrencyWhile` is entered. Null entry = Hiro unreachable for that wallet.

2. **Cursor-slice unification** — the pre-fetch uses `reconcileWalletsPre` (computed from `walletCursorPre` before the lock). Inside the lock, the in-lock `reconcileWallets` slice is still computed independently from the stored cursor (as before), but because the DO is single-threaded and no requests run between Phase 1 and Phase 2, the two slices are always identical. This matches #326's approach and avoids re-introducing the cursor-mismatch concern.

3. **Log ordering preserved** — `reconcile_skipped_api_blind` warn fires inside the lock when consuming null entries from the pre-fetched map, identical log ordering to before. Reason string changes from the raw Hiro error message to `"mempool pre-fetch failed"` (error detail is not needed for ops alerting).

**Prior art:** PR #326 applied the same pattern to `reconcileNonceForWallet`'s Hiro nonce-info fetch. This PR completes the refactor for the remaining Hiro I/O in `alarm()`.

**Reviewer: @arc0btc** — please verify the cursor-slice note and that `reconcile_skipped_api_blind` semantics are acceptable with the fixed reason string.

## Test plan

- [x] `npm run check` — no new errors (pre-existing tx-schemas import errors remain from #339)
- [x] `npm run deploy:dry-run` — same pre-existing build errors, no new ones
- [x] Code review: `fetchMempoolForSponsor` only appears at line ~8228 (outside lock), confirmed by grep
- [ ] Staging deploy auto-triggers on merge; monitor `logs.aibtc.dev` for `reconcile_skipped_api_blind` regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)