### PR TITLE
fix(nonce): enqueue failed gap_fill nonces into probe_queue when probeDepth set

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -8960,7 +8960,35 @@ export class NonceDO {
       }
 
       // -------------------------------------------------------------------------
-      // Step 3: Advance wallet head to flushEnd so /assign starts past the
+      // Step 3: Enqueue failed nonces into probe_queue for alarm-driven RBF when
+      // probeDepth is set. A failed gap_fill means the nonce is occupied by a
+      // ghost entry the node won't evict — exactly what the backward probe handles.
+      // This mirrors the empty-range probe path but seeds it with known-stuck
+      // nonces instead of backward enumeration.
+      // -------------------------------------------------------------------------
+      let probeEnqueued = 0;
+      if (probeDepth && probeDepth > 0 && failedNonces.length > 0) {
+        const now = new Date().toISOString();
+        for (const { nonce } of failedNonces) {
+          this.sql.exec(
+            `INSERT INTO probe_queue (wallet_index, nonce, state, created_at)
+             VALUES (?, ?, 'pending', ?)
+             ON CONFLICT (wallet_index, nonce) DO UPDATE SET state = 'pending', created_at = excluded.created_at`,
+            walletIndex,
+            nonce,
+            now
+          );
+          probeEnqueued++;
+        }
+        this.log("info", "flush_wallet_probe_enqueued_on_failure", {
+          walletIndex,
+          probeEnqueued,
+          failedNonces: failedNonces.map((f) => f.nonce),
+        });
+      }
+
+      // -------------------------------------------------------------------------
+      // Step 4: Advance wallet head to flushEnd so /assign starts past the
       // flushed range. Setting it to flushStart would cause immediate conflicts
       // with the self-transfers we just broadcast.
       // -------------------------------------------------------------------------
@@ -8974,6 +9002,7 @@ export class NonceDO {
         retracted,
         filledCount: filled.length,
         failedCount: failedNonces.length,
+        probeEnqueued,
         newHead: flushEnd,
         replayBufferDepth,
       });
@@ -8988,6 +9017,10 @@ export class NonceDO {
         failed: failedNonces,
         newHead: flushEnd,
         replayBufferDepth,
+        ...(probeEnqueued > 0 && {
+          probeEnqueued,
+          note: "Failed nonces enqueued for alarm-driven RBF processing (5/tick, RBF_FEE). Check GET /nonce/state for progress.",
+        }),
         ...(rawFlushEnd > flushStart + MAX_ADMIN_GAP_FILLS && {
           capped: true,
           totalNonceRange: rawFlushEnd - flushStart,


### PR DESCRIPTION
## Summary

Fixes #262.

The backward probe added in PR #261 only activated when the forward flush range was empty (`flushStart >= flushEnd`). But ghost nonces register as `detected_missing_nonces` in Hiro, which creates a non-empty forward range — so the probe **never ran** for the exact scenario it was designed to fix.

**Root cause:** After the forward gap-fill loop, nonces rejected with "broadcast rejected or already occupied" are classic ghost entries. The code recorded them in `failedNonces` but took no further action.

**Fix:** After the forward flush loop, if `probeDepth > 0` and `failedNonces.length > 0`, each failed nonce is upserted into `probe_queue` (state=`pending`). The existing alarm drain path picks them up and processes 5/tick at `RBF_FEE` (90k uSTX) — identical to the empty-range probe, just seeded from known-stuck nonces instead of backward enumeration.

Changes:
- Added Step 3 (probe enqueue on failure) between the flush loop and wallet head advance
- `flush_wallet_complete` log event now includes `probeEnqueued` count
- JSON response includes `probeEnqueued` field and progress note when probes are registered
- `ON CONFLICT DO UPDATE` ensures re-running `flush-wallet` resets any previously-processed probe entries

## Test plan

- [ ] `flush-wallet walletIndex=4 probeDepth=25` with ghost nonces in range — verify `failedNonces` are present in response and `probeEnqueued > 0`
- [ ] `GET /nonce/state` → `probeQueue` shows the failed nonces as `pending` entries
- [ ] After alarm fires, verify ghosts at failed nonces get RBF'd at 90k uSTX
- [ ] `flush-wallet` with empty forward range and no probeDepth — verify no change in behavior (probeEnqueued=0)
- [ ] Re-run `flush-wallet` with same wallet — verify `ON CONFLICT DO UPDATE` resets stale probe entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)