### PR TITLE
fix(dedup): extend liveness fail-closed to 502, add JSDoc + regression tests

### DIFF
--- a/src/__tests__/settlement-dedup.test.ts
+++ b/src/__tests__/settlement-dedup.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression tests for verifyTxidAlive Hiro status handling.
+ *
+ * verifyTxidAlive is private, so we exercise it indirectly through checkDedup:
+ * seed the KV with a stale "pending" entry (age > DEDUP_LIVENESS_AGE_MS=60s),
+ * mock fetch to return a specific HTTP status, and assert whether checkDedup
+ * returns a cached result (alive=true) or null (alive=false / invalidated).
+ *
+ * Covered:
+ *   429 → fail-closed (returns false, dedup invalidated)
+ *   502 → fail-closed (returns false, dedup invalidated)
+ *   503 → fail-closed (returns false, dedup invalidated)
+ *   500 → fail-open  (returns true, dedup preserved)
+ *   200 (success tx status) → alive (returns true, dedup preserved)
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SettlementService } from "../services/settlement";
+import { MemoryKV } from "./helpers/memory-kv";
+import type { Env, Logger, DedupResult } from "../types";
+
+// ---------------------------------------------------------------------------
+// Minimal test doubles
+// ---------------------------------------------------------------------------
+
+const noopLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+function makeService(kv: KVNamespace): SettlementService {
+  const env: Partial<Env> = {
+    STACKS_NETWORK: "testnet",
+    RELAY_KV: kv,
+  };
+  return new SettlementService(env as Env, noopLogger);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: seed a stale pending dedup entry for a given txHex
+// ---------------------------------------------------------------------------
+
+// Must exceed DEDUP_LIVENESS_AGE_MS (60s) so checkDedup triggers a liveness check.
+const STALE_AGE_MS = 90_000;
+
+async function seedStalePendingDedup(kv: MemoryKV, txHex: string): Promise<void> {
+  // Replicate the dedup key: SHA-256 of lowercase txHex (see computeTxHash in settlement.ts)
+  const normalized = txHex.toLowerCase().replace(/^0x/, "");
+  const hashBuf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(normalized));
+  const txHash = Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  const key = `dedup:${txHash}`;
+
+  const record: DedupResult = {
+    txid: "0xdeadbeef1234",
+    status: "pending",
+    sender: "aabbccdd",
+    recipient: "ST37NMC4HGFQ1H2JSFP4H3TMNQBF4PY0MVSD1GV7Z",
+    amount: "1000000",
+    recordedAt: Date.now() - STALE_AGE_MS,
+  };
+
+  await kv.put(key, JSON.stringify(record));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("verifyTxidAlive — fail-closed on Hiro error statuses", () => {
+  const txHex = "0000000000deadbeef";
+
+  it("returns false and invalidates the dedup entry when Hiro returns 429", async () => {
+    const kv = new MemoryKV();
+    await seedStalePendingDedup(kv, txHex);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 429 })
+    );
+
+    const service = makeService(kv);
+    const result = await service.checkDedup(txHex);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns false and invalidates the dedup entry when Hiro returns 502", async () => {
+    const kv = new MemoryKV();
+    await seedStalePendingDedup(kv, txHex);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 502 })
+    );
+
+    const service = makeService(kv);
+    const result = await service.checkDedup(txHex);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns false and invalidates the dedup entry when Hiro returns 503", async () => {
+    const kv = new MemoryKV();
+    await seedStalePendingDedup(kv, txHex);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 503 })
+    );
+
+    const service = makeService(kv);
+    const result = await service.checkDedup(txHex);
+
+    expect(result).toBeNull();
+  });
+
+  it("preserves the dedup entry (fail-open) when Hiro returns an unexpected 500", async () => {
+    const kv = new MemoryKV();
+    await seedStalePendingDedup(kv, txHex);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 500 })
+    );
+
+    const service = makeService(kv);
+    const result = await service.checkDedup(txHex);
+
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("pending");
+  });
+
+  it("preserves the dedup entry when Hiro returns a successful 200 with pending tx_status", async () => {
+    const kv = new MemoryKV();
+    await seedStalePendingDedup(kv, txHex);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ tx_status: "pending" }), { status: 200 })
+    );
+
+    const service = makeService(kv);
+    const result = await service.checkDedup(txHex);
+
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("pending");
+  });
+});

--- a/src/services/settlement.ts
+++ b/src/services/settlement.ts
@@ -1205,10 +1205,14 @@ export class SettlementService {
    * Used to validate "pending" dedup entries before returning them to callers.
    *
    * Returns true  if the tx is pending, success, dropped (transient), or the API
-   *               is unreachable (fail-open).
-   * Returns false if the tx is 404 (never indexed / evicted) or abort_* (terminal).
+   *               returns an unexpected error (fail-open).
+   * Returns false if the tx is 404 (never indexed / evicted), abort_* (terminal),
+   *               or if Hiro is rate-limited (429) / unavailable (502/503).
    *
    * Note: dropped_* statuses are treated as alive — see isTxDropped() for rationale.
+   * Note: 429/502/503 are fail-closed because Hiro cannot confirm the txid. Invalidating
+   *       the dedup entry allows a fresh broadcast retry. The worst case — a valid pending
+   *       tx gets invalidated — results in a retryable nonce conflict, not a double spend.
    */
   private async verifyTxidAlive(txid: string): Promise<boolean> {
     try {
@@ -1225,12 +1229,11 @@ export class SettlementService {
         return false;
       }
 
-      // 429 (rate-limit) and 503 (service unavailable): Hiro cannot confirm the txid.
-      // Treat as dead to invalidate the dedup entry and allow a fresh broadcast retry.
-      // This prevents phantom txids from stale dedup entries being served when Hiro is
-      // transiently unavailable. Worst case: a valid pending tx gets invalidated and
-      // the caller retries — the fresh broadcast will fail with nonce conflict (retryable).
-      if (response.status === 429 || response.status === 503) {
+      // 429 (rate-limit), 502 (bad gateway), and 503 (service unavailable): Hiro cannot
+      // confirm the txid. Treat as dead to invalidate the dedup entry and allow a fresh
+      // broadcast retry. This prevents phantom txids from stale dedup entries being served
+      // when Hiro is transiently unavailable.
+      if (response.status === 429 || response.status === 502 || response.status === 503) {
         this.logger.debug("Hiro API rate-limited/unavailable during liveness check, invalidating", {
           txid,
           status: response.status,


### PR DESCRIPTION
## Summary

Follow-on to #271 (merged 0ec1e00) addressing the remaining review asks that didn't make it into the squash merge.

- **502 added alongside 429/503** in `verifyTxidAlive`. A 502 from Hiro's Cloudflare edge ("Bad Gateway") has the same "upstream unreachable" semantics as 503 — the relay cannot verify txid liveness, so fail-closed is correct. arc0btc raised this question in the original review.
- **JSDoc updated** at `verifyTxidAlive`: documents the full fail-open/fail-closed contract, including which HTTP statuses are fail-closed and why the worst-case (retryable nonce conflict) is acceptable.
- **Regression tests added** in `src/__tests__/settlement-dedup.test.ts`: exercises `verifyTxidAlive` indirectly via `checkDedup` with a stale pending KV entry and mocked fetch. Covers 429, 502, 503 (invalidated), 500 (fail-open preserved), 200 (happy path preserved).

## Test plan

- [ ] `npm test` — all 106 tests pass
- [ ] `npm run deploy:dry-run` — build succeeds (pre-existing nonce-do.ts type errors unrelated to this diff)