### PR TITLE
feat(logs): downgrade bookkeeping lifecycle warns + add responsibleParty (closes #327, #328)

### DIFF
--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -104,6 +104,10 @@ async function processPaymentMessage(
   // Guard: if txid already set, a prior attempt broadcast this tx successfully.
   // Skip re-sponsoring to avoid burning a fresh nonce slot.
   if (record.txid) {
+    // #327: Idempotent retry reusing an existing broadcast is bookkeeping,
+    // not an incident — emit at info level. Keep the human-readable
+    // `Payment already has txid…` line at warn so operators still see one
+    // message per occurrence in human-tail logs.
     emitPaymentLifecycleEvent(logger, "payment.fallback_used", {
       route: "PAYMENT_QUEUE",
       paymentId,
@@ -114,7 +118,7 @@ async function processPaymentMessage(
       compatShimUsed: false,
       txid: record.txid,
       attempt,
-    }, "warn");
+    });
     logger.warn("Payment already has txid, skipping re-sponsor", {
       paymentId,
       txid: record.txid,
@@ -191,6 +195,9 @@ async function processPaymentMessage(
         if (record.senderAddress) {
           await repairSenderWedgeDO(env, logger, record.senderAddress);
         }
+        // #327: a nonce-gap hold is normal sender-side handling, not an
+        // unresolved incident — emit at info level.
+        // #328: attribute to sender so dashboards can split sender-vs-sponsor.
         emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
           route: "PAYMENT_QUEUE",
           paymentId,
@@ -199,7 +206,8 @@ async function processPaymentMessage(
           checkStatusUrlPresent: false,
           compatShimUsed: false,
           attempt,
-        }, "warn");
+          responsibleParty: "sender",
+        });
         message.ack();
         return;
       }
@@ -238,6 +246,7 @@ async function processPaymentMessage(
 
     if (isRetryable && attempt < MAX_ATTEMPTS) {
       // Let the queue retry with backoff
+      // #328: sponsor-side contention (rate limit / capacity / DO unavailable).
       emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
         route: "PAYMENT_QUEUE",
         paymentId,
@@ -248,6 +257,7 @@ async function processPaymentMessage(
         terminalReason: undefined,
         attempt,
         code,
+        responsibleParty: "sponsor",
       }, "warn");
       logger.warn("Sponsor contention, retrying via queue", {
         paymentId,
@@ -324,6 +334,9 @@ async function processPaymentMessage(
         await releaseNonceDO(env, logger, sponsorNonce, undefined, walletIndex);
       }
 
+      // #328: attribute contention to the responsible wallet so operators
+      // can tell sender-side congestion (origin chaining) from sponsor-side
+      // contention (nonce conflicts, sponsor-pool chaining limits).
       emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
         route: "PAYMENT_QUEUE",
         paymentId,
@@ -336,6 +349,7 @@ async function processPaymentMessage(
         checkStatusUrlPresent: false,
         compatShimUsed: false,
         attempt,
+        responsibleParty: isOriginChaining ? "sender" : "sponsor",
       }, "warn");
       logger.warn("Broadcast contention, retrying via queue", {
         paymentId,


### PR DESCRIPTION
## Summary

Two related logging cleanups in `src/queue-consumer.ts`. Closes #327 and #328.

### #327 — drop bookkeeping warns to info

Production warn stream was dominated by bookkeeping lifecycle events (208/339 warnings/day per the issue). Two non-incident events moved to info:

| Action | Why bookkeeping |
|---|---|
| `payment.fallback_used / reuse_existing_broadcast_state` | Idempotent retry — txid already exists, just skipping re-sponsor. No incident. |
| `payment.retry_decision / sender_nonce_gap_held` | Normal sender-side hold; will retry. No relay incident. |

Companion `logger.warn("Payment already has txid…")` line at the same site stays warn so a tailing operator still sees one human-readable message per occurrence.

**Kept warn (unresolved contention or terminal degraded):** `sponsor_failed_terminal`, `broadcast_failed_terminal`, `deserialization_failed`, `queue_retry_sponsor_contention`, `queue_retry_origin_chaining`, `queue_retry_too_much_chaining`, `queue_retry_nonce_conflict`, `payment.fallback_used` for the compatShim path.

### #328 — `responsibleParty` field

Contention warns now include `responsibleParty: "sender" | "sponsor"`. The `isOriginChaining` signal from the broadcast-outcome parser was already there; this just surfaces it as a top-level structured field so dashboards/alerts can group by responsible wallet without parsing action names.

| Action | responsibleParty |
|---|---|
| `queue_retry_sponsor_contention` | sponsor |
| `queue_retry_origin_chaining` | sender |
| `queue_retry_too_much_chaining` | sponsor (chaining limit on sponsor pool) |
| `queue_retry_nonce_conflict` | sponsor |
| `sender_nonce_gap_held` | sender |

## Test plan

- [x] `npm run check` clean
- [x] `vitest run src/__tests__/queue-consumer.test.ts` — 5/5 pass (existing assertions on `queue_retry_too_much_chaining` warn and `broadcast_failed_terminal` warn unchanged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>