### PR TITLE
fix(auth): use full address in appName + drop 'test' prefix from provisioned keys

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -678,12 +678,12 @@ export class AuthService {
       throw new DuplicateAddressError(type, address);
     }
 
-    const { apiKey, keyId, keyHash } = await this.generateKeyPair("test");
+    const { apiKey, keyId, keyHash } = await this.generateKeyPair("live");
     const { createdAt, expiresAt } = AuthService.createKeyDates();
 
     const metadata: ApiKeyMetadata = {
       keyId,
-      appName: `${type}:${address.slice(0, 8)}`,
+      appName: `${type}:${address}`,
       contactEmail: `${type}+${address}@x402relay.system`,
       tier: "free",
       createdAt,


### PR DESCRIPTION
## Summary

Two-line fix for two related auth/UX bugs in `provisionKeyByAddress`. Closes #346, #347.

## Changes (`src/services/auth.ts`)

**1. Use full address in appName (#346)**

Was: `appName: \`${type}:${address.slice(0, 8)}\`` — produced labels like \`stx:SP322ZK4\`, not unique enough to identify the key without cross-referencing the \`stxAddress\`/\`btcAddress\` metadata field.

Now: `appName: \`${type}:${address}\`` — full address, matches the spirit of how the field is used in operator UX (CLI \`list\`, support flows).

**2. Drop \"test\" hardcode from key prefix (#347)**

Was: `generateKeyPair(\"test\")` — produced \`x402_sk_test_<hex>\` keys for every self-provisioned key, including on the production mainnet relay (x402-relay.aibtc.com). Confusing for users and muddied signal during leak response.

Now: `generateKeyPair(\"live\")`. The string is cosmetic (KV + tier control access, not the prefix), but \"live\" matches the deployed environment for production keys. Admin \`createKey\` already accepts both \`test|live\`; \`API_KEY_REGEX\` already matches both. A future env-aware variant can be plumbed in (\`c.env.NETWORK\`-driven) without re-migration.

## Why these together

Same file, same function (\`provisionKeyByAddress\`), same UX layer (self-service provisioning), and a single typecheck cycle covers both. Splitting would be churn.

## Test plan

- [x] Local typecheck (\`npm run check\`) clean
- [ ] CI green
- Existing OpenAPI \`example\` strings in \`provision.ts\` / \`provision-stx.ts\` still reference \`x402_sk_test_...\` — those are decorative and \`API_KEY_REGEX\` matches both prefixes. Tracking that doc-drift cleanup as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>