### PR TITLE
fix(nonce-do): re-deliver zombie-retired dispatch entries instead of dropping them (#398)

### DIFF
--- a/src/__tests__/nonce-do-zombie-requeue.test.ts
+++ b/src/__tests__/nonce-do-zombie-requeue.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { NonceDO } from "../durable-objects/nonce-do";
+
+/**
+ * #398 Part 3 — the bounded-broadcast zombie guard must RE-DELIVER a still-deliverable
+ * sender tx (via the replay buffer) instead of silently dropping it, while still
+ * dropping txs that already confirmed or have already been replayed once.
+ *
+ * Exercises broadcastBoundedQueueEntries() with a single "zombie" entry
+ * (sponsor_nonce < walletHead) via the prototype-call-with-double pattern.
+ */
+
+interface ZombieEntry {
+  wallet_index: number;
+  payment_id: string | null;
+  sender_tx_hex: string;
+  sender_address: string;
+  sender_nonce: number;
+  sponsor_nonce: number;
+  is_gap_fill: number | null;
+}
+
+function makeDouble(opts: { entry: ZombieEntry; walletHead: number; senderConfirmed: boolean }) {
+  const retireQueuedEntry = vi.fn();
+  const addToReplayBuffer = vi.fn();
+  const isSenderNonceConfirmed = vi.fn(async () => opts.senderConfirmed);
+  const double = {
+    env: { STACKS_NETWORK: "testnet" as const },
+    sql: { exec: () => ({ toArray: () => [opts.entry] }) },
+    ledgerGetWalletHead: () => opts.walletHead,
+    retireQueuedEntry,
+    addToReplayBuffer,
+    isSenderNonceConfirmed,
+    log: () => {},
+  };
+  return { double, retireQueuedEntry, addToReplayBuffer, isSenderNonceConfirmed };
+}
+
+const run = (double: unknown) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (NonceDO as any).prototype.broadcastBoundedQueueEntries.call(double, [{ walletIndex: 0, address: "SP_SPONSOR" }]);
+
+const baseEntry: ZombieEntry = {
+  wallet_index: 0,
+  payment_id: "pay_zombie",
+  sender_tx_hex: "0xdeadbeef",
+  sender_address: "SP_SENDER",
+  sender_nonce: 866,
+  sponsor_nonce: 3881,
+  is_gap_fill: 0,
+};
+
+describe("bounded-broadcast zombie guard re-delivery (#398)", () => {
+  it("re-queues a still-deliverable sender tx to the replay buffer (not dropped)", async () => {
+    const { double, retireQueuedEntry, addToReplayBuffer } = makeDouble({
+      entry: baseEntry,
+      walletHead: 3882, // > sponsor_nonce 3881 → zombie
+      senderConfirmed: false,
+    });
+
+    await run(double);
+
+    // dead sponsor slot retired AND sender tx re-queued for re-sponsoring
+    expect(retireQueuedEntry).toHaveBeenCalledWith(0, 3881, "head_advanced_past_nonce");
+    expect(addToReplayBuffer).toHaveBeenCalledWith(0, "0xdeadbeef", "SP_SENDER", 866, 3881, "pay_zombie");
+  });
+
+  it("does NOT re-queue when the sender nonce already confirmed on-chain", async () => {
+    const { double, retireQueuedEntry, addToReplayBuffer } = makeDouble({
+      entry: baseEntry,
+      walletHead: 3882,
+      senderConfirmed: true,
+    });
+
+    await run(double);
+
+    expect(retireQueuedEntry).toHaveBeenCalledWith(0, 3881, "head_advanced_past_nonce");
+    expect(addToReplayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("does NOT re-queue an entry that is itself a replay (bounds re-delivery to one attempt)", async () => {
+    const { double, retireQueuedEntry, addToReplayBuffer, isSenderNonceConfirmed } = makeDouble({
+      entry: { ...baseEntry, is_gap_fill: 1 },
+      walletHead: 3882,
+      senderConfirmed: false,
+    });
+
+    await run(double);
+
+    expect(retireQueuedEntry).toHaveBeenCalledWith(0, 3881, "head_advanced_past_nonce");
+    expect(addToReplayBuffer).not.toHaveBeenCalled();
+    // short-circuits before the Hiro check for already-replayed entries
+    expect(isSenderNonceConfirmed).not.toHaveBeenCalled();
+  });
+});

--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -1332,6 +1332,22 @@ export class NonceDO {
    * Retire a queued dispatch entry that will never succeed on future broadcast retries.
    * Transitions both dispatch_queue and wallet_hand to 'retired' and releases the ledger slot.
    */
+  /**
+   * Best-effort check: has the sender's nonce already been consumed on-chain?
+   * Used by the zombie-requeue guard (#398) to avoid re-delivering a sender tx that
+   * already landed (a re-send would just be a free BadNonce rejection). Fails toward
+   * re-delivery (returns false) on Hiro error — a re-send of a landed tx is harmless,
+   * but losing a still-deliverable tx is not.
+   */
+  private async isSenderNonceConfirmed(senderAddress: string, senderNonce: number): Promise<boolean> {
+    try {
+      const info = await this.fetchNonceInfo(senderAddress);
+      return info.last_executed_tx_nonce !== null && senderNonce <= info.last_executed_tx_nonce;
+    } catch {
+      return false;
+    }
+  }
+
   private retireQueuedEntry(walletIndex: number, sponsorNonce: number, reason: string): void {
     this.transitionQueueEntry(walletIndex, sponsorNonce, "retired");
     this.sql.exec(
@@ -7865,8 +7881,9 @@ export class NonceDO {
         sender_address: string;
         sender_nonce: number;
         sponsor_nonce: number;
+        is_gap_fill: number | null;
       }>(
-        `SELECT wallet_index, payment_id, sender_tx_hex, sender_address, sender_nonce, sponsor_nonce
+        `SELECT wallet_index, payment_id, sender_tx_hex, sender_address, sender_nonce, sponsor_nonce, is_gap_fill
          FROM dispatch_queue
          WHERE state = 'queued'
          ORDER BY wallet_index ASC, sponsor_nonce ASC
@@ -7894,19 +7911,55 @@ export class NonceDO {
         continue;
       }
 
-      // Zombie guard: if the wallet head has advanced past this entry's sponsor_nonce,
-      // the chain has already consumed that nonce slot (via a successful confirm on a
-      // separate broadcast path, RBF, or external use). Retrying broadcast against an
-      // already-confirmed nonce produces ConflictingNonceInMempool indefinitely and
-      // wastes alarm CPU. Retire and move on.
+      // Zombie guard: the wallet head advanced past this entry's sponsor_nonce, so that
+      // sponsor slot is already consumed on-chain — broadcasting against it would just
+      // produce ConflictingNonceInMempool. Always retire the dead sponsor slot.
+      //
+      // But the SENDER tx may still be unsent and deliverable — dropping it here strands
+      // the payment at "queued" and the message never delivers (#398). So re-queue the
+      // sender tx to the replay buffer to be re-sponsored with a FRESH nonce, which also
+      // advances the payment record so it can reach "confirmed". Guards:
+      //  - skip if the sender nonce already confirmed on-chain (the tx landed some other
+      //    way — a re-send would be a wasted/rejected tx),
+      //  - skip if this entry is itself a replay (is_gap_fill=1) — bounds re-delivery to
+      //    a single attempt and prevents a re-queue loop.
       const walletHead = this.ledgerGetWalletHead(entry.wallet_index);
       if (walletHead !== null && entry.sponsor_nonce < walletHead) {
         this.retireQueuedEntry(entry.wallet_index, entry.sponsor_nonce, "head_advanced_past_nonce");
-        this.log("info", "bounded_broadcast_zombie_retired", {
-          walletIndex: entry.wallet_index,
-          sponsorNonce: entry.sponsor_nonce,
-          walletHead,
-        });
+
+        let skipReason: string | null = null;
+        if (entry.is_gap_fill === 1) {
+          skipReason = "already_replayed_no_requeue";
+        } else if (await this.isSenderNonceConfirmed(entry.sender_address, entry.sender_nonce)) {
+          skipReason = "sender_nonce_already_confirmed";
+        }
+
+        if (skipReason) {
+          this.log("info", "bounded_broadcast_zombie_retired", {
+            walletIndex: entry.wallet_index,
+            sponsorNonce: entry.sponsor_nonce,
+            walletHead,
+            reason: skipReason,
+          });
+        } else {
+          // Re-deliver: re-sponsored with a fresh nonce on the next alarm cycle.
+          this.addToReplayBuffer(
+            entry.wallet_index,
+            entry.sender_tx_hex,
+            entry.sender_address,
+            entry.sender_nonce,
+            entry.sponsor_nonce,
+            entry.payment_id
+          );
+          this.log("info", "bounded_broadcast_zombie_requeued", {
+            walletIndex: entry.wallet_index,
+            sponsorNonce: entry.sponsor_nonce,
+            walletHead,
+            senderAddress: entry.sender_address,
+            senderNonce: entry.sender_nonce,
+            action: "requeued_to_replay_buffer",
+          });
+        }
         continue;
       }
 


### PR DESCRIPTION
## What & why

Part 3 of #398 — and the piece that actually makes stuck messages **deliver** (the others recover/clean up; this one delivers).

**Reproduced live on mainnet.** A fresh inbox message (`pay_84d310c38f…`, sender `SP4DXVEC…` nonce 866) was assigned sponsor nonce 3881, but before the bounded-broadcast sent it, wallet 0's head advanced to 3882. The zombie guard then **dropped** the still-valid sender tx and the payment sat `queued` forever — message never delivered:

```
assign_run_to_wallet         sponsorNonce 3881
bounded_broadcast_zombie_retired   sponsorNonce 3881, walletHead 3882   ← dropped
(never broadcast; sender nonce 866 still open on-chain; message undelivered)
```

The zombie guard was right to retire the dead sponsor slot (broadcasting against a consumed nonce just yields `ConflictingNonceInMempool`), but wrong to throw away the sender tx.

## Change (`broadcastBoundedQueueEntries`)

When `sponsor_nonce < walletHead`: retire the dead slot **and** re-queue the sender tx to the **replay buffer**, which re-sponsors it with a **fresh** nonce on the next alarm and runs `syncPaymentAfterBroadcast` (so the payment record advances to `mempool`→`confirmed` and the message delivers).

**Guards (both requested):**
- **Confirmed-nonce guard** — `isSenderNonceConfirmed(sender, nonce)` via Hiro: skip re-queue if the sender nonce already confirmed on-chain (a re-send would be a wasted/rejected tx). Fails *open* toward re-delivery on Hiro error.
- **Loop bound** — skip re-queue if the entry is itself a replay (`is_gap_fill=1`); caps re-delivery to a single attempt so a repeatedly-racing tx can't loop.

## Fee safety
Only a tx that **confirms** costs gas; retired (pre-broadcast) and rejected (`ConflictingNonce`) attempts cost nothing. The sender nonce can confirm **once**, so even if the old and re-sponsored copies both reach the mempool, only one lands — no double-spend. Net cost = the single legitimate delivery fee.

## Tests
`nonce-do-zombie-requeue.test.ts` (3): re-queues a deliverable tx; skips when sender nonce already confirmed; skips (no Hiro call) when already a replay. `npm run check` clean; full suite green except the pre-existing `nonce-do-sponsor-status.test.ts` failure (the `@aibtc/tx-schemas` 0.7.0→1.1.0 bump — unrelated).

## #398 series
- #399 terminalize-on-exhaustion (merged) · #400 DLQ consumer (merged) · #401 reconcile sweep (recovery, open)
- **This (Part 3)** is the delivery fix — complements the sweep: it re-delivers within ~1 alarm cycle, the sweep only terminalizes anything still stuck after 5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
