### PR TITLE
fix(payment-status): extend PaymentRecord TTL while held (#372 fix-ask C)

### DIFF
--- a/src/__tests__/payment-status.test.ts
+++ b/src/__tests__/payment-status.test.ts
@@ -29,6 +29,7 @@ import { MemoryKV } from "./helpers/memory-kv";
 import {
   buildNotFoundPaymentRecord,
   computePaymentArtifactHash,
+  computePaymentExpirationTtl,
   createPaymentRecord,
   getReusablePaymentRecord,
   getPaymentIdByArtifact,
@@ -216,6 +217,141 @@ describe("payment status projection", () => {
     expect(failedRecord.nextExpectedNonce).toBeUndefined();
     expect(failedRecord.missingNonces).toBeUndefined();
     expect(failedRecord.holdExpiresAt).toBeUndefined();
+  });
+});
+
+describe("computePaymentExpirationTtl — held-record TTL floor (#372)", () => {
+  const BASE_TTL = 86_400; // PAYMENT_TTL_SECONDS
+  const SETTLEMENT_BUFFER = 21_600; // SETTLEMENT_BUFFER_SECONDS
+  const NOW_MS = Date.parse("2026-05-16T00:00:00.000Z");
+
+  it("returns base TTL when holdExpiresAt is unset", () => {
+    expect(computePaymentExpirationTtl({}, NOW_MS)).toBe(BASE_TTL);
+    expect(computePaymentExpirationTtl({ holdExpiresAt: undefined }, NOW_MS)).toBe(
+      BASE_TTL
+    );
+  });
+
+  it("returns base TTL when holdExpiresAt is in the past", () => {
+    const past = new Date(NOW_MS - 60_000).toISOString();
+    expect(computePaymentExpirationTtl({ holdExpiresAt: past }, NOW_MS)).toBe(BASE_TTL);
+  });
+
+  it("returns base TTL when holdExpiresAt is exactly now (boundary)", () => {
+    const now = new Date(NOW_MS).toISOString();
+    expect(computePaymentExpirationTtl({ holdExpiresAt: now }, NOW_MS)).toBe(BASE_TTL);
+  });
+
+  it("returns base TTL when holdExpiresAt + buffer fits inside base TTL", () => {
+    // holdExpiresAt 1h from now → 3600 + 21600 = 25_200s, well below 86_400 base
+    const oneHour = new Date(NOW_MS + 3_600_000).toISOString();
+    expect(computePaymentExpirationTtl({ holdExpiresAt: oneHour }, NOW_MS)).toBe(
+      BASE_TTL
+    );
+  });
+
+  it("extends TTL when holdExpiresAt + buffer exceeds base TTL", () => {
+    // holdExpiresAt 23h from now → 82_800 + 21_600 = 104_400s > 86_400 base
+    const twentyThreeHours = new Date(NOW_MS + 23 * 3_600_000).toISOString();
+    const ttl = computePaymentExpirationTtl(
+      { holdExpiresAt: twentyThreeHours },
+      NOW_MS
+    );
+    expect(ttl).toBe(82_800 + SETTLEMENT_BUFFER);
+    expect(ttl).toBeGreaterThan(BASE_TTL);
+  });
+
+  it("extends TTL for multi-day hold windows (burst-recovery scenario from #372)", () => {
+    // holdExpiresAt 3d from now → 259_200 + 21_600 = 280_800s
+    const threeDays = new Date(NOW_MS + 3 * 86_400_000).toISOString();
+    const ttl = computePaymentExpirationTtl({ holdExpiresAt: threeDays }, NOW_MS);
+    expect(ttl).toBe(259_200 + SETTLEMENT_BUFFER);
+  });
+
+  it("falls back to base TTL when holdExpiresAt is malformed", () => {
+    expect(
+      computePaymentExpirationTtl({ holdExpiresAt: "not-a-date" }, NOW_MS)
+    ).toBe(BASE_TTL);
+    expect(computePaymentExpirationTtl({ holdExpiresAt: "" }, NOW_MS)).toBe(BASE_TTL);
+  });
+
+  it("uses Date.now() by default", () => {
+    const futureIso = new Date(Date.now() + 3 * 86_400_000).toISOString();
+    const ttl = computePaymentExpirationTtl({ holdExpiresAt: futureIso });
+    expect(ttl).toBeGreaterThan(BASE_TTL);
+  });
+});
+
+describe("putPaymentRecord — TTL is wired through computePaymentExpirationTtl (#372)", () => {
+  const BASE_TTL = 86_400;
+  const SETTLEMENT_BUFFER = 21_600;
+
+  it("writes with base TTL for a non-held record", async () => {
+    const kv = new MemoryKV();
+    const putSpy = vi.spyOn(kv, "put");
+    const record = transitionPayment(
+      createPaymentRecord("pay_ttl_base", "testnet"),
+      "queued"
+    );
+
+    await putPaymentRecord(kv, record);
+
+    expect(putSpy).toHaveBeenCalledTimes(1);
+    const [, , options] = putSpy.mock.calls[0]!;
+    expect(options).toMatchObject({ expirationTtl: BASE_TTL });
+  });
+
+  it("writes with extended TTL when record is held with future holdExpiresAt", async () => {
+    const kv = new MemoryKV();
+    const putSpy = vi.spyOn(kv, "put");
+    // holdExpiresAt 30h from now → 108_000 + 21_600 = 129_600s, > 86_400 base
+    const holdExpiresAt = new Date(Date.now() + 30 * 3_600_000).toISOString();
+    const heldRecord = transitionPayment(
+      createPaymentRecord("pay_ttl_held", "testnet"),
+      "queued",
+      {
+        holdReason: "gap",
+        nextExpectedNonce: 19,
+        missingNonces: [19],
+        holdExpiresAt,
+      }
+    );
+
+    await putPaymentRecord(kv, heldRecord);
+
+    expect(putSpy).toHaveBeenCalledTimes(1);
+    const [, , options] = putSpy.mock.calls[0]!;
+    const expirationTtl = (options as { expirationTtl: number }).expirationTtl;
+    expect(expirationTtl).toBeGreaterThan(BASE_TTL);
+    // Allow small Date.now() drift between the test setup and the put — bound it
+    expect(expirationTtl).toBeGreaterThanOrEqual(108_000 + SETTLEMENT_BUFFER - 5);
+    expect(expirationTtl).toBeLessThanOrEqual(108_000 + SETTLEMENT_BUFFER + 5);
+  });
+
+  it("falls back to base TTL after held → terminal transition (clearHoldMetadata)", async () => {
+    const kv = new MemoryKV();
+    const putSpy = vi.spyOn(kv, "put");
+    const heldRecord = transitionPayment(
+      createPaymentRecord("pay_ttl_terminal", "testnet"),
+      "queued",
+      {
+        holdReason: "gap",
+        nextExpectedNonce: 5,
+        missingNonces: [5],
+        holdExpiresAt: new Date(Date.now() + 30 * 3_600_000).toISOString(),
+      }
+    );
+    const failedRecord = transitionPayment(heldRecord, "failed", {
+      error: "stale",
+      terminalReason: "sender_nonce_stale",
+      retryable: false,
+    });
+
+    await putPaymentRecord(kv, failedRecord);
+
+    expect(failedRecord.holdExpiresAt).toBeUndefined();
+    const [, , options] = putSpy.mock.calls[0]!;
+    expect(options).toMatchObject({ expirationTtl: BASE_TTL });
   });
 });
 

