### PR TITLE
fix(nonce-do): retire bounded_broadcast zombies on head-advance + structural exceptions

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -7894,6 +7894,22 @@ export class NonceDO {
         continue;
       }
 
+      // Zombie guard: if the wallet head has advanced past this entry's sponsor_nonce,
+      // the chain has already consumed that nonce slot (via a successful confirm on a
+      // separate broadcast path, RBF, or external use). Retrying broadcast against an
+      // already-confirmed nonce produces ConflictingNonceInMempool indefinitely and
+      // wastes alarm CPU. Retire and move on.
+      const walletHead = this.ledgerGetWalletHead(entry.wallet_index);
+      if (walletHead !== null && entry.sponsor_nonce < walletHead) {
+        this.retireQueuedEntry(entry.wallet_index, entry.sponsor_nonce, "head_advanced_past_nonce");
+        this.log("info", "bounded_broadcast_zombie_retired", {
+          walletIndex: entry.wallet_index,
+          sponsorNonce: entry.sponsor_nonce,
+          walletHead,
+        });
+        continue;
+      }
+
       // Note: no pre-flight headroom gate here. Queued entries already have assigned nonces
       // within the wallet's head-frontier gap — broadcasting them fills the gap rather than
       // expanding it. Headroom measures local gap, not mempool depth, so gating on it would
@@ -8019,10 +8035,45 @@ export class NonceDO {
           errors++;
         }
       } catch (e) {
+        const errMsg = e instanceof Error ? e.message : String(e);
+
+        // Structural-failure retire: certain @stacks/transactions throws indicate the
+        // queued hex is structurally invalid for sponsoring (e.g., non-sponsored auth
+        // type slipped in, malformed bytes). Retrying these forever produces log spam
+        // and never recovers — the hex itself is broken, not a transient failure.
+        // Retire the entry rather than swallow-and-retry.
+        //
+        // Patterns we treat as structural / non-retryable:
+        //   - "Cannot sponsor sign a non-sponsored transaction" (auth.authType !== Sponsored)
+        //   - "Failed to deserialize" / deserializeTransaction throws (malformed hex)
+        //
+        // tx-schemas follow-up: extend NodeBroadcastOutcomeSchema with a local pre-broadcast
+        // outcome variant so decideBroadcastAction owns this classification instead of a
+        // string-match here. Tracked in REGRESSION-NOTES for #373.
+        const isStructuralFailure =
+          /non-sponsored transaction/i.test(errMsg) ||
+          /failed to deserialize/i.test(errMsg) ||
+          /malformed/i.test(errMsg);
+
+        if (isStructuralFailure) {
+          this.retireQueuedEntry(
+            entry.wallet_index,
+            entry.sponsor_nonce,
+            "structural_failure"
+          );
+          this.log("warn", "bounded_broadcast_structural_retire", {
+            walletIndex: entry.wallet_index,
+            sponsorNonce: entry.sponsor_nonce,
+            error: errMsg,
+          });
+          errors++;
+          continue;
+        }
+
         this.log("warn", "bounded_broadcast_error", {
           walletIndex: entry.wallet_index,
           sponsorNonce: entry.sponsor_nonce,
-          error: e instanceof Error ? e.message : String(e),
+          error: errMsg,
         });
         errors++;
       }


### PR DESCRIPTION
## Summary

Two guards in the `bounded_broadcast` retry loop to stop dispatch_queue zombies from generating perpetual `bounded_broadcast_error` log spam and wasting alarm CPU.

## Problem

Production incident **2026-05-19T13:00 UTC** left 3 zombie dispatch_queue entries on wallet 0 (sponsorNonces 3854, 3855, 3856). PR #390 stopped *new* zombies from being created (gated the buggy `/settle` re-sponsor branch behind `ENABLE_SETTLE_RESPONSOR=false`), but the 3 existing ones continued firing `bounded_broadcast_error` every ~5 min for 2.5+ hours, even after the chain head advanced past them to 3856.

`flush-wallet` couldn't reach them because its flush range is `[chainFrontier, assignmentHead]` (both at 3856 = same value = range-of-one).

## Fix

### 1. Head-advance guard

```ts
const walletHead = this.ledgerGetWalletHead(entry.wallet_index);
if (walletHead !== null && entry.sponsor_nonce < walletHead) {
  this.retireQueuedEntry(entry.wallet_index, entry.sponsor_nonce, "head_advanced_past_nonce");
  this.log("info", "bounded_broadcast_zombie_retired", { walletIndex, sponsorNonce, walletHead });
  continue;
}
```

If chain head has advanced past the entry, the nonce slot is already consumed. Retire instead of retrying ConflictingNonceInMempool forever. Handles wallet-0 nonces 3854 and 3855 immediately on next alarm tick.

### 2. Structural-failure retire in catch block

```ts
const isStructuralFailure =
  /non-sponsored transaction/i.test(errMsg) ||
  /failed to deserialize/i.test(errMsg) ||
  /malformed/i.test(errMsg);

if (isStructuralFailure) {
  this.retireQueuedEntry(entry.wallet_index, entry.sponsor_nonce, "structural_failure");
  this.log("warn", "bounded_broadcast_structural_retire", { ... });
  ...
}
```

When @stacks/transactions throws on a queued tx with a structural pattern (auth-type mismatch, deserialize failure, malformed bytes), the hex is broken — retrying never recovers. Retire instead of swallow-and-retry. Handles wallet-0 nonce 3856 (which is currently AT the head, so guard #1 doesn't catch it).

## Test plan

- [x] `npm run check` clean
- [x] Only pre-existing unrelated test failure (`nonce-do-sponsor-status`)
- [ ] Post-deploy: log for `bounded_broadcast_zombie_retired` events on wallet 0 nonces 3854/3855 within 1 alarm tick (~5 min)
- [ ] Post-deploy: log for `bounded_broadcast_structural_retire` event on wallet 0 nonce 3856 within 1 alarm tick (~5 min)
- [ ] Post-deploy: `bounded_broadcast_error` with "Cannot sponsor sign a non-sponsored transaction" should NOT fire again on those nonces

## Follow-up (tracked in REGRESSION-NOTES.md)

The string-match classifier is a stopgap. Proper fix extends `@aibtc/tx-schemas` `NodeBroadcastOutcomeSchema` with a local pre-broadcast outcome variant so `decideBroadcastAction` owns this classification. That work also covers the re-sponsor rewrite needed to re-enable `ENABLE_SETTLE_RESPONSOR`.

Refs #373, builds on PR #390. cc @arc0btc