### PR TITLE
feat(queue): consume the DLQ to terminalize dead-lettered payments (#398)

### DIFF
--- a/src/__tests__/queue-consumer.test.ts
+++ b/src/__tests__/queue-consumer.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPaymentRecord, getPaymentRecord, putPaymentRecord, transitionPayment } from "../services/payment-status";
-import { handlePaymentQueue } from "../queue-consumer";
+import { handlePaymentQueue, handlePaymentDLQ } from "../queue-consumer";
 import { MemoryKV } from "./helpers/memory-kv";
 
 const mocks = vi.hoisted(() => ({
@@ -513,5 +513,79 @@ describe("queue consumer recovery boundaries", () => {
     const finalRecord = await getPaymentRecord(kv, "pay_retry");
     // Left for the queue to retry — not prematurely terminalized.
     expect(finalRecord?.status).not.toBe("failed");
+  });
+});
+
+describe("payment DLQ consumer (#398)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("terminalizes a dead-lettered payment still stuck non-terminal", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_dlq", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 3;
+    record.senderAddress = "STDLQ00000000000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    const message = createMessage({
+      paymentId: "pay_dlq",
+      txHex: "dlq_tx",
+      network: "testnet",
+      attempt: 5,
+    });
+
+    await handlePaymentDLQ(
+      {
+        queue: "x402-payment-dlq-test",
+        messages: [message],
+      } as unknown as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    const finalRecord = await getPaymentRecord(kv, "pay_dlq");
+    expect(finalRecord).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        retryable: true,
+        terminalReason: "internal_error",
+        errorCode: "BROADCAST_EXHAUSTED",
+      })
+    );
+  });
+
+  it("does not regress an already-terminal dead-lettered payment", async () => {
+    const kv = new MemoryKV();
+    const confirmed = transitionPayment(
+      createPaymentRecord("pay_dlq_confirmed", "testnet"),
+      "confirmed",
+      { txid: "0xdef" }
+    );
+    await putPaymentRecord(kv, confirmed);
+
+    const message = createMessage({
+      paymentId: "pay_dlq_confirmed",
+      txHex: "x",
+      network: "testnet",
+      attempt: 5,
+    });
+
+    await handlePaymentDLQ(
+      {
+        queue: "x402-payment-dlq-test",
+        messages: [message],
+      } as unknown as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    const finalRecord = await getPaymentRecord(kv, "pay_dlq_confirmed");
+    expect(finalRecord?.status).toBe("confirmed");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { dashboard } from "./dashboard";
 import { discovery } from "./routes/discovery";
 import { VERSION } from "./version";
 import { SettlementHealthService } from "./services";
-import { handlePaymentQueue } from "./queue-consumer";
+import { handlePaymentQueue, handlePaymentDLQ } from "./queue-consumer";
 import type { PaymentQueueMessage } from "./services/payment-status";
 export { NonceDO } from "./durable-objects/nonce-do";
 export { StatsDO } from "./durable-objects/stats-do";
@@ -243,12 +243,22 @@ export default {
    * Queue consumer — processes PAYMENT_QUEUE messages serially.
    * Each message: sponsor tx → assign nonce via NonceDO → broadcast → update status.
    * Serial consumption eliminates nonce contention by design.
+   *
+   * Also consumes the dead-letter queue (x402-payment-dlq-*): messages that
+   * exhausted the main queue's retries land there with a still-non-terminal
+   * payment record. handlePaymentDLQ() terminalizes them so they can't be
+   * stranded at "queued" (which would wedge the sender wallet via inbox dedup).
+   * Routed by batch.queue since both queues share this single handler. (#398)
    */
   async queue(
     batch: MessageBatch<PaymentQueueMessage>,
     env: Env,
     ctx: ExecutionContext
   ): Promise<void> {
-    await handlePaymentQueue(batch, env, ctx);
+    if (batch.queue.includes("-dlq-")) {
+      await handlePaymentDLQ(batch, env, ctx);
+    } else {
+      await handlePaymentQueue(batch, env, ctx);
+    }
   },
 };

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -507,6 +507,7 @@ async function finalizeExhaustedPayment(
   env: Env,
   paymentId: string,
   logger: Logger,
+  opts?: { route?: string; error?: string; action?: string },
 ): Promise<void> {
   try {
     const kv = env.RELAY_KV;
@@ -515,7 +516,7 @@ async function finalizeExhaustedPayment(
     // Only terminalize records still in flight — never regress a confirmed/failed one.
     if (!record || isTerminalPaymentStatus(record.status)) return;
     const updated = transitionPayment(record, "failed", {
-      error: "Payment processing exhausted retries before broadcast",
+      error: opts?.error ?? "Payment processing exhausted retries before broadcast",
       errorCode: "BROADCAST_EXHAUSTED",
       terminalReason: "internal_error",
       retryable: true,
@@ -525,18 +526,18 @@ async function finalizeExhaustedPayment(
       logger,
       "payment.finalized",
       {
-        route: "PAYMENT_QUEUE",
+        route: opts?.route ?? "PAYMENT_QUEUE",
         paymentId,
         status: updated.status,
         terminalReason: updated.terminalReason,
-        action: "exhausted_retries_terminalized",
+        action: opts?.action ?? "exhausted_retries_terminalized",
         checkStatusUrlPresent: false,
         compatShimUsed: false,
       },
       "warn",
     );
   } catch (e) {
-    logger.warn("Failed to finalize exhausted payment before dead-letter", {
+    logger.warn("Failed to finalize exhausted payment", {
       paymentId,
       error: e instanceof Error ? e.message : String(e),
     });
@@ -577,5 +578,41 @@ export async function handlePaymentQueue(
         message.ack(); // final ack — drops the message (not dead-lettered)
       }
     }
+  }
+}
+
+/**
+ * Dead-letter queue consumer for x402-payment-dlq-*.
+ *
+ * A message reaches the DLQ only after exhausting the main queue's retries via
+ * message.retry() (e.g. the unbounded capacity-hold retry path), which leaves
+ * the payment record non-terminal at "queued". Nothing else re-drives a DLQ'd
+ * message, so without this consumer the payment is stranded forever — and the
+ * aibtc inbox dedups future sends onto the stuck record, wedging the sender
+ * wallet so it can no longer send any message.
+ *
+ * This consumer enforces the safety-net invariant: no dead-lettered payment is
+ * left non-terminal. It marks the record failed + retryable (via
+ * finalizeExhaustedPayment), releasing the inbox dedup so the agent can cleanly
+ * resubmit. Always acks — never re-throws into an infinite DLQ loop. (#398)
+ */
+export async function handlePaymentDLQ(
+  batch: MessageBatch<PaymentQueueMessage>,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<void> {
+  for (const message of batch.messages) {
+    const logger = createWorkerLogger(env.LOGS, ctx, {
+      component: "payment_dlq",
+      queue: batch.queue,
+      paymentId: message.body.paymentId,
+      attempt: message.attempts,
+    });
+    await finalizeExhaustedPayment(env, message.body.paymentId, logger, {
+      route: "PAYMENT_DLQ",
+      error: "Payment dead-lettered after exhausting queue retries",
+      action: "dlq_terminalized",
+    });
+    message.ack();
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -41,6 +41,11 @@
         "max_batch_size": 1,
         "max_retries": 5,
         "dead_letter_queue": "x402-payment-dlq-dev"
+      },
+      {
+        "queue": "x402-payment-dlq-dev",
+        "max_batch_size": 1,
+        "max_retries": 3
       }
     ]
   },
@@ -108,6 +113,11 @@
             "max_batch_size": 1,
             "max_retries": 5,
             "dead_letter_queue": "x402-payment-dlq-staging"
+          },
+          {
+            "queue": "x402-payment-dlq-staging",
+            "max_batch_size": 1,
+            "max_retries": 3
           }
         ]
       },
@@ -158,6 +168,11 @@
             "max_batch_size": 1,
             "max_retries": 5,
             "dead_letter_queue": "x402-payment-dlq-production"
+          },
+          {
+            "queue": "x402-payment-dlq-production",
+            "max_batch_size": 1,
+            "max_retries": 3
           }
         ]
       },


### PR DESCRIPTION
## What & why

Part 2 of #398. **Stacked on #399** (base = `fix/398-terminal-state-on-exhaustion`); review/merge #399 first.

#399 guaranteed a terminal record on the catch-all path (which `ack()`s/drops the message — never reaches the DLQ). But the **capacity-hold** path calls `message.retry()` *unconditionally*, so when capacity stays unavailable it exhausts the main queue's `max_retries` and the message lands in `x402-payment-dlq-*` — which **had no consumer**. The payment record was left non-terminal at `queued` forever → the aibtc inbox dedups future sends onto the stuck record → the sender wallet is wedged.

## Change

- **`wrangler.jsonc`**: add a consumer for `x402-payment-dlq-{dev,staging,production}` (`max_retries: 3`, no further DLQ so it can't recurse).
- **`index.ts`**: the single `queue()` export now routes by `batch.queue` — DLQ batches → `handlePaymentDLQ`, everything else → `handlePaymentQueue`.
- **`queue-consumer.ts`**: `handlePaymentDLQ` terminalizes any still-non-terminal record (`failed` + `retryable`, via the shared `finalizeExhaustedPayment`, now parameterized for distinct logging), then acks. Fail-open; never regresses a `confirmed`/`failed` record.

This completes the **"no dead-lettered payment is left non-terminal"** invariant: the inbox dedup releases and the agent can resubmit.

## Tests

- DLQ terminalizes a stuck non-terminal payment (`failed`+`retryable`).
- DLQ does **not** regress an already-`confirmed` record.
- `npm run check` clean; `npm run deploy:dry-run` validates the new consumer binding + build; queue-consumer suite 9/9.

## Scope / not in this PR

Actual **re-delivery** (re-sponsor with a fresh nonce via the replay buffer so the message goes out without the agent resubmitting) is the riskier enhancement — deferred to a focused follow-up (idempotency, double-send guards, loop bounds). Also still pending for #398: the DO zombie-guard → replay-buffer fix and a proactive `queued`-stale reconcile sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