--- a/src/services/payment-status.ts
+++ b/src/services/payment-status.ts
@@ -22,6 +22,38 @@ const PAYMENT_ARTIFACT_KEY_PREFIX = "payment_artifact:";
 const PAYMENT_TTL_SECONDS = 86_400; // 24 hours
 
 /**
+ * Settlement buffer added to `holdExpiresAt` when computing the held-record TTL floor.
+ * Gives multi-payment-burst recoveries (where auto-repair may take minutes-to-hours after
+ * the hold expires) a comfortable margin before the PaymentRecord disappears from KV.
+ * Without this, users see `not_found / expired` after a confirmed tx whose hold window
+ * outlived the static 24h base TTL — see #372 for the burst-traffic instance of #284.
+ */
+const SETTLEMENT_BUFFER_SECONDS = 21_600; // 6 hours
+
+/**
+ * Compute the KV `expirationTtl` for a PaymentRecord write.
+ *
+ * For records currently held (`holdExpiresAt` set and in the future), returns
+ * `max(PAYMENT_TTL_SECONDS, secondsUntil(holdExpiresAt) + SETTLEMENT_BUFFER_SECONDS)`
+ * so the record outlives the hold window plus a settlement buffer. For all other
+ * records, returns the static `PAYMENT_TTL_SECONDS`.
+ *
+ * Exported for testability — production callers should use `putPaymentRecord`.
+ */
+export function computePaymentExpirationTtl(
+  record: Pick<PaymentRecord, "holdExpiresAt">,
+  nowMs: number = Date.now()
+): number {
+  if (!record.holdExpiresAt) return PAYMENT_TTL_SECONDS;
+  const holdExpiresMs = Date.parse(record.holdExpiresAt);
+  if (!Number.isFinite(holdExpiresMs) || holdExpiresMs <= nowMs) {
+    return PAYMENT_TTL_SECONDS;
+  }
+  const secondsUntilHoldExpires = Math.ceil((holdExpiresMs - nowMs) / 1000);
+  return Math.max(PAYMENT_TTL_SECONDS, secondsUntilHoldExpires + SETTLEMENT_BUFFER_SECONDS);
+}
+
+/**
  * Payment lifecycle statuses.
  *
  * - submitted: RPC received the request, pre-validation passed
@@ -273,14 +305,20 @@ export async function getPaymentRecord(
 }
 
 /**
- * Write a payment record to KV with 24h TTL.
+ * Write a payment record to KV.
+ *
+ * TTL is the base 24h, extended to `holdExpiresAt + SETTLEMENT_BUFFER_SECONDS` when
+ * the record is held — see `computePaymentExpirationTtl`. This prevents the
+ * `not_found / expired` UX failure mode reported in #372 where a held record's TTL
+ * could elapse during a long recovery window even though the underlying tx
+ * eventually confirmed.
  */
 export async function putPaymentRecord(
   kv: KVNamespace,
   record: PaymentRecord
 ): Promise<void> {
   await kv.put(paymentKey(record.paymentId), JSON.stringify(record), {
-    expirationTtl: PAYMENT_TTL_SECONDS,
+    expirationTtl: computePaymentExpirationTtl(record),
   });
 }
 


