### PR TITLE
feat(relay): add nonceExpiresAt to /relay and /sponsor responses (#374)

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -85,6 +85,8 @@ interface AssignNonceResponse {
   sponsorAddress: string;
   /** Total reserved nonces across all wallets at time of assignment (pool pressure signal) */
   totalReserved: number;
+  /** ISO 8601 timestamp after which the relay may reclaim this sponsor nonce. Callers MUST NOT retry the same sponsored hex past this timestamp — re-call /relay to mint a fresh sponsorship instead. */
+  nonceExpiresAt: string;
 }
 
 interface RecordTxidRequest {
@@ -2019,6 +2021,7 @@ export class NonceDO {
       sponsorNonce: firstAssigned.sponsorNonce,
       walletIndex: firstAssigned.walletIndex,
       sponsorAddress: "",
+      nonceExpiresAt: new Date(Date.now() + STALE_THRESHOLD_MS).toISOString(),
     };
   }
 
@@ -9059,6 +9062,7 @@ export class NonceDO {
           walletIndex: result.walletIndex,
           sponsorAddress: body.sponsorAddress,
           totalReserved: result.totalReserved,
+          nonceExpiresAt: new Date(Date.now() + STALE_THRESHOLD_MS).toISOString(),
         };
         return this.jsonResponse(response);
       } catch (error) {

--- a/src/endpoints/BaseEndpoint.ts
+++ b/src/endpoints/BaseEndpoint.ts
@@ -66,6 +66,7 @@ export class BaseEndpoint extends OpenAPIRoute {
       settlement?: SettlementResult;
       sponsoredTx?: string;
       receiptId?: string;
+      nonceExpiresAt?: string;
     }
   ) {
     const response: RelaySuccessResponse = {
@@ -76,6 +77,7 @@ export class BaseEndpoint extends OpenAPIRoute {
       ...(opts.settlement && { settlement: opts.settlement }),
       ...(opts.sponsoredTx && { sponsoredTx: opts.sponsoredTx }),
       ...(opts.receiptId && { receiptId: opts.receiptId }),
+      ...(opts.nonceExpiresAt && { nonceExpiresAt: opts.nonceExpiresAt }),
     };
     return c.json(response);
   }

--- a/src/endpoints/relay.ts
+++ b/src/endpoints/relay.ts
@@ -644,6 +644,7 @@ export class Relay extends BaseEndpoint {
                   settlement: retrySettlement,
                   sponsoredTx: retrySponsorResult.sponsoredTxHex,
                   receiptId: retryStoredReceipt ? retryReceiptId : undefined,
+                  nonceExpiresAt: retrySponsorResult.nonceExpiresAt,
                 });
               } else {
                 // Retry broadcast also failed — release retry nonce, fall through to error
@@ -840,6 +841,7 @@ export class Relay extends BaseEndpoint {
         settlement,
         sponsoredTx: sponsorResult.sponsoredTxHex,
         receiptId: storedReceipt ? receiptId : undefined,
+        nonceExpiresAt: sponsorResult.nonceExpiresAt,
       });
     } catch (e) {
       logger.error("Unexpected error", {

--- a/src/services/sponsor.ts
+++ b/src/services/sponsor.ts
@@ -79,6 +79,8 @@ export interface SponsorSuccess {
   fee: string;
   /** Index of the wallet that signed this transaction (for nonce release routing) */
   walletIndex: number;
+  /** ISO 8601 timestamp after which the relay may reclaim this sponsor nonce. Callers MUST NOT retry the same sponsored hex past this timestamp — re-call the sponsor endpoint to mint a fresh sponsorship instead. Derived from STALE_THRESHOLD_MS at assignment time. */
+  nonceExpiresAt: string;
 }
 
 /**
@@ -549,7 +551,7 @@ export class SponsorService {
         };
       }
 
-      const data = (await response.json()) as { nonce?: number; walletIndex?: number; totalReserved?: number };
+      const data = (await response.json()) as { nonce?: number; walletIndex?: number; totalReserved?: number; nonceExpiresAt?: string };
       if (typeof data?.nonce !== "number") {
         this.logger.warn("Nonce DO response missing nonce field");
         return { ok: false, error: "NonceDO response missing nonce field", status: 500 };
@@ -557,7 +559,8 @@ export class SponsorService {
 
       const walletIndex = typeof data.walletIndex === "number" ? data.walletIndex : 0;
       const totalReserved = typeof data.totalReserved === "number" ? data.totalReserved : 0;
-      return { ok: true, nonce: BigInt(data.nonce), walletIndex, totalReserved };
+      const nonceExpiresAt = typeof data.nonceExpiresAt === "string" ? data.nonceExpiresAt : undefined;
+      return { ok: true, nonce: BigInt(data.nonce), walletIndex, totalReserved, nonceExpiresAt };
     } catch (e) {
       this.logger.warn("Failed to fetch nonce from NonceDO", {
         error: e instanceof Error ? e.message : String(e),
@@ -804,6 +807,8 @@ export class SponsorService {
     // Track whether NonceDO assigned a nonce so we can release it on any failure path
     let nonceFromDO = false;
     let assignedNonceValue: number | undefined;
+    // ISO 8601 expiry for the assigned sponsor nonce slot (from DO assignment, forwarded to callers)
+    let nonceExpiresAt: string | undefined;
     // Pool pressure data from NonceDO for fee tier selection (0 = no data / low pressure)
     let totalReserved = 0;
 
@@ -875,6 +880,7 @@ export class SponsorService {
         walletIndex = handResult.walletIndex;
         nonceFromDO = true;
         assignedNonceValue = handResult.sponsorNonce;
+        nonceExpiresAt = handResult.nonceExpiresAt;
         this.logger.debug("Transaction dispatched via hand-submit", {
           senderAddress,
           senderNonce,
@@ -903,6 +909,7 @@ export class SponsorService {
           totalReserved = doResult.totalReserved;
           nonceFromDO = true;
           assignedNonceValue = Number(doResult.nonce);
+          nonceExpiresAt = doResult.nonceExpiresAt;
           this.logger.debug("Using legacy NonceDO sponsor nonce (hand-submit fallback)", {
             sponsorNonce: sponsorNonce.toString(),
             walletIndex,
@@ -1078,6 +1085,7 @@ export class SponsorService {
         sponsoredTxHex,
         fee: actualFee,
         walletIndex,
+        nonceExpiresAt: nonceExpiresAt ?? new Date(Date.now() + 10 * 60 * 1000).toISOString(),
       };
     } catch (e) {
       this.logger.error("Failed to sponsor transaction", {

--- a/src/types.ts
+++ b/src/types.ts
@@ -723,6 +723,8 @@ export interface RelaySuccessResponse extends BaseSuccessResponse {
   sponsoredTx?: string;
   /** Receipt token for verifying payment via GET /verify/:receiptId */
   receiptId?: string;
+  /** ISO 8601 timestamp after which the relay may reclaim this sponsor nonce. Present when sponsoredTx is included. Callers MUST NOT retry the same sponsored hex past this timestamp — re-call the relay endpoint to mint a fresh sponsorship instead. */
+  nonceExpiresAt?: string;
 }
 
 // =============================================================================
@@ -1519,6 +1521,8 @@ export type HandSubmitResult =
       walletIndex: number;
       /** Sponsor wallet Stacks address */
       sponsorAddress: string;
+      /** ISO 8601 timestamp after which the relay may reclaim this sponsor nonce. Callers MUST NOT retry the same sponsored hex past this timestamp — re-call the sponsor endpoint to mint a fresh sponsorship instead. */
+      nonceExpiresAt: string;
     }
   | {
       dispatched: false;


### PR DESCRIPTION
## Summary

Implements #374: relay now publishes `nonceExpiresAt` (ISO 8601) on every response that includes a `sponsoredTx` hex. Downstream queues can gate retry decisions on this timestamp instead of guessing the relay's internal TTL.

- `nonceExpiresAt` is derived from `Date.now() + STALE_THRESHOLD_MS` at nonce-assignment time in the DO — the same constant that governs reclaim in the reconcile loop
- Threaded through both dispatch paths: hand-submit (`checkAndAssignRun`) and legacy `/assign`
- Falls back to a local `Date.now() + 10min` estimate if the DO path is unavailable (keeps the field always-present on `SponsorSuccess`)
- Present on all `okWithTx` responses that include `sponsoredTx` — absent from dedup hits and self-pay paths where no new nonce is assigned

## Changed files

| File | Change |
|------|--------|
| `src/durable-objects/nonce-do.ts` | `AssignNonceResponse` interface + `/assign` handler + `checkAndAssignRun()` return `nonceExpiresAt` |
| `src/types.ts` | `HandSubmitResult` (dispatched:true) + `RelaySuccessResponse` gain `nonceExpiresAt` |
| `src/services/sponsor.ts` | `SponsorSuccess` gains `nonceExpiresAt`; captured from both DO paths |
| `src/endpoints/BaseEndpoint.ts` | `okWithTx` opts + response spread `nonceExpiresAt` |
| `src/endpoints/relay.ts` | `sponsorResult.nonceExpiresAt` forwarded at primary + inline-resync-retry response sites |

## How this resolves #375

Once landing-page reads `nonceExpiresAt` from the initial `/relay` response, it can implement Option C:
```ts
// At enqueue time:
if (Date.now() + estimatedQueueBudget > Date.parse(response.nonceExpiresAt)) {
  // re-call /relay for a fresh sponsorship instead of queuing stale hex
}

// At each retry attempt:
if (Date.now() > Date.parse(queuedItem.nonceExpiresAt)) {
  // re-sponsor instead of retrying — guaranteed to avoid ConflictingNonceInMempool
}
```

This eliminates the failure class from #373 without requiring a static TTL constant in landing-page (which is exactly the fragility that produced the 7× mismatch in #375).

## Test plan

- [ ] `GET /relay` response includes `nonceExpiresAt` when `sponsoredTx` is present
- [ ] `nonceExpiresAt` is ~10 min in the future at response time
- [ ] Dedup hit responses do NOT include `nonceExpiresAt` (no new nonce assigned)
- [ ] TypeScript: `bun build --no-bundle src/index.ts` passes (pre-existing `worker-configuration.d.ts` error is env-generated, unrelated to this PR)

Closes #374
Part of #375 (relay side complete; landing-page change needed for full Option C)
Depends on / pairs with #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)