### PR TITLE
fix(stream): improve Hiro tx stream error logging and reduce stream budget (closes #313)

### DIFF
--- a/src/services/hiro-tx-stream.ts
+++ b/src/services/hiro-tx-stream.ts
@@ -228,9 +228,17 @@ export async function waitForHiroTxConfirmationViaStream(
     };
 
     const handleError = (event: unknown) => {
+      // Cloudflare Workers WebSocket error events have non-enumerable
+      // properties, so JSON.stringify(event) was always producing "{}".
+      // Extract the diagnostic fields the runtime exposes (mirroring the
+      // close-event handler below).
+      const err = event as { message?: string; type?: string; code?: number };
       logger.warn("Hiro tx stream errored; falling back", {
         txid,
-        error: JSON.stringify(event),
+        type: err?.type ?? null,
+        code: err?.code ?? null,
+        message:
+          err?.message ?? "(WebSocket error event with no enumerable properties)",
       });
       finish(null, "error");
     };

--- a/src/services/settlement.ts
+++ b/src/services/settlement.ts
@@ -52,8 +52,10 @@ const MAX_POLL_DELAY_MS = 8_000;
  *  After broadcasting, if the first polling round times out, we retry
  *  polling (without re-broadcasting) since the tx is already in mempool. */
 const POLL_RETRY_ROUNDS = 2;
-/** Reserve a tail window for degraded REST polling if tx streaming is unavailable. */
-const STREAM_FALLBACK_TAIL_MS = 30_000;
+/** Cap on tx-stream wait. The Hiro WebSocket either delivers a terminal
+ *  update within seconds or errors fast — there's no value in waiting longer.
+ *  REST polling is the long-tail strategy; this is just a head-start. */
+const STREAM_BUDGET_MS = 30_000;
 
 // Hiro API timeout configuration
 /** Timeout for each broadcast attempt POST to Hiro /v2/transactions (ms).
@@ -647,12 +649,11 @@ export class SettlementService {
       ? Math.min(maxPollTimeMs, MAX_POLL_TIME_MS)
       : DEFAULT_POLL_TIME_MS;
 
-    const fallbackBudgetMs = Math.min(
-      STREAM_FALLBACK_TAIL_MS,
-      effectivePollTimeMs,
-      Math.max(10_000, Math.floor(effectivePollTimeMs / 3))
-    );
-    const streamBudgetMs = Math.max(0, effectivePollTimeMs - fallbackBudgetMs);
+    // Stream gets a short head-start (≤ STREAM_BUDGET_MS); REST polling gets
+    // the bulk of the budget. Previously the split was reversed and a
+    // fast-erroring stream consumed ~150s before fallback kicked in.
+    const streamBudgetMs = Math.min(STREAM_BUDGET_MS, effectivePollTimeMs);
+    const fallbackBudgetMs = Math.max(0, effectivePollTimeMs - streamBudgetMs);
 
     const initialStatus = await this.fetchHiroTxStatus(txid);
     if (initialStatus) {


### PR DESCRIPTION
## Summary

Closes #313. Two related fixes in the Hiro WebSocket tx-stream path.

### 1. Error logging — `{}` → real diagnostics

`hiro-tx-stream.ts:230` was logging `JSON.stringify(event)` on every WebSocket `error` event, which always produced `"{}"` because the Cloudflare Workers WebSocket error event has non-enumerable properties. **Zero diagnostic visibility on stream failures.** (Issue body: 13 occurrences in a single day with empty `{}` payloads.)

Extract the `type` / `code` / `message` fields the runtime exposes, mirroring the existing `handleClose` handler. When no fields are available, log a clear sentinel string instead of `{}`.

```ts
const err = event as { message?: string; type?: string; code?: number };
logger.warn("Hiro tx stream errored; falling back", {
  txid,
  type: err?.type ?? null,
  code: err?.code ?? null,
  message: err?.message ?? "(WebSocket error event with no enumerable properties)",
});
```

### 2. Budget allocation — swap stream vs REST split

`settlement.ts:650-655` allocated **150s to the stream and 30s to REST polling** out of a 180s effective budget. In practice the Hiro WebSocket either returns terminal status within seconds or errors fast. Waiting 150s on a stream that errored at t=1s is wasted budget that should be REST polling.

Swap: stream gets **≤30s as a head-start**, REST polling gets the remainder (~150s in default case).

```ts
// Before: stream 150s + fallback 30s
const fallbackBudgetMs = Math.min(STREAM_FALLBACK_TAIL_MS, effective, max(10_000, effective/3));
const streamBudgetMs   = Math.max(0, effective - fallbackBudgetMs);

// After: stream ≤30s + fallback ~150s
const streamBudgetMs   = Math.min(STREAM_BUDGET_MS, effective);
const fallbackBudgetMs = Math.max(0, effective - streamBudgetMs);
```

Renamed the const `STREAM_FALLBACK_TAIL_MS` → `STREAM_BUDGET_MS` to reflect the new semantics — it's now the cap on stream wait, not the reserve for fallback.

## Test plan

- [x] `npm run check` (TypeScript) clean
- [ ] CI green
- Operationally: after merge, watch the `Hiro tx stream errored; falling back` warn-level entries to confirm `type`/`code`/`message` are now populated for typical failures (or that the sentinel fires when the runtime really gives nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>