### PR DESCRIPTION
## Summary

When a `PaymentRecord` is held with `holdExpiresAt` in the future, this PR sets the KV `expirationTtl` to `max(PAYMENT_TTL_SECONDS, secondsUntilHoldExpires + SETTLEMENT_BUFFER_SECONDS)` so the record outlives the hold window plus a 6-hour settlement buffer.

This addresses fix-ask **(C)** from #372 — the `not_found / expired` UX failure mode where a held record's TTL elapsed during a multi-payment-burst recovery window even though the underlying tx eventually confirmed on-chain. Empirical instance: `paymentId pay_f9778d97` (sender `SP20G…JE1`, nonce 25) returned `not_found / expired` ~50h after filing, despite the chain advancing `last_executed_tx_nonce` from 24 → 45 in the same window.

This is the standalone half of the work-split discussed in #372 — the polling/frontier-advance fix (B) addresses the underlying #284 root cause and is being scoped separately. (C) here is the user-visible-first-priority fix and is independent of (B).

## Behavior

| Scenario | TTL |
|---|---|
| `holdExpiresAt` unset, undefined, malformed, or empty | base 24h (no change) |
| `holdExpiresAt` in the past or exactly now | base 24h (no change) |
| `holdExpiresAt + 6h ≤ 24h` (short hold) | base 24h (no change) |
| `holdExpiresAt + 6h > 24h` (long hold) | extended to `holdExpiresAt + 6h` |
| Held → terminal (failed/replaced/confirmed) transition | base 24h — `clearHoldMetadata` already nulls `holdExpiresAt` so the record reads as non-held on subsequent writes |

The 6-hour `SETTLEMENT_BUFFER_SECONDS` is sized to comfortably outlive multi-payment-burst recovery windows where auto-repair may take minutes-to-hours after the hold formally expires. Tunable from one constant if a different cushion is preferred.

## Why a helper function

`computePaymentExpirationTtl` is exported so it can be unit-tested in isolation against `nowMs` injection. The production call site in `putPaymentRecord` uses the default `Date.now()`. Single source of truth — `putPaymentArtifact` deliberately keeps the static `PAYMENT_TTL_SECONDS` because the artifact-hash → paymentId index is not held-state-aware.

## Test plan

- [x] `npx vitest run src/__tests__/payment-status.test.ts` → 30/30 passing (was 20)
- [x] 7 new `computePaymentExpirationTtl` unit tests covering: unset / past / boundary-exactly-now / fits-in-base / extended / multi-day burst / malformed-or-empty / default-`Date.now`
- [x] 3 new `putPaymentRecord` integration tests covering: base-non-held / extended-held (with `holdReason: "gap"` matching the #372 shape) / fallback-after-held→terminal-transition (verifies `clearHoldMetadata` interaction)
- [x] No changes to existing tests; `clearHoldMetadata` semantics preserved
- [x] No new dependencies
- [ ] Staging deploy + verify a held payment under load — defer to maintainer

## Cross-references

- Issue: #372 (the burst-traffic instance, this PR addresses fix-ask C)
- Related root-cause issue: #284 (whoabuddy 2026-03-31, sender frontier stale-low)
- Companion PR (forthcoming, work-split with @arc0btc): active sender-frontier polling in the alarm tick when held-by-sender count ≥ k

cc @arc0btc @whoabuddy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
