### PR TITLE
Sample routine worker-log info events

### DIFF
--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import type { LogsRPC } from "../types";
 import { createWorkerLogger } from "../utils/logger";
+import { shouldEmitLog } from "../utils/log-sampling";
+
+function findDroppedPaymentId(message: string): string {
+  for (let i = 0; i < 1_000; i++) {
+    const paymentId = `pay_test_${i}`;
+    if (!shouldEmitLog("info", message, { paymentId })) return paymentId;
+  }
+  throw new Error(`No dropped sample found for ${message}`);
+}
 
 describe("createWorkerLogger", () => {
   afterEach(() => {
@@ -73,6 +82,43 @@ describe("createWorkerLogger", () => {
 
     expect(() => logger.info("Queue log")).not.toThrow();
     expect(logs.info).toHaveBeenCalledTimes(1);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+  });
+
+  it("samples routine INFO logs before sending them to worker-logs", () => {
+    const logs: LogsRPC = {
+      info: vi.fn(async () => {}),
+      warn: vi.fn(async () => {}),
+      error: vi.fn(async () => {}),
+      debug: vi.fn(async () => {}),
+    };
+    const waitUntil = vi.fn((promise: Promise<void>) => promise);
+    const paymentId = findDroppedPaymentId("payment.poll");
+    const logger = createWorkerLogger(logs, { waitUntil }, {});
+
+    logger.info("payment.poll", { paymentId, route: "GET /payment/:id" });
+
+    expect(logs.info).not.toHaveBeenCalled();
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+  it("does not sample WARN logs for routine event names", () => {
+    const logs: LogsRPC = {
+      info: vi.fn(async () => {}),
+      warn: vi.fn(async () => {}),
+      error: vi.fn(async () => {}),
+      debug: vi.fn(async () => {}),
+    };
+    const waitUntil = vi.fn((promise: Promise<void>) => promise);
+    const paymentId = findDroppedPaymentId("payment.poll");
+    const logger = createWorkerLogger(logs, { waitUntil }, {});
+
+    logger.warn("payment.poll", { paymentId, route: "GET /payment/:id" });
+
+    expect(logs.warn).toHaveBeenCalledWith("x402-relay", "payment.poll", {
+      paymentId,
+      route: "GET /payment/:id",
+    });
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/payment-status.test.ts
+++ b/src/__tests__/payment-status.test.ts
@@ -374,7 +374,7 @@ describe("payment polling runtime alignment", () => {
     const record = createPaymentRecord("pay_submitted", "testnet");
     await putPaymentRecord(kv, record);
 
-    const infoSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const env = {
@@ -407,24 +407,6 @@ describe("payment polling runtime alignment", () => {
     );
     expect(rpcResult.terminalReason).toBeUndefined();
     expect(httpResult.terminalReason).toBeUndefined();
-    expect(infoSpy).toHaveBeenCalledWith("[INFO] payment.poll", expect.objectContaining({
-      service: "relay",
-      route: "rpc.checkPayment",
-      paymentId: "pay_submitted",
-      status: "queued",
-      checkStatusUrl_present: true,
-      compat_shim_used: true,
-      repo_version: expect.any(String),
-    }));
-    expect(infoSpy).toHaveBeenCalledWith("[INFO] payment.poll", expect.objectContaining({
-      service: "relay",
-      route: "GET /payment/:id",
-      paymentId: "pay_submitted",
-      status: "queued",
-      checkStatusUrl_present: true,
-      compat_shim_used: true,
-      repo_version: expect.any(String),
-    }));
     expect(warnSpy).toHaveBeenCalledWith("[WARN] payment.fallback_used", expect.objectContaining({
       service: "relay",
       paymentId: "pay_submitted",

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -18,6 +18,7 @@ import type {
   HandSubmitResult,
   RunDispatchResult,
 } from "../types";
+import { shouldEmitLog } from "../utils/log-sampling";
 import { getHiroBaseUrl, getHiroHeaders } from "../utils";
 import {
   getPaymentRecord,
@@ -2122,6 +2123,8 @@ export class NonceDO {
     message: string,
     context?: Record<string, unknown>
   ): void {
+    if (!shouldEmitLog(level, message, context)) return;
+
     if (isLogsRPC(this.env.LOGS)) {
       this.state.waitUntil(this.env.LOGS[level](APP_ID, message, context));
     } else {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ export { buildExplorerUrl } from "./response";
 export { getHiroBaseUrl, getHiroHeaders, getBroadcastTargets } from "./hiro";
 export type { BroadcastTarget } from "./hiro";
 export { createWorkerLogger, isLogsRPC } from "./logger";
+export { shouldEmitLog } from "./log-sampling";
 export {
   buildPaymentCheckStatusUrl,
   emitPaymentLifecycleEvent,

--- a/src/utils/log-sampling.ts
+++ b/src/utils/log-sampling.ts
@@ -1,0 +1,50 @@
+type LogLevel = "info" | "warn" | "error" | "debug";
+
+const INFO_SAMPLE_RATES: Record<string, number> = {
+  "payment.poll": 0.01,
+  settlement_confirmed: 0.05,
+};
+
+function stableSampleKey(
+  message: string,
+  context?: Record<string, unknown>
+): string {
+  if (!context) return message;
+
+  const keyParts = [
+    context.paymentId,
+    context.txid,
+    context.walletIndex,
+    context.sponsorNonce,
+    context.senderAddress,
+    context.route,
+  ].filter((part) => part !== undefined && part !== null);
+
+  return keyParts.length > 0
+    ? `${message}:${keyParts.map(String).join(":")}`
+    : message;
+}
+
+function hashToUnitInterval(input: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) / 0x100000000;
+}
+
+export function shouldEmitLog(
+  level: LogLevel,
+  message: string,
+  context?: Record<string, unknown>
+): boolean {
+  if (level !== "info") return true;
+
+  const rate = INFO_SAMPLE_RATES[message];
+  if (rate === undefined) return true;
+  if (rate <= 0) return false;
+  if (rate >= 1) return true;
+
+  return hashToUnitInterval(stableSampleKey(message, context)) < rate;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import type { Logger, LogsRPC } from "../types";
+import { shouldEmitLog } from "./log-sampling";
 
 const APP_ID = "x402-relay";
 
@@ -29,11 +30,14 @@ function createRpcLogger(
     message: string,
     context?: Record<string, unknown>
   ) => {
+    const mergedContext = {
+      ...baseContext,
+      ...context,
+    };
+    if (!shouldEmitLog(level, message, mergedContext)) return;
+
     try {
-      const result = logs[level](APP_ID, message, {
-        ...baseContext,
-        ...context,
-      });
+      const result = logs[level](APP_ID, message, mergedContext);
       const promise = Promise.resolve(result).catch(() => {});
       try {
         ctx.waitUntil(promise);
@@ -64,7 +68,10 @@ function createRpcLogger(
 function createConsoleLogger(baseContext: Record<string, unknown>): Logger {
   return {
     info: (message, context) => {
-      console.log(`[INFO] ${message}`, { ...baseContext, ...context });
+      const mergedContext = { ...baseContext, ...context };
+      if (shouldEmitLog("info", message, mergedContext)) {
+        console.log(`[INFO] ${message}`, mergedContext);
+      }
     },
     warn: (message, context) => {
       console.warn(`[WARN] ${message}`, { ...baseContext, ...context });


### PR DESCRIPTION
## Summary
- Add deterministic INFO log sampling for routine high-volume worker-logs events.
- Sample `payment.poll` at 1% and `settlement_confirmed` at 5%; WARN/ERROR/DEBUG and all other INFO events continue to emit normally.
- Apply the same sampling path to request/RPC loggers and `NonceDO` direct worker-logs calls.
- Update tests so payment.poll INFO is no longer required while `payment.fallback_used` WARN remains asserted.

## Billing context
This is the Phase -1 Cloudflare bill-audit item for `x402-sponsor-relay`: reduce routine INFO ingestion volume in worker-logs while preserving operational WARN/ERROR visibility.

## Validation
- `npm run check`
- `npm test -- src/__tests__/logger.test.ts src/__tests__/payment-status.test.ts`
- `git diff --check`
- `npm run wrangler -- deploy --dry-run --env production`