### PR TITLE
fix(settlement): attribute nonce conflicts via reason_data.is_origin (#377)

### DIFF
--- a/src/__tests__/broadcast-outcome.test.ts
+++ b/src/__tests__/broadcast-outcome.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Unit tests for parseBroadcastOutcome + decideBroadcastAction.
+ *
+ * Full matrix: (reason ∈ {BadNonce, ConflictingNonceInMempool, TooMuchChaining})
+ *              × (is_origin ∈ {true, false, undefined})
+ *
+ * Plus additional coverage for non-nonce reasons.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  parseBroadcastOutcome,
+  decideBroadcastAction,
+  type RawBroadcastError,
+} from "../utils/broadcast-outcome";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRaw(
+  reason: string,
+  statusOverride?: number,
+  reasonData?: Record<string, unknown>
+): RawBroadcastError {
+  return {
+    status: statusOverride ?? 400,
+    reason,
+    body: `{"error":"MemPoolRejection","reason":"${reason}"}`,
+    reasonData,
+  };
+}
+
+function pipeline(raw: RawBroadcastError) {
+  const outcome = parseBroadcastOutcome(raw);
+  const decision = decideBroadcastAction(outcome);
+  return { outcome, decision };
+}
+
+// ---------------------------------------------------------------------------
+// BadNonce matrix (3 cells: is_origin ∈ {true, false, undefined})
+// ---------------------------------------------------------------------------
+
+describe("BadNonce", () => {
+  it("is_origin=true → responsible:sender, agentErrorCode:sender_nonce_confirmed", () => {
+    const { decision } = pipeline(makeRaw("BadNonce", 400, { is_origin: true }));
+    expect(decision.responsible).toBe("sender");
+    expect(decision.action).toBe("report_to_agent");
+    if (decision.responsible === "sender") {
+      expect(decision.agentErrorCode).toBe("sender_nonce_confirmed");
+    }
+  });
+
+  it("is_origin=false → responsible:sponsor, action:skip_nonce", () => {
+    const { decision } = pipeline(makeRaw("BadNonce", 400, { is_origin: false }));
+    expect(decision.responsible).toBe("sponsor");
+    expect(decision.action).toBe("skip_nonce");
+  });
+
+  it("is_origin=undefined → responsible:sponsor, action:skip_nonce", () => {
+    const { decision } = pipeline(makeRaw("BadNonce", 400, undefined));
+    expect(decision.responsible).toBe("sponsor");
+    expect(decision.action).toBe("skip_nonce");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ConflictingNonceInMempool matrix (3 cells)
+// ---------------------------------------------------------------------------
+
+describe("ConflictingNonceInMempool", () => {
+  it("is_origin=true → responsible:sender, agentErrorCode:sender_nonce_confirmed", () => {
+    const { decision } = pipeline(makeRaw("ConflictingNonceInMempool", 400, { is_origin: true }));
+    expect(decision.responsible).toBe("sender");
+    expect(decision.action).toBe("report_to_agent");
+    if (decision.responsible === "sender") {
+      expect(decision.agentErrorCode).toBe("sender_nonce_confirmed");
+    }
+  });
+
+  it("is_origin=false → responsible:sponsor, action:skip_nonce", () => {
+    const { decision } = pipeline(makeRaw("ConflictingNonceInMempool", 400, { is_origin: false }));
+    expect(decision.responsible).toBe("sponsor");
+    expect(decision.action).toBe("skip_nonce");
+  });
+
+  it("is_origin=undefined → responsible:sponsor, action:skip_nonce", () => {
+    const { decision } = pipeline(makeRaw("ConflictingNonceInMempool", 400, undefined));
+    expect(decision.responsible).toBe("sponsor");
+    expect(decision.action).toBe("skip_nonce");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TooMuchChaining matrix (3 cells)
+// ---------------------------------------------------------------------------
+
+describe("TooMuchChaining", () => {
+  it("is_origin=true → responsible:sender, agentErrorCode:origin_chaining_limit", () => {
+    const { decision } = pipeline(
+      makeRaw("TooMuchChaining", 400, {
+        is_origin: true,
+        principal: "SP1234",
+        expected: 25,
+        actual: 26,
+      })
+    );
+    expect(decision.responsible).toBe("sender");
+    expect(decision.action).toBe("report_to_agent");
+    if (decision.responsible === "sender") {
+      expect(decision.agentErrorCode).toBe("origin_chaining_limit");
+    }
+  });
+
+  it("is_origin=false → responsible:sponsor, action:wait_for_confirmations", () => {
+    const { decision } = pipeline(
+      makeRaw("TooMuchChaining", 400, {
+        is_origin: false,
+        principal: "SP5678",
+        expected: 20,
+        actual: 21,
+      })
+    );
+    expect(decision.responsible).toBe("sponsor");
+    expect(decision.action).toBe("wait_for_confirmations");
+  });
+
+  it("is_origin=undefined → responsible:sponsor, action:wait_for_confirmations", () => {
+    const { decision } = pipeline(
+      makeRaw("TooMuchChaining", 400, {
+        principal: "SP5678",
+        expected: 20,
+        actual: 21,
+      })
+    );
+    expect(decision.responsible).toBe("sponsor");
+    expect(decision.action).toBe("wait_for_confirmations");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-nonce reasons
+// ---------------------------------------------------------------------------
+
+describe("FeeTooLow", () => {
+  it("→ responsible:sponsor, action:retry_with_higher_fee", () => {
+    const { decision } = pipeline(
+      makeRaw("FeeTooLow", 400, { expected: 2000, actual: 1000 })
+    );
+    expect(decision.responsible).toBe("sponsor");
+    expect(decision.action).toBe("retry_with_higher_fee");
+  });
+});
+
+describe("NotEnoughFunds", () => {
+  it("→ responsible:sponsor, action:skip_nonce (sponsor covers fees; insufficient_funds is sponsor-side)", () => {
+    // In a sponsored transaction the relay (sponsor) is responsible for ensuring
+    // the sender has sufficient balance before broadcasting. The stacks-core
+    // NotEnoughFunds maps to insufficient_funds → sponsor responsible.
+    const { decision } = pipeline(
+      makeRaw("NotEnoughFunds", 400, { expected: 5000000, actual: 0 })
+    );
+    expect(decision.responsible).toBe("sponsor");
+    expect(decision.action).toBe("skip_nonce");
+  });
+});
+
+describe("Deserialization", () => {
+  it("→ responsible:sender, action:report_to_agent, code:invalid_transaction", () => {
+    const { decision } = pipeline(makeRaw("Deserialization", 400));
+    expect(decision.responsible).toBe("sender");
+    expect(decision.action).toBe("report_to_agent");
+    if (decision.responsible === "sender") {
+      expect(decision.agentErrorCode).toBe("invalid_transaction");
+    }
+  });
+});
+
+describe("HTTP 5xx (server_error)", () => {
+  it("→ responsible:network, action:retry_after_delay, retryAfterMs:10000", () => {
+    const { decision } = pipeline(makeRaw("InternalError", 500));
+    expect(decision.responsible).toBe("network");
+    expect(decision.action).toBe("retry_after_delay");
+    if (decision.responsible === "network") {
+      expect(decision.retryAfterMs).toBe(10_000);
+    }
+  });
+});
+
+describe("HTTP 429 (rate_limited)", () => {
+  it("→ responsible:network, action:retry_after_delay, retryAfterMs:30000", () => {
+    const { decision } = pipeline(makeRaw("RateLimited", 429));
+    expect(decision.responsible).toBe("network");
+    expect(decision.action).toBe("retry_after_delay");
+    if (decision.responsible === "network") {
+      expect(decision.retryAfterMs).toBe(30_000);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-checks: parseBroadcastOutcome outcome field
+// ---------------------------------------------------------------------------
+
+describe("parseBroadcastOutcome outcomes", () => {
+  it("BadNonce is_origin=true → outcome:nonce_conflict, isOrigin:true", () => {
+    const outcome = parseBroadcastOutcome(makeRaw("BadNonce", 400, { is_origin: true }));
+    expect(outcome.outcome).toBe("nonce_conflict");
+    if (outcome.outcome === "nonce_conflict") {
+      expect(outcome.isOrigin).toBe(true);
+    }
+  });
+
+  it("BadNonce is_origin=false → outcome:nonce_too_low", () => {
+    const outcome = parseBroadcastOutcome(makeRaw("BadNonce", 400, { is_origin: false }));
+    expect(outcome.outcome).toBe("nonce_too_low");
+  });
+
+  it("ConflictingNonceInMempool is_origin=true → outcome:nonce_conflict, isOrigin:true", () => {
+    const outcome = parseBroadcastOutcome(makeRaw("ConflictingNonceInMempool", 400, { is_origin: true }));
+    expect(outcome.outcome).toBe("nonce_conflict");
+    if (outcome.outcome === "nonce_conflict") {
+      expect(outcome.isOrigin).toBe(true);
+    }
+  });
+
+  it("ConflictingNonceInMempool is_origin=false → outcome:nonce_conflict, isOrigin:false", () => {
+    const outcome = parseBroadcastOutcome(makeRaw("ConflictingNonceInMempool", 400, { is_origin: false }));
+    expect(outcome.outcome).toBe("nonce_conflict");
+    if (outcome.outcome === "nonce_conflict") {
+      expect(outcome.isOrigin).toBe(false);
+    }
+  });
+});

--- a/src/endpoints/relay.ts
+++ b/src/endpoints/relay.ts
@@ -506,6 +506,19 @@ export class Relay extends BaseEndpoint {
         const clientRejection = broadcastResult.clientRejection;
         const isClientError = clientRejection !== undefined;
 
+        // Log structured attribution from the broadcast-outcome pipeline (#377).
+        // responsible/agentErrorCode are populated by parseBroadcastOutcome + decideBroadcastAction
+        // in settlement.broadcastAndConfirm using reason_data.is_origin from the Stacks node.
+        if (broadcastResult.nonceConflict || broadcastResult.tooMuchChaining) {
+          logger.info("Broadcast failure attribution", {
+            responsible: broadcastResult.responsible,
+            agentErrorCode: broadcastResult.agentErrorCode,
+            nonceConflict: broadcastResult.nonceConflict,
+            tooMuchChaining: broadcastResult.tooMuchChaining,
+            isOriginChaining: broadcastResult.isOriginChaining,
+          });
+        }
+
         c.executionCtx.waitUntil(statsService.recordError(isClientError ? "validation" : "internal").catch(() => {}));
         c.executionCtx.waitUntil(
           statsService.logFailure("relay", isClientError, {
@@ -526,6 +539,9 @@ export class Relay extends BaseEndpoint {
         // Sponsor-side issues (nonce conflict or TooMuchChaining) → inline resync + single retry.
         // Mirror the pattern in settle.ts:494-583: await resync, re-sponsor, re-verify, re-broadcast.
         // Only fall back to 409/429 if the retry also fails.
+        // NOTE: broadcastResult.responsible is now available from the structured pipeline.
+        // Recovery still triggers on nonceConflict/tooMuchChaining for backward compat;
+        // Phase 2 will refine the gating to use responsible === "sponsor" instead.
         if (broadcastResult.nonceConflict || broadcastResult.tooMuchChaining) {
           const retryReason = broadcastResult.nonceConflict ? "nonce_conflict" : "too_much_chaining";
           logger.warn("Sponsor wallet issue on relay — attempting inline resync + retry", {

--- a/src/endpoints/settle.ts
+++ b/src/endpoints/settle.ts
@@ -547,12 +547,29 @@ export class Settle extends BaseEndpoint {
         // so isClientError is naturally false for relay congestion.
         const isClientError = clientRejection !== undefined;
 
+        // Log structured attribution from the broadcast-outcome pipeline (#377).
+        // responsible/agentErrorCode are populated by parseBroadcastOutcome + decideBroadcastAction
+        // in settlement.broadcastAndConfirm using reason_data.is_origin from the Stacks node.
+        // Phase 2 will use broadcastResult.responsible to gate re-sponsor recovery.
+        if (broadcastResult.nonceConflict || broadcastResult.tooMuchChaining) {
+          logger.info("Broadcast failure attribution", {
+            responsible: broadcastResult.responsible,
+            agentErrorCode: broadcastResult.agentErrorCode,
+            nonceConflict: broadcastResult.nonceConflict,
+            tooMuchChaining: broadcastResult.tooMuchChaining,
+            isOriginChaining: broadcastResult.isOriginChaining,
+          });
+        }
+
         // Record stats once for all error branches
         c.executionCtx.waitUntil(
           statsService.logFailure("settle", isClientError, failureCtx, isClientError ? "invalid_transaction" : "broadcast_failure").catch(() => {})
         );
 
         // Sponsor-side issues (nonce conflict or TooMuchChaining) → inline resync + single retry
+        // NOTE: This gate (sponsorNonce !== null) is intentionally preserved from before Phase 1.
+        // Phase 2 will change this gate to use broadcastResult.responsible === "sponsor" so that
+        // pre-sponsored transactions (/settle with pre-signed hex) also get recovery.
         if (sponsorNonce !== null && (broadcastResult.nonceConflict || broadcastResult.tooMuchChaining)) {
           const reason = broadcastResult.nonceConflict ? "nonce_conflict" : "too_much_chaining";
           logger.warn("Sponsor wallet issue on auto-sponsored settle — attempting inline resync + retry", {

--- a/src/services/settlement.ts
+++ b/src/services/settlement.ts
@@ -25,6 +25,8 @@ import type {
 } from "../types";
 import { getHiroBaseUrl, getHiroHeaders, getBroadcastTargets, NONCE_CONFLICT_REASONS, CLIENT_REJECTION_REASONS, stripHexPrefix } from "../utils";
 import type { BroadcastTarget } from "../utils";
+import { parseBroadcastOutcome, decideBroadcastAction } from "../utils/broadcast-outcome";
+import type { RawBroadcastError } from "../utils/broadcast-outcome";
 import {
   SBTC_CONTRACT_MAINNET,
   SBTC_CONTRACT_NAME,
@@ -860,24 +862,42 @@ export class SettlementService {
               const senderSigner = transaction.auth.spendingCondition.signer;
               const senderNonce = Number(transaction.auth.spendingCondition.nonce);
 
-              if (sponsorNonceForLog === null) {
-                // No relay-assigned sponsor nonce: this is a client pre-signed tx.
-                // Log at INFO — the nonce conflict is the client's problem, not the relay's.
-                this.logger.info("Broadcast rejected due to client nonce conflict (pre-signed tx)", {
+              // Use the structured pipeline to determine who is responsible for the
+              // nonce conflict. parseBroadcastOutcome + decideBroadcastAction reads
+              // reason_data.is_origin from the Stacks node response to distinguish
+              // sender-caused from sponsor-caused conflicts (#377).
+              // This replaces the sponsorNonceForLog === null heuristic which only
+              // approximated attribution by checking whether a relay nonce was assigned.
+              const rawBroadcastErr: RawBroadcastError = {
+                status: broadcastResponse.status,
+                reason: errorDetails,  // errorDetails holds the Stacks reason string (e.g. "ConflictingNonceInMempool")
+                body: responseText,
+                reasonData: reasonData as Record<string, unknown> | undefined,
+              };
+              const broadcastOutcome = parseBroadcastOutcome(rawBroadcastErr);
+              const broadcastDecision = decideBroadcastAction(broadcastOutcome);
+
+              // Log based on structured attribution instead of sponsorNonceForLog heuristic
+              if (broadcastDecision.responsible === "sender") {
+                this.logger.info("Broadcast rejected due to sender nonce conflict", {
                   status: broadcastResponse.status,
                   details: conflictDetails,
                   senderSigner,
                   senderNonce,
+                  responsible: broadcastDecision.responsible,
+                  agentErrorCode: broadcastDecision.agentErrorCode,
+                  sponsorNonce: sponsorNonceForLog,
                   nodeUrl: target.baseUrl,
                 });
               } else {
-                // Relay assigned a sponsor nonce: unexpected conflict on relay side.
+                // sponsor or network responsible
                 this.logger.warn("Broadcast rejected due to nonce conflict", {
                   status: broadcastResponse.status,
                   details: conflictDetails,
                   sponsorNonce: sponsorNonceForLog,
                   senderSigner,
                   senderNonce,
+                  responsible: broadcastDecision.responsible,
                   nodeUrl: target.baseUrl,
                 });
               }
@@ -893,6 +913,10 @@ export class SettlementService {
                 clientRejection: matchedReason,
                 nodeUrl: target.baseUrl,
                 httpStatus: broadcastResponse.status,
+                responsible: broadcastDecision.responsible,
+                agentErrorCode: broadcastDecision.responsible === "sender"
+                  ? broadcastDecision.agentErrorCode
+                  : undefined,
               };
             }
 
@@ -900,8 +924,17 @@ export class SettlementService {
             // The node's reason_data.is_origin distinguishes origin (sender) vs sponsor triggers.
             // On sponsor-side this is relay congestion — retryable after backoff.
             // On origin-side this is the agent's problem — report back, don't penalize sponsor.
-            if (matchedReason === "TooMuchChaining" && sponsorNonceForLog !== null) {
+            if (matchedReason === "TooMuchChaining") {
+              const rawBroadcastErr: RawBroadcastError = {
+                status: broadcastResponse.status,
+                reason: errorDetails,
+                body: responseText,
+                reasonData: reasonData as Record<string, unknown> | undefined,
+              };
+              const chainOutcome = parseBroadcastOutcome(rawBroadcastErr);
+              const chainDecision = decideBroadcastAction(chainOutcome);
               const isOrigin = reasonData?.is_origin === true;
+
               this.logger.warn(
                 isOrigin
                   ? "Origin (sender) chaining limit hit (TooMuchChaining)"
@@ -911,6 +944,10 @@ export class SettlementService {
                   details: errorDetails,
                   sponsorNonce: sponsorNonceForLog,
                   isOrigin,
+                  responsible: chainDecision.responsible,
+                  agentErrorCode: chainDecision.responsible === "sender"
+                    ? chainDecision.agentErrorCode
+                    : undefined,
                   principal: reasonData?.principal,
                   expected: reasonData?.expected,
                   actual: reasonData?.actual,
@@ -927,6 +964,10 @@ export class SettlementService {
                 isOriginChaining: isOrigin,
                 nodeUrl: target.baseUrl,
                 httpStatus: broadcastResponse.status,
+                responsible: chainDecision.responsible,
+                agentErrorCode: chainDecision.responsible === "sender"
+                  ? chainDecision.agentErrorCode
+                  : undefined,
               };
             }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1337,6 +1337,21 @@ export type BroadcastAndConfirmResult =
       clientRejection?: string;
       nodeUrl?: string;
       httpStatus?: number;
+      /**
+       * Who is responsible for this broadcast failure.
+       * Derived from parseBroadcastOutcome + decideBroadcastAction using reason_data.is_origin.
+       * - "sender"  → agent's nonce or transaction is invalid; no sponsor slot consumed
+       * - "sponsor" → relay-side conflict; sponsor wallet should resync or skip nonce
+       * - "network" → transient node/network error; retry after delay
+       * undefined on code paths that predate the structured pipeline.
+       */
+      responsible?: "sender" | "sponsor" | "network";
+      /**
+       * Agent-facing error code when responsible === "sender".
+       * Examples: "sender_nonce_confirmed", "origin_chaining_limit", "invalid_transaction"
+       * Undefined when responsible is "sponsor" or "network".
+       */
+      agentErrorCode?: string;
     };
 
 /**
@@ -1355,6 +1370,10 @@ export type BroadcastOnlyResult =
       clientRejection?: string;
       nodeUrl?: string;
       httpStatus?: number;
+      /** Who is responsible for this broadcast failure (see BroadcastAndConfirmResult). */
+      responsible?: "sender" | "sponsor" | "network";
+      /** Agent-facing error code when responsible === "sender". */
+      agentErrorCode?: string;
     };
 
 /**

--- a/src/utils/broadcast-outcome.ts
+++ b/src/utils/broadcast-outcome.ts
@@ -24,6 +24,16 @@ export interface RawBroadcastError {
  *
  * Maps stacks-core MemPoolRejection reason strings to the tx-schemas
  * discriminated union, extracting isOrigin and other fields from reason_data.
+ *
+ * BadNonce routing: stacks-core emits "BadNonce" in two distinct situations:
+ *   (a) is_origin === true  → the *sender* used a nonce that is already confirmed
+ *       on-chain. Routes to nonce_conflict so decideBroadcastAction returns
+ *       responsible:"sender". No sponsor slot should be penalised.
+ *   (b) is_origin !== true  → the *sponsor* used a nonce below the sponsor chain
+ *       head. Routes to nonce_too_low so decideBroadcastAction returns
+ *       responsible:"sponsor" / action:"skip_nonce".
+ * This mirrors the ConflictingNonceInMempool routing and is the correct fix for
+ * the original bug where all BadNonce cases were attributed to the sponsor.
  */
 export function parseBroadcastOutcome(raw: RawBroadcastError): NodeBroadcastOutcome {
   const { reason, status, reasonData } = raw;
@@ -43,6 +53,13 @@ export function parseBroadcastOutcome(raw: RawBroadcastError): NodeBroadcastOutc
       };
 
     case "BadNonce":
+      // When the origin (sender) caused the bad nonce (is_origin=true), treat it
+      // the same as ConflictingNonceInMempool — the sender is responsible.
+      // When the sponsor caused it (is_origin=false/undefined), the nonce is simply
+      // too low for the sponsor chain — route to nonce_too_low (sponsor responsible).
+      if (isOrigin) {
+        return { outcome: "nonce_conflict", isOrigin: true };
+      }
       return { outcome: "nonce_too_low" };
 
     case "FeeTooLow":


### PR DESCRIPTION
## Summary

Closes #377

Wires the existing `parseBroadcastOutcome` + `decideBroadcastAction` typed pipeline into the settlement broadcast hot path so every nonce-conflict failure carries `responsible: "sender" | "sponsor" | "network"` derived from the Stacks node's `reason_data.is_origin` flag.

### Problem

The relay was using `sponsorNonceForLog === null` as a proxy for attribution: "no relay-assigned nonce → client's problem". This was incorrect for pre-sponsored `/settle` calls (which always have `sponsorNonceForLog === null`) even when the conflict was relay-caused.

Additionally, the `BadNonce` case in `parseBroadcastOutcome` always returned `outcome: "nonce_too_low"` regardless of `is_origin`, attributing all `BadNonce` rejections to the sponsor.

### Fix

- **`src/utils/broadcast-outcome.ts`**: Fix BadNonce routing — when `is_origin === true` (sender used an already-confirmed nonce) route to `nonce_conflict` (sender responsible). When `is_origin !== true` (sponsor nonce below chain head) keep as `nonce_too_low` (sponsor responsible).

- **`src/types.ts`**: Extend `BroadcastAndConfirmResult` and `BroadcastOnlyResult` error arms with optional `responsible?: "sender" | "sponsor" | "network"` and `agentErrorCode?: string` fields.

- **`src/services/settlement.ts`**: Replace the `sponsorNonceForLog === null` heuristic in `broadcastAndConfirm` with structured calls to `parseBroadcastOutcome` + `decideBroadcastAction`. Affects both the `isNonceConflict` and `TooMuchChaining` branches. The TooMuchChaining branch now calls the pipeline in all cases (removed the `sponsorNonceForLog !== null` guard that was blocking attribution for pre-sponsored txs).

- **`src/endpoints/settle.ts`**, **`src/endpoints/relay.ts`**: Add INFO logging of `responsible` and `agentErrorCode` for observability. Recovery gating is **intentionally unchanged** — Phase 2 (#373) uses `broadcastResult.responsible` to unlock re-sponsor recovery for pre-sponsored `/settle` calls.

### Test matrix

9-cell matrix (`reason × is_origin`) tested in `src/__tests__/broadcast-outcome.test.ts`:

| reason | is_origin | responsible | action |
|--------|-----------|-------------|--------|
| BadNonce | true | sender | report_to_agent (sender_nonce_confirmed) |
| BadNonce | false | sponsor | skip_nonce |
| BadNonce | undefined | sponsor | skip_nonce |
| ConflictingNonceInMempool | true | sender | report_to_agent (sender_nonce_confirmed) |
| ConflictingNonceInMempool | false | sponsor | skip_nonce |
| ConflictingNonceInMempool | undefined | sponsor | skip_nonce |
| TooMuchChaining | true | sender | report_to_agent (origin_chaining_limit) |
| TooMuchChaining | false | sponsor | wait_for_confirmations |
| TooMuchChaining | undefined | sponsor | wait_for_confirmations |

Plus 5 additional cases: FeeTooLow, NotEnoughFunds, Deserialization, HTTP 5xx, HTTP 429.

### No behavior change

This is a wiring-only phase. External API behavior (`/settle` and `/relay` response shapes, error codes, recovery logic) is **unchanged**. Phase 2 (#373) will use the new `responsible` field to gate re-sponsor recovery for pre-sponsored transactions.

Note: copilot review request failed (user not found) — trigger via GitHub UI if needed.

## Files touched

- `src/utils/broadcast-outcome.ts` — BadNonce is_origin routing fix
- `src/types.ts` — `responsible` + `agentErrorCode` fields on BroadcastAndConfirmResult / BroadcastOnlyResult
- `src/services/settlement.ts` — structured pipeline replaces sponsorNonceForLog heuristic
- `src/endpoints/settle.ts` — attribution logging (observability only)
- `src/endpoints/relay.ts` — attribution logging (observability only)
- `src/__tests__/broadcast-outcome.test.ts` — NEW: 18-test matrix

## Test plan

- [x] `npm run check` — TypeScript clean
- [x] `npm test -- broadcast-outcome` — all 18 matrix tests pass
- [x] `npm test` — full suite green (1 pre-existing failure in `payment-validation.test.ts` unrelated to this PR, confirmed failing on `main` before this branch)
- [ ] Manual: `npm run dev` and submit a known-bad nonce sender — logs should show `responsible: "sender"` not `"sponsor"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)