### PR TITLE
fix(settle): re-sponsor pre-sponsored txs on sponsor-fault conflict (#373)

### DIFF
--- a/src/__tests__/settle-responsor.test.ts
+++ b/src/__tests__/settle-responsor.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the /settle pre-sponsored tx re-sponsor recovery (Phase 2, issue #373).
+ *
+ * Covers:
+ *   1. SENDER_NONCE_CONFLICT error code value and categorization
+ *   2. Decision tree: sponsor-fault → re-sponsor path (responsible="sponsor")
+ *   3. Decision tree: sender-fault → SENDER_NONCE_CONFLICT, no sponsor slot burned
+ *   4. Existing auto-sponsored path regression: sponsorNonce !== null uses original branch
+ *   5. Stats terminal reason mapping for sender-fault path
+ */
+import { describe, expect, it } from "vitest";
+import { X402_V2_ERROR_CODES } from "../types";
+import {
+  parseBroadcastOutcome,
+  decideBroadcastAction,
+  type RawBroadcastError,
+} from "../utils/broadcast-outcome";
+import { TERMINAL_REASON_TO_CATEGORY } from "@aibtc/tx-schemas/core/terminal-reasons";
+import type { BroadcastOnlyResult } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConflictRaw(isOrigin: boolean | undefined): RawBroadcastError {
+  return {
+    status: 400,
+    reason: "ConflictingNonceInMempool",
+    body: '{"error":"MemPoolRejection","reason":"ConflictingNonceInMempool"}',
+    reasonData: isOrigin !== undefined ? { is_origin: isOrigin } : undefined,
+  };
+}
+
+function makeBroadcastOnlyError(
+  responsible: "sender" | "sponsor" | "network",
+  agentErrorCode?: string
+): Extract<BroadcastOnlyResult, { error: string }> {
+  return {
+    error: "Nonce conflict",
+    details: "ConflictingNonceInMempool",
+    retryable: true,
+    nonceConflict: true,
+    responsible,
+    agentErrorCode,
+    nodeUrl: "https://api.hiro.so",
+    httpStatus: 400,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. SENDER_NONCE_CONFLICT error code value
+// ---------------------------------------------------------------------------
+
+describe("SENDER_NONCE_CONFLICT error code", () => {
+  it("has the correct v2 wire value", () => {
+    expect(X402_V2_ERROR_CODES.SENDER_NONCE_CONFLICT).toBe("sender_nonce_conflict");
+  });
+
+  it("is distinct from CONFLICTING_NONCE (sponsor-side conflict code)", () => {
+    expect(X402_V2_ERROR_CODES.SENDER_NONCE_CONFLICT).not.toBe(
+      X402_V2_ERROR_CODES.CONFLICTING_NONCE
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Decision tree: sponsor-fault pre-sponsored conflict → re-sponsor path
+// ---------------------------------------------------------------------------
+
+describe("Sponsor-fault pre-sponsored nonce conflict", () => {
+  it("broadcast pipeline attributes ConflictingNonceInMempool is_origin=false to sponsor", () => {
+    // This is the signal that gates the new re-sponsor recovery path.
+    const outcome = parseBroadcastOutcome(makeConflictRaw(false));
+    const decision = decideBroadcastAction(outcome);
+    expect(decision.responsible).toBe("sponsor");
+  });
+
+  it("BroadcastOnlyResult with responsible=sponsor and sponsorNonce=null triggers re-sponsor branch", () => {
+    const broadcastResult = makeBroadcastOnlyError("sponsor");
+    const sponsorNonce: number | null = null;
+
+    // Simulate the gate: sponsorNonce === null AND nonceConflict AND responsible === "sponsor"
+    const shouldEnterPreSponsoredBranch =
+      sponsorNonce === null &&
+      (broadcastResult.nonceConflict === true || broadcastResult.tooMuchChaining === true);
+    const shouldReSponsor =
+      shouldEnterPreSponsoredBranch && broadcastResult.responsible === "sponsor";
+
+    expect(shouldEnterPreSponsoredBranch).toBe(true);
+    expect(shouldReSponsor).toBe(true);
+  });
+
+  it("auto-sponsored path (sponsorNonce !== null) does NOT enter the new pre-sponsored branch", () => {
+    const broadcastResult = makeBroadcastOnlyError("sponsor");
+    const sponsorNonce: number | null = 42; // relay auto-sponsored this tx
+
+    // Simulate the gate for the OLD path (unchanged)
+    const shouldEnterOldPath =
+      sponsorNonce !== null &&
+      (broadcastResult.nonceConflict === true || broadcastResult.tooMuchChaining === true);
+
+    // The NEW pre-sponsored branch gate (only fires when sponsorNonce === null)
+    const shouldEnterNewPath =
+      sponsorNonce === null &&
+      (broadcastResult.nonceConflict === true || broadcastResult.tooMuchChaining === true);
+
+    // When relay auto-sponsored: old path fires, new path does not
+    expect(shouldEnterOldPath).toBe(true);
+    expect(shouldEnterNewPath).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Sender-fault pre-sponsored conflict → SENDER_NONCE_CONFLICT, no slot burned
+// ---------------------------------------------------------------------------
+
+describe("Sender-fault pre-sponsored nonce conflict", () => {
+  it("broadcast pipeline attributes ConflictingNonceInMempool is_origin=true to sender", () => {
+    const outcome = parseBroadcastOutcome(makeConflictRaw(true));
+    const decision = decideBroadcastAction(outcome);
+    expect(decision.responsible).toBe("sender");
+    expect(decision.action).toBe("report_to_agent");
+    if (decision.responsible === "sender") {
+      expect(decision.agentErrorCode).toBe("sender_nonce_confirmed");
+    }
+  });
+
+  it("BroadcastOnlyResult with responsible=sender and sponsorNonce=null returns SENDER_NONCE_CONFLICT", () => {
+    const broadcastResult = makeBroadcastOnlyError("sender", "sender_nonce_confirmed");
+    const sponsorNonce: number | null = null;
+
+    const shouldEnterPreSponsoredBranch =
+      sponsorNonce === null &&
+      (broadcastResult.nonceConflict === true || broadcastResult.tooMuchChaining === true);
+    const shouldReturnSenderNonceConflict =
+      shouldEnterPreSponsoredBranch && broadcastResult.responsible !== "sponsor";
+
+    expect(shouldEnterPreSponsoredBranch).toBe(true);
+    expect(shouldReturnSenderNonceConflict).toBe(true);
+
+    // The error code returned in this case
+    const errorCode = X402_V2_ERROR_CODES.SENDER_NONCE_CONFLICT;
+    expect(errorCode).toBe("sender_nonce_conflict");
+  });
+
+  it("sender-fault path does NOT try to re-sponsor (no sponsor slot consumed)", () => {
+    const broadcastResult = makeBroadcastOnlyError("sender", "sender_nonce_confirmed");
+    const sponsorNonce: number | null = null;
+
+    // Re-sponsor is only called when responsible === "sponsor"
+    const wouldReSponsor =
+      sponsorNonce === null &&
+      (broadcastResult.nonceConflict === true || broadcastResult.tooMuchChaining === true) &&
+      broadcastResult.responsible === "sponsor";
+
+    expect(wouldReSponsor).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Stats terminal reason categorization for sender-fault path
+// ---------------------------------------------------------------------------
+
+describe("Stats terminal reason categorization", () => {
+  it("sender_nonce_stale maps to the 'sender' category bucket", () => {
+    // This is the terminal reason passed to statsService.logFailure on the sender-fault path.
+    // It must map to the "sender" bucket in the 6-category dashboard breakdown.
+    const category = TERMINAL_REASON_TO_CATEGORY["sender_nonce_stale"];
+    expect(category).toBe("sender");
+  });
+
+  it("sponsor_nonce_conflict maps to the 'relay' category bucket (sponsor-fault fallback)", () => {
+    // When re-sponsor recovery fails, sponsor_nonce_conflict is the terminal reason.
+    // It should map to the "relay" bucket (relay-owned failure to recover).
+    const category = TERMINAL_REASON_TO_CATEGORY["sponsor_nonce_conflict"];
+    expect(category).toBe("relay");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Regression: pre-sponsored path with NO conflict does not enter either branch
+// ---------------------------------------------------------------------------
+
+describe("Non-conflict broadcast failure does not enter recovery branches", () => {
+  it("broadcast_failure (retryable, no nonce conflict) skips all recovery branches", () => {
+    const broadcastResult: Extract<BroadcastOnlyResult, { error: string }> = {
+      error: "Broadcast failed",
+      details: "HTTP 502",
+      retryable: true,
+      responsible: "network",
+      nodeUrl: "https://api.hiro.so",
+      httpStatus: 502,
+    };
+    const sponsorNonce: number | null = null;
+
+    const hasNonceConflict = broadcastResult.nonceConflict === true;
+    const hasTooMuchChaining = broadcastResult.tooMuchChaining === true;
+
+    const shouldEnterAutoSponsoredPath =
+      sponsorNonce !== null && (hasNonceConflict || hasTooMuchChaining);
+    const shouldEnterPreSponsoredPath =
+      sponsorNonce === null && (hasNonceConflict || hasTooMuchChaining);
+
+    expect(shouldEnterAutoSponsoredPath).toBe(false);
+    expect(shouldEnterPreSponsoredPath).toBe(false);
+  });
+});

--- a/src/endpoints/settle.ts
+++ b/src/endpoints/settle.ts
@@ -561,15 +561,14 @@ export class Settle extends BaseEndpoint {
           });
         }
 
-        // Record stats once for all error branches
+        // Record stats once for all error branches (before entering recovery branches).
+        // The recovery branches may fire additional logFailure calls for more precise reasons.
         c.executionCtx.waitUntil(
           statsService.logFailure("settle", isClientError, failureCtx, isClientError ? "invalid_transaction" : "broadcast_failure").catch(() => {})
         );
 
         // Sponsor-side issues (nonce conflict or TooMuchChaining) → inline resync + single retry
-        // NOTE: This gate (sponsorNonce !== null) is intentionally preserved from before Phase 1.
-        // Phase 2 will change this gate to use broadcastResult.responsible === "sponsor" so that
-        // pre-sponsored transactions (/settle with pre-signed hex) also get recovery.
+        // Gate: sponsorNonce !== null means the relay auto-sponsored this tx (it owns the conflict).
         if (sponsorNonce !== null && (broadcastResult.nonceConflict || broadcastResult.tooMuchChaining)) {
           const reason = broadcastResult.nonceConflict ? "nonce_conflict" : "too_much_chaining";
           logger.warn("Sponsor wallet issue on auto-sponsored settle — attempting inline resync + retry", {
@@ -667,6 +666,116 @@ export class Settle extends BaseEndpoint {
               : X402_V2_ERROR_CODES.BROADCAST_FAILED,
             200
           );
+        } else if (
+          sponsorNonce === null &&
+          (broadcastResult.nonceConflict || broadcastResult.tooMuchChaining)
+        ) {
+          // Pre-sponsored tx (sponsorNonce === null) had a nonce conflict.
+          // Use Phase 1's responsible signal to determine who caused the conflict.
+          if (broadcastResult.responsible === "sponsor") {
+            // Sponsor-fault: the relay's previous sponsor nonce is stale.
+            // Re-sponsor the inner client-signed payload with a fresh sponsor nonce.
+            // parsedTx holds the original deserialized tx — the client's origin
+            // spending condition is preserved; only the sponsor slot is overwritten.
+            logger.warn("Sponsor-fault conflict on pre-sponsored settle — attempting re-sponsor", {
+              nonceConflict: broadcastResult.nonceConflict,
+              tooMuchChaining: broadcastResult.tooMuchChaining,
+            });
+
+            const reResponsorService = new SponsorService(c.env, logger);
+            await reResponsorService.resyncNonceDO();
+
+            const oldSponsorNonce = extractSponsorNonce(parsedTx);
+            const reSponsorResult = await reResponsorService.sponsorTransaction(parsedTx);
+            if (reSponsorResult.success) {
+              const reSponsoredTx = deserializeTransaction(stripHexPrefix(reSponsorResult.sponsoredTxHex));
+              const newSponsorNonce = extractSponsorNonce(reSponsoredTx);
+              const reSponsorWalletIndex = reSponsorResult.walletIndex;
+              const reSponsorFee = reSponsorResult.fee;
+              const reSponsorHex = reSponsorResult.sponsoredTxHex;
+
+              const reVerifyResult = settlementService.verifyPaymentParams(reSponsorHex, settleOptions);
+              if (reVerifyResult.valid) {
+                const reBroadcastResult = await settlementService.broadcastOnly(reVerifyResult.data.transaction);
+                if (!("error" in reBroadcastResult)) {
+                  const senderAddr = settlementService.senderToAddress(reVerifyResult.data.transaction, c.env.STACKS_NETWORK);
+                  logger.info("settle.responsor_after_conflict", {
+                    old_sponsor_nonce: oldSponsorNonce,
+                    new_sponsor_nonce: newSponsorNonce,
+                    sender: senderAddr,
+                    original_txid: "pre_broadcast",
+                    resigned_txid: reBroadcastResult.txid,
+                  });
+                  return this.handleBroadcastSuccess({
+                    c, logger, txid: reBroadcastResult.txid, txHex, network,
+                    sponsorNonce: newSponsorNonce, sponsorWalletIndex: reSponsorWalletIndex, sponsorFee: reSponsorFee,
+                    verifiedTx: reVerifyResult.data.transaction,
+                    recipient: reVerifyResult.data.recipient,
+                    amount: reVerifyResult.data.amount,
+                    settleOptions, settlementService, statsService,
+                    paymentIdService, paymentIdentifier, paymentIdPayloadHash,
+                    submittedAt,
+                  });
+                } else {
+                  // Retry broadcast failed — release nonce, fall through to error
+                  logger.warn("Re-sponsor broadcast failed for pre-sponsored tx", {
+                    error: reBroadcastResult.error,
+                  });
+                  if (newSponsorNonce !== null) {
+                    c.executionCtx.waitUntil(
+                      Promise.all([
+                        recordBroadcastOutcomeDO(
+                          c.env, logger, newSponsorNonce, reSponsorWalletIndex,
+                          undefined, reBroadcastResult.httpStatus, reBroadcastResult.nodeUrl, reBroadcastResult.details
+                        ),
+                        releaseNonceDO(c.env, logger, newSponsorNonce, undefined, reSponsorWalletIndex),
+                      ]).catch((e) => {
+                        logger.warn("Failed nonce lifecycle after re-sponsor broadcast failure", { error: String(e) });
+                      })
+                    );
+                  }
+                }
+              } else {
+                // Verify failed on re-sponsored tx — release nonce
+                logger.warn("Re-sponsor verify failed for pre-sponsored tx", { error: reVerifyResult.error });
+                if (newSponsorNonce !== null) {
+                  c.executionCtx.waitUntil(
+                    releaseNonceDO(c.env, logger, newSponsorNonce, undefined, reSponsorWalletIndex).catch((e) => {
+                      logger.warn("Failed to release nonce after re-verify failure", { error: String(e) });
+                    })
+                  );
+                }
+              }
+            } else if (!("held" in reSponsorResult && reSponsorResult.held)) {
+              const reFail = reSponsorResult as { error: string; code?: string };
+              logger.warn("Re-sponsor failed for pre-sponsored tx", { error: reFail.error, code: reFail.code });
+            }
+
+            // Re-sponsor did not succeed — schedule resync, record stats, return error
+            this.scheduleNonceResync(c, reResponsorService.resyncNonceDODelayed(), logger);
+            c.executionCtx.waitUntil(
+              statsService.logFailure("settle", false, failureCtx, "sponsor_nonce_conflict").catch(() => {})
+            );
+            return v2Error(
+              broadcastResult.nonceConflict
+                ? X402_V2_ERROR_CODES.CONFLICTING_NONCE
+                : X402_V2_ERROR_CODES.BROADCAST_FAILED,
+              200
+            );
+          } else {
+            // Sender-fault on pre-sponsored tx — no sponsor slot was burned.
+            // Return a distinct code so the sender knows to re-sign with the correct nonce.
+            logger.info("Sender-fault nonce conflict on pre-sponsored settle — no sponsor slot burned", {
+              responsible: broadcastResult.responsible,
+              agentErrorCode: broadcastResult.agentErrorCode,
+              nonceConflict: broadcastResult.nonceConflict,
+            });
+            // Record with sender_nonce_stale (maps to "sender" bucket in TERMINAL_REASON_TO_CATEGORY).
+            c.executionCtx.waitUntil(
+              statsService.logFailure("settle", true, failureCtx, "sender_nonce_stale").catch(() => {})
+            );
+            return v2Error(X402_V2_ERROR_CODES.SENDER_NONCE_CONFLICT, 200);
+          }
         }
 
         if (clientRejection) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -418,6 +418,12 @@ export const X402_V2_ERROR_CODES = {
   SIGNATURE_VALIDATION_FAILED: "signature_validation_failed",
   /** Transaction is held pending a sender nonce gap fill — agent must submit missing nonces */
   TRANSACTION_HELD: "transaction_held",
+  /**
+   * Pre-sponsored tx conflict caused by the sender's nonce — relay cannot recover
+   * because the conflict originates from the client's origin spending condition.
+   * Sender must re-sign with the correct nonce before retrying.
+   */
+  SENDER_NONCE_CONFLICT: "sender_nonce_conflict",
 } as const;
 
 /**
@@ -611,7 +617,8 @@ export type RelayErrorCode =
   | "MALFORMED_PAYLOAD"
   | "QUEUE_NOT_FOUND"
   | "QUEUE_ACCESS_DENIED"
-  | "SENDER_NONCE_GAP";
+  | "SENDER_NONCE_GAP"
+  | "SENDER_NONCE_CONFLICT";
 
 /**
  * Default retry-after for SERVICE_DEGRADED responses (seconds).


### PR DESCRIPTION
## Summary

Resolves #373. Unlocks `/settle` recovery for pre-sponsored transactions when the nonce conflict is sponsor-side.

**Problem:** The recovery gate at the broadcast failure handler was gated on `sponsorNonce !== null`, so pre-sponsored payloads (submitted with an existing sponsor sig) never reached the recovery branch, even when `is_origin=false` (sponsor caused the conflict). On 2026-05-15 13:02-13:03 UTC this produced 18 hard `CONFLICTING_NONCE` returns that were all relay-recoverable.

**Fix:** Add a new recovery branch for pre-sponsored txs (`sponsorNonce === null`) that gates on Phase 1's `broadcastResult.responsible` signal:
- `responsible === "sponsor"` → re-sponsor `parsedTx` (the deserialized original tx) with a fresh nonce from NonceDO, rebroadcast, return success. The client's inner origin spending condition is preserved — only the sponsor slot is overwritten by `SponsorService.sponsorTransaction`.
- `responsible !== "sponsor"` (sender-fault) → return new error code `SENDER_NONCE_CONFLICT` (`"sender_nonce_conflict"`), no sponsor slot burned, stats recorded under `sender_nonce_stale` → "sender" bucket.

**New log event:** `settle.responsor_after_conflict` emitted on the success branch with `{old_sponsor_nonce, new_sponsor_nonce, sender, original_txid, resigned_txid}`.

**New error code:** `SENDER_NONCE_CONFLICT = "sender_nonce_conflict"` — signals to the client that their origin nonce is the problem, not the relay.

**No regression:** The existing auto-sponsored recovery gate (`sponsorNonce !== null`) is unchanged.

## Relationship to other PRs

- **Depends on #381** (Phase 1) which wires the `responsible` field through `BroadcastOnlyResult`. This PR is based on `fix/377-nonce-conflict-attribution` (Phase 1's branch). Once #381 merges, this PR should be retargeted to `main` and rebased.

## Files changed

- `src/types.ts` — adds `SENDER_NONCE_CONFLICT` to `X402_V2_ERROR_CODES` and `RelayErrorCode` union
- `src/endpoints/settle.ts` — new `else if` branch for pre-sponsored conflict recovery; sponsor-fault and sender-fault sub-paths
- `src/__tests__/settle-responsor.test.ts` — 11 unit tests covering the decision tree, error code value, stats bucketing, and regression check

## Test plan

- [x] `npm run check` — TypeScript clean
- [x] `npm test -- settle-responsor` — 11 tests green
- [x] `npm test` — 157 passing (1 pre-existing failure in `payment-validation.test.ts`, present before this PR on the Phase 1 branch)
- [ ] CI on staging + production builds via `wrangler deploy --dry-run`
- [ ] Manual staging verification: replay a pre-sponsored tx with a known-stale sponsor nonce and observe `settle.responsor_after_conflict` in worker-logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)