### PR TITLE
fix(test): add nonceExpiresAt to checkAndAssignRun toEqual assertion

### DIFF
--- a/src/__tests__/nonce-do-sponsor-status.test.ts
+++ b/src/__tests__/nonce-do-sponsor-status.test.ts
@@ -186,7 +186,7 @@ describe("NonceDO stale sender repair helpers", () => {
       getHand: () => [
         {
           sender_nonce: 7,
-          received_at: "2026-03-31T20:04:00.000Z",
+          received_at: "026-03-31T20:04:00.000Z",
           expires_at: "2026-03-31T20:11:00.000Z",
         },
         {
@@ -458,8 +458,7 @@ describe("NonceDO stale sender repair helpers", () => {
       getSenderState: () => ({
         next_expected_nonce: 3,
         last_refresh_attempt_at: null,
-        last_refresh_failure_at: null,
-      }),
+        last_refresh_failure_at: null,     }),
       getHand: () => [
         {
           sender_nonce: 7,
@@ -521,7 +520,7 @@ describe("NonceDO stale sender repair helpers", () => {
     );
     expect(updated).not.toHaveProperty("holdReason");
     expect(updated).not.toHaveProperty("nextExpectedNonce");
-    expect(updated).not.toHaveProperty("missingNonces");
+    expect(updated).not.toHaveProperty("missingnonces");
     expect(updated).not.toHaveProperty("holdExpiresAt");
     expect(updated).not.toHaveProperty("error");
   });
@@ -554,6 +553,7 @@ describe("NonceDO stale sender repair helpers", () => {
 
     expect(result).toEqual({
       dispatched: true,
+      nonceExpiresAt: expect.any(String),
       sponsorNonce: 44,
       walletIndex: 1,
       sponsorAddress: "",

--- a/src/__tests__/nonce-do-sponsor-status.test.ts
+++ b/src/__tests__/nonce-do-sponsor-status.test.ts
@@ -186,7 +186,7 @@ describe("NonceDO stale sender repair helpers", () => {
       getHand: () => [
         {
           sender_nonce: 7,
-          received_at: "026-03-31T20:04:00.000Z",
+          received_at: "2026-03-31T20:04:00.000Z",
           expires_at: "2026-03-31T20:11:00.000Z",
         },
         {
@@ -458,7 +458,8 @@ describe("NonceDO stale sender repair helpers", () => {
       getSenderState: () => ({
         next_expected_nonce: 3,
         last_refresh_attempt_at: null,
-        last_refresh_failure_at: null,     }),
+        last_refresh_failure_at: null,
+      }),
       getHand: () => [
         {
           sender_nonce: 7,
@@ -520,7 +521,7 @@ describe("NonceDO stale sender repair helpers", () => {
     );
     expect(updated).not.toHaveProperty("holdReason");
     expect(updated).not.toHaveProperty("nextExpectedNonce");
-    expect(updated).not.toHaveProperty("missingnonces");
+    expect(updated).not.toHaveProperty("missingNonces");
     expect(updated).not.toHaveProperty("holdExpiresAt");
     expect(updated).not.toHaveProperty("error");
   });


### PR DESCRIPTION
Fixes #405.

The tx-schemas 1.1.0 bump added `nonceExpiresAt` to the nonce assignment result shape. The failing test used `.toEqual()` with an expected object that did not include this field, causing:

```
AssertionError: expected { dispatched: true, …(4) } to deeply equal { dispatched: true, …(3) }
+ "nonceExpiresAt": "2026-05-25T15:48:21.597Z",
```

**Fix:** Added `nonceExpiresAt: expect.any(String)` to the `.toEqual()` assertion at line 555.

Unrelated to the #398 fix series — this was a pre-existing test gap from the tx-schemas bump noted in that PR series but not addressed there.