### PR TITLE
fix(settle): gate buggy re-sponsor recovery behind ENABLE_SETTLE_RESPONSOR (default off)

### DIFF
--- a/src/__tests__/settle-responsor.test.ts
+++ b/src/__tests__/settle-responsor.test.ts
@@ -205,3 +205,50 @@ describe("Non-conflict broadcast failure does not enter recovery branches", () =
     expect(shouldEnterPreSponsoredPath).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 6. ENABLE_SETTLE_RESPONSOR feature flag — gates the buggy re-sponsor path
+// ---------------------------------------------------------------------------
+
+describe("ENABLE_SETTLE_RESPONSOR feature flag", () => {
+  function shouldEnterResponsorBranch(
+    broadcastResult: BroadcastOnlyResult,
+    sponsorNonce: number | null,
+    envFlag: string | undefined
+  ): boolean {
+    const enabled = envFlag === "true";
+    const inPreSponsoredGate =
+      sponsorNonce === null &&
+      ((broadcastResult as { nonceConflict?: boolean }).nonceConflict === true ||
+        (broadcastResult as { tooMuchChaining?: boolean }).tooMuchChaining === true);
+    return (
+      inPreSponsoredGate &&
+      (broadcastResult as { responsible?: "sender" | "sponsor" | "network" }).responsible === "sponsor" &&
+      enabled
+    );
+  }
+
+  it("OFF by default: sponsor-fault conflict on pre-sponsored tx does NOT enter re-sponsor branch", () => {
+    const broadcastResult = makeBroadcastOnlyError("sponsor");
+    expect(shouldEnterResponsorBranch(broadcastResult, null, undefined)).toBe(false);
+    expect(shouldEnterResponsorBranch(broadcastResult, null, "false")).toBe(false);
+    expect(shouldEnterResponsorBranch(broadcastResult, null, "")).toBe(false);
+  });
+
+  it("ON (\"true\"): sponsor-fault conflict on pre-sponsored tx enters re-sponsor branch", () => {
+    const broadcastResult = makeBroadcastOnlyError("sponsor");
+    expect(shouldEnterResponsorBranch(broadcastResult, null, "true")).toBe(true);
+  });
+
+  it("Flag does NOT affect sender-fault path (always returns SENDER_NONCE_CONFLICT)", () => {
+    const broadcastResult = makeBroadcastOnlyError("sender", "sender_nonce_confirmed");
+    expect(shouldEnterResponsorBranch(broadcastResult, null, "true")).toBe(false);
+    expect(shouldEnterResponsorBranch(broadcastResult, null, "false")).toBe(false);
+  });
+
+  it("Flag does NOT affect auto-sponsored path (sponsorNonce !== null)", () => {
+    const broadcastResult = makeBroadcastOnlyError("sponsor");
+    expect(shouldEnterResponsorBranch(broadcastResult, 42, "true")).toBe(false);
+    expect(shouldEnterResponsorBranch(broadcastResult, 42, "false")).toBe(false);
+  });
+});

--- a/src/endpoints/settle.ts
+++ b/src/endpoints/settle.ts
@@ -672,7 +672,18 @@ export class Settle extends BaseEndpoint {
         ) {
           // Pre-sponsored tx (sponsorNonce === null) had a nonce conflict.
           // Use Phase 1's responsible signal to determine who caused the conflict.
-          if (broadcastResult.responsible === "sponsor") {
+          //
+          // The sponsor-fault re-sponsor path is gated behind ENABLE_SETTLE_RESPONSOR
+          // because the current implementation routes the pre-sponsored tx through
+          // the hand-submit dispatch queue, which then attempts to sponsor-sign a
+          // tx that the broadcast worker treats as non-sponsored — wedging the sponsor
+          // nonce slot until the next reconcile_stale (~22 min). Production incident
+          // 2026-05-19T13:00 UTC stuck 3 wallet-0 nonces. Until the path is rewritten
+          // to bypass the dispatch queue and clean up its own queue entry on failure,
+          // we return CONFLICTING_NONCE for sponsor-fault conflicts as the pre-Phase-2
+          // behavior did.
+          const settleResponsorEnabled = c.env.ENABLE_SETTLE_RESPONSOR === "true";
+          if (broadcastResult.responsible === "sponsor" && settleResponsorEnabled) {
             // Sponsor-fault: the relay's previous sponsor nonce is stale.
             // Re-sponsor the inner client-signed payload with a fresh sponsor nonce.
             // parsedTx holds the original deserialized tx — the client's origin
@@ -762,7 +773,7 @@ export class Settle extends BaseEndpoint {
                 : X402_V2_ERROR_CODES.BROADCAST_FAILED,
               200
             );
-          } else {
+          } else if (broadcastResult.responsible === "sender") {
             // Sender-fault on pre-sponsored tx — no sponsor slot was burned.
             // Return a distinct code so the sender knows to re-sign with the correct nonce.
             logger.info("Sender-fault nonce conflict on pre-sponsored settle — no sponsor slot burned", {
@@ -775,6 +786,23 @@ export class Settle extends BaseEndpoint {
               statsService.logFailure("settle", true, failureCtx, "sender_nonce_stale").catch(() => {})
             );
             return v2Error(X402_V2_ERROR_CODES.SENDER_NONCE_CONFLICT, 200);
+          } else {
+            // Sponsor-fault on pre-sponsored tx, but ENABLE_SETTLE_RESPONSOR is off.
+            // Restore pre-Phase-2 behavior: return CONFLICTING_NONCE without burning a slot.
+            logger.info("Sponsor-fault conflict on pre-sponsored settle — re-sponsor disabled, returning CONFLICTING_NONCE", {
+              responsible: broadcastResult.responsible,
+              nonceConflict: broadcastResult.nonceConflict,
+              tooMuchChaining: broadcastResult.tooMuchChaining,
+            });
+            c.executionCtx.waitUntil(
+              statsService.logFailure("settle", true, failureCtx, "sponsor_nonce_conflict").catch(() => {})
+            );
+            return v2Error(
+              broadcastResult.nonceConflict
+                ? X402_V2_ERROR_CODES.CONFLICTING_NONCE
+                : X402_V2_ERROR_CODES.BROADCAST_FAILED,
+              200
+            );
           }
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,17 @@ export interface Env {
   BROADCAST_NODE_URLS?: string;
   /** Recipient address for nonce gap-fill transactions (default: SPEB8Z3TAY2130B8M5THXZEQQ4D6S3RMYT37WTAC) */
   FLUSH_RECIPIENT?: string;
+  /**
+   * Feature flag for the /settle re-sponsor recovery branch (Phase 2 / issue #373).
+   * Default OFF (any value other than "true"). When OFF, sponsor-fault nonce conflicts
+   * on pre-sponsored /settle calls return CONFLICTING_NONCE (pre-Phase-2 behavior).
+   * When "true", the relay attempts to re-sponsor the inner client-signed payload.
+   * Disabled by default because the current re-sponsor implementation routes through
+   * the hand-submit dispatch queue and wedges the sponsor nonce slot on sign failure
+   * (production incident 2026-05-19T13:00 UTC). Re-enable only after the dispatch-queue
+   * cleanup is rewritten.
+   */
+  ENABLE_SETTLE_RESPONSOR?: string;
   // LOGS is a service binding to worker-logs, typed loosely to avoid complex Service<> generics
   LOGS?: unknown;
   // KV namespace for receipts, dedup, fee cache, and health checks

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -48,7 +48,8 @@
     "STACKS_NETWORK": "testnet",
     "SPONSOR_WALLET_COUNT": "10",
     "SPONSOR_WALLET_MAX": "10",
-    "FLUSH_RECIPIENT": "STEB8Z3TAY2130B8M5THXZEQQ4D6S3RMYRENN2KB"
+    "FLUSH_RECIPIENT": "STEB8Z3TAY2130B8M5THXZEQQ4D6S3RMYRENN2KB",
+    "ENABLE_SETTLE_RESPONSOR": "false"
   },
   // Cron trigger: run health check every 5 minutes
   "triggers": {
@@ -74,7 +75,8 @@
         "STACKS_NETWORK": "testnet",
         "SPONSOR_WALLET_COUNT": "10",
         "SPONSOR_WALLET_MAX": "10",
-        "FLUSH_RECIPIENT": "STEB8Z3TAY2130B8M5THXZEQQ4D6S3RMYRENN2KB"
+        "FLUSH_RECIPIENT": "STEB8Z3TAY2130B8M5THXZEQQ4D6S3RMYRENN2KB",
+        "ENABLE_SETTLE_RESPONSOR": "false"
       },
       // Bindings must be duplicated per environment
       "services": [
@@ -123,7 +125,8 @@
         "STACKS_NETWORK": "mainnet",
         "SPONSOR_WALLET_COUNT": "10",
         "SPONSOR_WALLET_MAX": "10",
-        "FLUSH_RECIPIENT": "SPEB8Z3TAY2130B8M5THXZEQQ4D6S3RMYT37WTAC"
+        "FLUSH_RECIPIENT": "SPEB8Z3TAY2130B8M5THXZEQQ4D6S3RMYT37WTAC",
+        "ENABLE_SETTLE_RESPONSOR": "false"
       },
       // Bindings must be duplicated per environment
       "services": [


### PR DESCRIPTION
## Summary

Production incident **2026-05-19T13:00 UTC** stuck 3 wallet-0 sponsor nonces (3854, 3855, 3856) for 22+ min with `"Cannot sponsor sign a non-sponsored transaction"` retries. This is the second occurrence of a regression introduced by #382 (Phase 2 of nonce-conflict-attribution quest, issue #373).

This PR **gates the buggy re-sponsor branch behind `ENABLE_SETTLE_RESPONSOR` (default `"false"`)**, restoring pre-Phase-2 behavior: sponsor-fault conflicts on pre-sponsored `/settle` calls return `CONFLICTING_NONCE` (retryable, no slot burned) instead of attempting recovery.

## Root cause

The re-sponsor branch at `src/endpoints/settle.ts` calls `SponsorService.sponsorTransaction(parsedTx)` where `parsedTx` is the original *already-sponsored* hex. That routes through the hand-submit dispatch queue (`boundedBroadcast`), which then attempts to sponsor-sign a tx that the worker treats as non-sponsored — wedging the sponsor nonce slot until `nonce_reconcile_stale` clears it ~22 min later.

| | Burst 1 | Burst 2 |
|---|---|---|
| Time | 2026-05-19T07:00 UTC | 2026-05-19T13:00 UTC |
| Stuck nonces | 1 (wallet 1 / 1811) | 3 (wallet 0 / 3854-3856) |
| Duration | 22 min, self-healed | 17+ min (cleared by manual flush-wallet) |
| Severity | bounded | escalating |

## What this PR does NOT change

- The other quest deliverables (#377 attribution wiring, #374 TTL contract, #376 WS pool) remain fully active — they're not implicated.
- The sender-fault path (returns `SENDER_NONCE_CONFLICT`) is unaffected.
- The auto-sponsor recovery path (sponsorNonce !== null) is unaffected.
- The re-sponsor code itself is preserved — only the entry gate is added. A proper fix can re-enable it.

## Why a flag rather than full revert

The flag preserves the test infrastructure, the `SENDER_NONCE_CONFLICT` error code, the stats categorization, and the surrounding logging. A follow-up PR can rewrite the re-sponsor implementation to bypass the dispatch queue + clean up its own queue entry on failure, then re-enable the flag — without re-doing the scaffolding.

## Production cleanup performed before this PR

- Manual `POST /nonce/reset {action:"flush-wallet", walletIndex:0}` cleared the 3 wedged nonces on wallet 0.
- New admin API key minted (previous one had expired); see notes in REGRESSION-NOTES.md in `.planning/2026-05-18-nonce-conflict-attribution/`.

## Changes

| File | Change |
|------|--------|
| `src/endpoints/settle.ts` | Gate the responsor branch on `c.env.ENABLE_SETTLE_RESPONSOR === "true"`. When off, sponsor-fault falls through to CONFLICTING_NONCE with a clear log line. |
| `src/types.ts` | Declare optional `ENABLE_SETTLE_RESPONSOR` env var with full doc explaining why it defaults off. |
| `src/__tests__/settle-responsor.test.ts` | 4 new tests for the flag gate. |
| `wrangler.jsonc` | Declare `"ENABLE_SETTLE_RESPONSOR": "false"` in dev / staging / production env blocks. |

## Test plan

- [x] `npm run check` clean
- [x] `npm test -- settle-responsor` — all 15 tests pass (11 existing + 4 new)
- [x] Full `npm test` — only pre-existing `nonce-do-sponsor-status` failure on main (unrelated)
- [ ] CI green on this PR
- [ ] Post-deploy: 0 new `Re-sponsor failed` events
- [ ] Post-deploy: 0 new `"Cannot sponsor sign a non-sponsored transaction"` errors

## Follow-up

File a tracking issue for the proper re-sponsor rewrite. Rough approach:

1. Mint a sponsor nonce manually (without hand-submit).
2. Sign with `@stacks/transactions sponsorTransaction()` in-process.
3. Broadcast directly via `settlementService.broadcastOnly()`.
4. On any failure: release the nonce, do NOT enqueue, return CONFLICTING_NONCE.
5. Add a vitest case that mocks the sign step to throw and asserts no dispatch_queue side-effect.
6. Re-enable the flag.

Refs #373, #382. cc @arc0btc