### PR TITLE
feat(reconcile): cron sweep to recover stuck payment records (#398)

### DIFF
--- a/src/__tests__/helpers/memory-kv.ts
+++ b/src/__tests__/helpers/memory-kv.ts
@@ -53,7 +53,18 @@ export class MemoryKV implements KVNamespace {
     this.store.delete(key);
   }
 
-  async list(): Promise<KVNamespaceListResult<unknown>> {
-    throw new Error("not implemented");
+  async list(options?: {
+    prefix?: string | null;
+    limit?: number | null;
+    cursor?: string | null;
+  }): Promise<KVNamespaceListResult<unknown>> {
+    const prefix = options?.prefix ?? "";
+    const names = [...this.store.keys()].filter((k) => k.startsWith(prefix)).sort();
+    const limited = options?.limit != null ? names.slice(0, options.limit) : names;
+    return {
+      keys: limited.map((name) => ({ name })),
+      list_complete: true,
+      cacheStatus: null,
+    } as KVNamespaceListResult<unknown>;
   }
 }

--- a/src/__tests__/payment-reconcile.test.ts
+++ b/src/__tests__/payment-reconcile.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createPaymentRecord,
+  getPaymentRecord,
+  putPaymentRecord,
+  transitionPayment,
+  type PaymentRecord,
+  type PaymentStatus,
+} from "../services/payment-status";
+import { reconcileStuckPayments } from "../services/payment-reconcile";
+import { MemoryKV } from "./helpers/memory-kv";
+
+const logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as unknown as Parameters<typeof reconcileStuckPayments>[1];
+
+const env = (kv: MemoryKV) =>
+  ({ RELAY_KV: kv, STACKS_NETWORK: "mainnet" }) as unknown as Parameters<typeof reconcileStuckPayments>[0];
+
+/** Build a stuck record older than the 5-minute staleness threshold. */
+function staleRecord(
+  id: string,
+  sender: string,
+  nonce: number,
+  status: PaymentStatus = "queued",
+): PaymentRecord {
+  const r = transitionPayment(createPaymentRecord(id, "mainnet"), status);
+  r.senderAddress = sender;
+  r.senderNonce = nonce;
+  const old = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+  r.submittedAt = old;
+  r.queuedAt = old;
+  return r;
+}
+
+interface MockTx {
+  nonce: number;
+  tx_id: string;
+  tx_status: string;
+  sponsored?: boolean;
+  block_height?: number;
+}
+
+function mockHiro(opts: { lastExec: number | null; next: number | null; mempool?: number[]; txs?: MockTx[] }) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      if (url.includes("/nonces")) {
+        return {
+          ok: true,
+          json: async () => ({
+            last_executed_tx_nonce: opts.lastExec,
+            possible_next_nonce: opts.next,
+            detected_mempool_nonces: opts.mempool ?? [],
+          }),
+        };
+      }
+      if (url.includes("/transactions")) {
+        return { ok: true, json: async () => ({ results: opts.txs ?? [] }) };
+      }
+      return { ok: false, json: async () => ({}) };
+    }),
+  );
+}
+
+describe("reconcileStuckPayments (#398)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("confirms a stuck record whose sender nonce settled via a sponsored tx (+ writes txid_map)", async () => {
+    const kv = new MemoryKV();
+    await putPaymentRecord(kv, staleRecord("pay_conf", "SP_SENDER", 47));
+    mockHiro({
+      lastExec: 49,
+      next: 50,
+      txs: [{ nonce: 47, tx_id: "0xabc", tx_status: "success", sponsored: true, block_height: 100 }],
+    });
+
+    await reconcileStuckPayments(env(kv), logger);
+
+    const r = await getPaymentRecord(kv, "pay_conf");
+    expect(r).toEqual(expect.objectContaining({ status: "confirmed", txid: "0xabc", blockHeight: 100 }));
+    expect(await kv.get("txid_map:0xabc")).toBe("pay_conf");
+  });
+
+  it("marks a record superseded when a different (self-paid) tx took the nonce", async () => {
+    const kv = new MemoryKV();
+    await putPaymentRecord(kv, staleRecord("pay_sup", "SP_SENDER", 47));
+    mockHiro({
+      lastExec: 49,
+      next: 50,
+      txs: [{ nonce: 47, tx_id: "0xdef", tx_status: "success", sponsored: false }],
+    });
+
+    await reconcileStuckPayments(env(kv), logger);
+
+    const r = await getPaymentRecord(kv, "pay_sup");
+    expect(r).toEqual(expect.objectContaining({ status: "replaced", terminalReason: "superseded" }));
+    expect(await kv.get("txid_map:0xdef")).toBeNull();
+  });
+
+  it("fails a record whose tx aborted on-chain", async () => {
+    const kv = new MemoryKV();
+    await putPaymentRecord(kv, staleRecord("pay_abort", "SP_SENDER", 47));
+    mockHiro({
+      lastExec: 49,
+      next: 50,
+      txs: [{ nonce: 47, tx_id: "0xbad", tx_status: "abort_by_response", sponsored: true }],
+    });
+
+    await reconcileStuckPayments(env(kv), logger);
+
+    const r = await getPaymentRecord(kv, "pay_abort");
+    expect(r).toEqual(
+      expect.objectContaining({ status: "failed", terminalReason: "chain_abort", retryable: false }),
+    );
+  });
+
+  it("terminalizes a never-landed stuck record (nonce open, not in mempool) as failed+retryable", async () => {
+    const kv = new MemoryKV();
+    await putPaymentRecord(kv, staleRecord("pay_stale", "SP_SENDER", 47));
+    mockHiro({ lastExec: 46, next: 47, mempool: [] });
+
+    await reconcileStuckPayments(env(kv), logger);
+
+    const r = await getPaymentRecord(kv, "pay_stale");
+    expect(r).toEqual(
+      expect.objectContaining({ status: "failed", retryable: true, terminalReason: "internal_error" }),
+    );
+  });
+
+  it("leaves an in-flight record (nonce in mempool) untouched", async () => {
+    const kv = new MemoryKV();
+    await putPaymentRecord(kv, staleRecord("pay_inflight", "SP_SENDER", 47));
+    mockHiro({ lastExec: 46, next: 47, mempool: [47] });
+
+    await reconcileStuckPayments(env(kv), logger);
+
+    const r = await getPaymentRecord(kv, "pay_inflight");
+    expect(r?.status).toBe("queued");
+  });
+
+  it("skips records that are too recent to be stale", async () => {
+    const kv = new MemoryKV();
+    // Fresh record — createPaymentRecord stamps submittedAt = now.
+    const fresh = transitionPayment(createPaymentRecord("pay_fresh", "mainnet"), "queued");
+    fresh.senderAddress = "SP_SENDER";
+    fresh.senderNonce = 47;
+    await putPaymentRecord(kv, fresh);
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await reconcileStuckPayments(env(kv), logger);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const r = await getPaymentRecord(kv, "pay_fresh");
+    expect(r?.status).toBe("queued");
+  });
+
+  it("skips already-terminal records", async () => {
+    const kv = new MemoryKV();
+    await putPaymentRecord(kv, staleRecord("pay_done", "SP_SENDER", 47, "confirmed"));
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await reconcileStuckPayments(env(kv), logger);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const r = await getPaymentRecord(kv, "pay_done");
+    expect(r?.status).toBe("confirmed");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { discovery } from "./routes/discovery";
 import { VERSION } from "./version";
 import { SettlementHealthService } from "./services";
 import { handlePaymentQueue, handlePaymentDLQ } from "./queue-consumer";
+import { reconcileStuckPayments } from "./services/payment-reconcile";
+import { createWorkerLogger } from "./utils";
 import type { PaymentQueueMessage } from "./services/payment-status";
 export { NonceDO } from "./durable-objects/nonce-do";
 export { StatsDO } from "./durable-objects/stats-do";
@@ -227,7 +229,8 @@ export default {
   /**
    * Scheduled handler — runs on the cron trigger defined in wrangler.jsonc.
    * Executes a settlement health check every 5 minutes to populate KV history
-   * so that the dashboard uptime24h metric is accurate.
+   * so that the dashboard uptime24h metric is accurate, and runs the stuck-payment
+   * reconcile sweep (#398) to recover records stranded non-terminal at "queued".
    */
   async scheduled(
     _event: ScheduledEvent,
@@ -237,6 +240,13 @@ export default {
     const logger = createNoOpLogger();
     const healthService = new SettlementHealthService(env, logger);
     ctx.waitUntil(healthService.checkHealth());
+
+    // Recover stuck payment records (confirm settled ones, terminalize dead ones)
+    // so the aibtc inbox dedup releases and wedged wallets can resubmit. (#398)
+    const reconcileLogger = createWorkerLogger(env.LOGS, ctx, {
+      component: "payment_reconcile",
+    });
+    ctx.waitUntil(reconcileStuckPayments(env, reconcileLogger));
   },
 
   /**

--- a/src/services/payment-reconcile.ts
+++ b/src/services/payment-reconcile.ts
@@ -1,0 +1,219 @@
+/**
+ * Reconcile sweep for stuck payment records (#398).
+ *
+ * The forward fixes (#399 terminalize-on-exhaustion, #400 DLQ consumer) stop NEW
+ * strands, but they're forward-only: records already stuck non-terminal — and any
+ * predating those fixes — stay stuck. The aibtc inbox dedups future sends onto a
+ * stuck record, so a wedged wallet can't recover until its record reaches a
+ * terminal state. This sweep, run from the cron `scheduled()` handler, recovers
+ * those strands.
+ *
+ * For each payment record stuck non-terminal past a staleness threshold (so we
+ * never race in-flight queue processing), it checks the sender's on-chain nonce:
+ *   - nonce confirmed via a sponsored tx        -> confirmed (+ txid_map) so aibtc delivers
+ *   - nonce taken by a different (self-paid) tx  -> replaced (superseded)
+ *   - nonce aborted on-chain                     -> failed (chain_abort)
+ *   - nonce still open, never reached the chain  -> failed + retryable (releases inbox dedup)
+ *
+ * Fail-open throughout; bounded per run to cap cron time and Hiro API usage.
+ */
+import type { Env, Logger } from "../types";
+import {
+  getPaymentRecord,
+  putPaymentRecord,
+  transitionPayment,
+  isTerminalPaymentStatus,
+  type PaymentRecord,
+} from "./payment-status";
+import { getHiroBaseUrl, getHiroHeaders } from "../utils";
+
+const PAYMENT_KEY_PREFIX = "payment:";
+/** Only act on records older than this — avoids racing in-flight queue processing. */
+const STALE_MS = 5 * 60 * 1000;
+/** Cap actions (and thus Hiro calls) per cron run. */
+const MAX_ACTIONS_PER_RUN = 25;
+const TXID_MAP_TTL_S = 86_400;
+
+interface HiroNonces {
+  last_executed_tx_nonce: number | null;
+  possible_next_nonce: number | null;
+  detected_mempool_nonces?: number[];
+}
+
+interface HiroTx {
+  tx_id: string;
+  nonce: number;
+  tx_status: string;
+  sponsored?: boolean;
+  block_height?: number;
+}
+
+/**
+ * Scan RELAY_KV for non-terminal payment records and resolve the stuck ones.
+ * Safe to call on every cron tick — fail-open and bounded.
+ */
+export async function reconcileStuckPayments(env: Env, logger: Logger): Promise<void> {
+  const kv = env.RELAY_KV;
+  if (!kv) return;
+
+  const now = Date.now();
+  let scanned = 0;
+  let acted = 0;
+
+  try {
+    const list = await kv.list({ prefix: PAYMENT_KEY_PREFIX, limit: 1000 });
+    for (const key of list.keys) {
+      if (acted >= MAX_ACTIONS_PER_RUN) break;
+
+      const paymentId = key.name.slice(PAYMENT_KEY_PREFIX.length);
+      // Defensive: only payment records (artifact keys use a disjoint prefix).
+      if (!paymentId.startsWith("pay_")) continue;
+
+      const record = await getPaymentRecord(kv, paymentId).catch(() => null);
+      if (!record || isTerminalPaymentStatus(record.status)) continue;
+
+      // Skip recent records — they may still be mid-flight in the queue consumer.
+      const startedAt = record.queuedAt ?? record.submittedAt;
+      if (startedAt && now - new Date(startedAt).getTime() < STALE_MS) continue;
+
+      // Need a sender identity to look up the on-chain nonce.
+      if (!record.senderAddress || record.senderNonce === undefined) continue;
+
+      scanned++;
+      try {
+        if (await reconcileOne(env, kv, logger, record)) acted++;
+      } catch (e) {
+        logger.warn("reconcile_stuck_payment_error", {
+          paymentId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+  } catch (e) {
+    logger.warn("reconcile_stuck_payments_list_error", {
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  if (scanned > 0) {
+    logger.info("reconcile_stuck_payments_summary", { scanned, acted });
+  }
+}
+
+/**
+ * Resolve a single stuck record against on-chain state.
+ * Returns true if it transitioned the record to a terminal state.
+ */
+async function reconcileOne(
+  env: Env,
+  kv: KVNamespace,
+  logger: Logger,
+  record: PaymentRecord,
+): Promise<boolean> {
+  const sender = record.senderAddress as string;
+  const nonce = record.senderNonce as number;
+  const baseUrl = getHiroBaseUrl(env.STACKS_NETWORK);
+  const headers = getHiroHeaders(env.HIRO_API_KEY);
+
+  const nonceRes = await fetch(`${baseUrl}/extended/v1/address/${sender}/nonces`, { headers });
+  if (!nonceRes.ok) return false; // Hiro unavailable — retry next cron
+  const nonces = (await nonceRes.json()) as HiroNonces;
+  const lastExec = nonces.last_executed_tx_nonce;
+
+  // Case A: the sender nonce has been consumed on-chain.
+  if (typeof lastExec === "number" && nonce <= lastExec) {
+    const tx = await fetchSenderTxAtNonce(baseUrl, headers, sender, nonce);
+    if (!tx) return false; // can't classify yet — retry next cron
+
+    if (tx.tx_status === "success") {
+      if (tx.sponsored) {
+        // Relay-sponsored success — this payment DID land. Link txid -> paymentId
+        // (so chainhook/poll agree) and confirm so aibtc releases the staged message.
+        await kv.put(`txid_map:${tx.tx_id}`, record.paymentId, { expirationTtl: TXID_MAP_TTL_S });
+        const updated = transitionPayment(record, "confirmed", {
+          txid: tx.tx_id,
+          ...(typeof tx.block_height === "number" ? { blockHeight: tx.block_height } : {}),
+        });
+        await putPaymentRecord(kv, updated);
+        logger.info("reconcile_confirmed", {
+          paymentId: record.paymentId,
+          txid: tx.tx_id,
+          senderNonce: nonce,
+        });
+      } else {
+        // A different (self-paid) tx took the nonce — the relay payment was superseded.
+        const updated = transitionPayment(record, "replaced", {
+          txid: tx.tx_id,
+          terminalReason: "superseded",
+          replacedReason: "sender_nonce_consumed_by_other_tx",
+          resubmittable: false,
+        });
+        await putPaymentRecord(kv, updated);
+        logger.info("reconcile_superseded", {
+          paymentId: record.paymentId,
+          txid: tx.tx_id,
+          senderNonce: nonce,
+        });
+      }
+      return true;
+    }
+
+    if (tx.tx_status.startsWith("abort")) {
+      const updated = transitionPayment(record, "failed", {
+        txid: tx.tx_id,
+        error: `Transaction aborted on-chain: ${tx.tx_status}`,
+        errorCode: "SETTLEMENT_FAILED",
+        terminalReason: "chain_abort",
+        retryable: false,
+      });
+      await putPaymentRecord(kv, updated);
+      logger.info("reconcile_aborted", {
+        paymentId: record.paymentId,
+        txid: tx.tx_id,
+        txStatus: tx.tx_status,
+      });
+      return true;
+    }
+
+    // dropped/pending at that nonce — leave for a later cycle.
+    return false;
+  }
+
+  // Case B: nonce not yet executed.
+  const mempool = new Set(nonces.detected_mempool_nonces ?? []);
+  if (mempool.has(nonce)) return false; // genuinely in flight — leave it
+
+  // Case C: nonce still open, nothing in the mempool, and the record is stale —
+  // the tx never reached the chain. Terminalize so the inbox dedup releases and
+  // the agent can resubmit. (Policy: terminalize only — no blind re-broadcast.)
+  const updated = transitionPayment(record, "failed", {
+    error: "Payment stuck queued past timeout without reaching the chain",
+    errorCode: "BROADCAST_EXHAUSTED",
+    terminalReason: "internal_error",
+    retryable: true,
+  });
+  await putPaymentRecord(kv, updated);
+  logger.info("reconcile_terminalized_stale", {
+    paymentId: record.paymentId,
+    senderNonce: nonce,
+  });
+  return true;
+}
+
+/** Find the sender's transaction occupying a specific nonce (within recent history). */
+async function fetchSenderTxAtNonce(
+  baseUrl: string,
+  headers: Record<string, string>,
+  sender: string,
+  nonce: number,
+): Promise<HiroTx | null> {
+  const res = await fetch(`${baseUrl}/extended/v1/address/${sender}/transactions?limit=50`, { headers });
+  if (!res.ok) return null;
+  const data = (await res.json()) as { results?: Array<Record<string, unknown>> };
+  for (const r of data.results ?? []) {
+    const tx = ((r.tx as HiroTx | undefined) ?? (r as unknown as HiroTx));
+    if (typeof tx.nonce !== "number") continue;
+    if (tx.nonce === nonce) return tx;
+  }
+  return null;
+}

--- a/src/services/payment-reconcile.ts
+++ b/src/services/payment-reconcile.ts
@@ -62,6 +62,11 @@ export async function reconcileStuckPayments(env: Env, logger: Logger): Promise<
 
   try {
     const list = await kv.list({ prefix: PAYMENT_KEY_PREFIX, limit: 1000 });
+    // At current volumes one page covers all records. If that ever stops being
+    // true, surface it — records past page 1 would be silently skipped this tick.
+    if (!list.list_complete) {
+      logger.warn("reconcile_stuck_payments_truncated", { limit: 1000 });
+    }
     for (const key of list.keys) {
       if (acted >= MAX_ACTIONS_PER_RUN) break;
 
@@ -76,8 +81,8 @@ export async function reconcileStuckPayments(env: Env, logger: Logger): Promise<
       const startedAt = record.queuedAt ?? record.submittedAt;
       if (startedAt && now - new Date(startedAt).getTime() < STALE_MS) continue;
 
-      // Need a sender identity to look up the on-chain nonce.
-      if (!record.senderAddress || record.senderNonce === undefined) continue;
+      // Need a sender identity to look up the on-chain nonce (== null covers null + undefined).
+      if (!record.senderAddress || record.senderNonce == null) continue;
 
       scanned++;
       try {
@@ -200,7 +205,14 @@ async function reconcileOne(
   return true;
 }
 
-/** Find the sender's transaction occupying a specific nonce (within recent history). */
+/**
+ * Find the sender's transaction occupying a specific nonce (within recent history).
+ * For a stuck payment the target nonce sits at/near the chain frontier, so the
+ * recent window covers it; a miss returns null (fail-open — retried next cron).
+ *
+ * Note: this endpoint caps `limit` at 50 (limit=100 → HTTP 400), so 50 is the
+ * max single-page window. If a deeper window is ever needed, paginate via offset.
+ */
 async function fetchSenderTxAtNonce(
   baseUrl: string,
   headers: Record<string, string>,
@@ -209,10 +221,10 @@ async function fetchSenderTxAtNonce(
 ): Promise<HiroTx | null> {
   const res = await fetch(`${baseUrl}/extended/v1/address/${sender}/transactions?limit=50`, { headers });
   if (!res.ok) return null;
-  const data = (await res.json()) as { results?: Array<Record<string, unknown>> };
-  for (const r of data.results ?? []) {
-    const tx = ((r.tx as HiroTx | undefined) ?? (r as unknown as HiroTx));
-    if (typeof tx.nonce !== "number") continue;
+  // The /extended/v1/address/{principal}/transactions endpoint returns flat tx
+  // objects in `results` (not the `{ tx: ... }` wrapper some other endpoints use).
+  const data = (await res.json()) as { results?: HiroTx[] };
+  for (const tx of data.results ?? []) {
     if (tx.nonce === nonce) return tx;
   }
   return null;


### PR DESCRIPTION
## What & why

Part 4 of #398 — the **recovery** piece. #399 (terminalize-on-exhaustion) and #400 (DLQ consumer) stop *new* strands, but they're forward-only: payments already stuck non-terminal at `queued` — and any predating those fixes — stay stuck, and the aibtc.com inbox dedups future sends onto them, **wedging the sender wallet**. This sweep recovers them.

Branches off `main` and is independent (reuses existing exports only) — can merge on its own.

## How

Runs from the existing cron `scheduled()` handler (`*/5 * * * *`). `reconcileStuckPayments()` scans `payment:` records and, for each non-terminal one older than a **5-minute staleness threshold** (so it never races in-flight queue processing), checks the sender's on-chain nonce and resolves:

| On-chain state | Action |
|---|---|
| nonce settled via a **sponsored** tx | `confirmed` (+ write `txid_map`) → aibtc delivers the staged message |
| nonce taken by a **different** (self-paid) tx | `replaced` (superseded) |
| nonce **aborted** on-chain | `failed` (`chain_abort`) |
| nonce **open**, never reached the chain | `failed` + `retryable` → releases inbox dedup |

- **Fail-open** throughout (Hiro/KV errors are logged and retried next cron).
- **Bounded** to 25 actions/run to cap cron time and Hiro API usage.
- **Policy: terminalize-only** for the never-landed case — no blind re-broadcast, so no double-send risk (confirmed with maintainer).

This is what un-wedges the historical strands (e.g. the 4 `pay_…` on `SP20GPDS5…` called out in #397/#399) and the `pay_8890512c` wedge reproduced live in #398.

## Tests

7 cases (mock `fetch` + `MemoryKV`): confirm-via-sponsored, supersede, abort, terminalize-never-landed, leave-in-flight, skip-too-recent, skip-already-terminal. Also implements `MemoryKV.list()` (was an unimplemented stub).

`npm run check` clean; `npm run deploy:dry-run` builds; full suite green except the **pre-existing** `nonce-do-sponsor-status.test.ts` failure from the `@aibtc/tx-schemas` 0.7.0→1.1.0 bump (unrelated; tracked separately).

## Closes out #398

With #399 + #400 + this, #398 is fully addressed: forward paths never strand a payment, and the sweep recovers any that are. Sibling #397 (conflict-path `txid_map` gap) is *also* recovered by this sweep's confirm branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
