### PR TITLE
fix(queue): resolve and verify sender-origin nonce conflicts instead of false sponsor_failure (#397)

### DIFF
--- a/src/__tests__/queue-sender-conflict-resolve.test.ts
+++ b/src/__tests__/queue-sender-conflict-resolve.test.ts
@@ -3,14 +3,15 @@
  *
  * When a payment terminates on a sender-origin nonce conflict, the relay must:
  * 1. Look up the sender's actual on-chain txid by (senderAddress, senderNonce)
- * 2. Verify the on-chain tx satisfies the payment's settle requirements
- * 3. Wire in txid + txid_map on match, "replaced"/superseded on mismatch, fallback on error
- * 4. Never report responsibleParty="sponsor" or terminalReason="sponsor_failure" for sender conflicts
+ * 2. Fetch the raw hex of the resolved on-chain tx from Hiro
+ * 3. Verify the ON-CHAIN tx (not the queued txHex) satisfies the payment's settle requirements
+ * 4. Wire in txid + txid_map + sender bookkeeping on match, "replaced"/superseded on mismatch
+ * 5. Never report responsibleParty="sponsor" or terminalReason="sponsor_failure" for sender conflicts
  *
  * Issue: #397
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createPaymentRecord,
   getPaymentRecord,
@@ -108,6 +109,14 @@ function hiroTxResponse(txs: Array<{ tx_id: string; tx_status: string; nonce: nu
   };
 }
 
+/** Build a minimal Hiro raw-tx API response */
+function hiroRawTxResponse(rawHex: string) {
+  return {
+    ok: true,
+    json: async () => ({ raw_tx: `0x${rawHex}` }),
+  };
+}
+
 const DEFAULT_SETTLE = {
   expectedRecipient: "SP3RECIPIENT000000000000000000000000000",
   minAmount: "1000",
@@ -131,10 +140,15 @@ describe("queue consumer: sender-origin nonce conflict resolve-then-verify (#397
     vi.stubGlobal("fetch", mocks.fetch);
   });
 
+  // Restore global stubs after every test to prevent leak into other test files
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   // -------------------------------------------------------------------------
   // 1. Sender-origin conflict, on-chain tx MATCHES settle requirements
   // -------------------------------------------------------------------------
-  it("wires txid and txid_map when on-chain tx matches settle requirements", async () => {
+  it("wires txid, txid_map, and sender bookkeeping when on-chain tx matches settle requirements", async () => {
     const kv = new MemoryKV();
     const record = transitionPayment(
       createPaymentRecord("pay_resolve_match", "testnet"),
@@ -164,12 +178,13 @@ describe("queue consumer: sender-origin nonce conflict resolve-then-verify (#397
       retryable: false,
     });
 
-    // Hiro lookup returns the confirmed tx
-    mocks.fetch.mockResolvedValue(
-      hiroTxResponse([{ tx_id: "0x6084cc29", tx_status: "success", nonce: 93 }])
-    );
+    // First fetch: Hiro address/transactions lookup returns the confirmed tx
+    // Second fetch: Hiro raw-tx fetch returns the on-chain hex
+    mocks.fetch
+      .mockResolvedValueOnce(hiroTxResponse([{ tx_id: "0x6084cc29", tx_status: "success", nonce: 93 }]))
+      .mockResolvedValueOnce(hiroRawTxResponse("deadbeef1234"));
 
-    // Settle verification passes
+    // Settle verification passes — verifyPaymentParams is called with the RAW on-chain hex
     mocks.verifyPaymentParams.mockReturnValue({
       valid: true,
       data: {
@@ -208,6 +223,18 @@ describe("queue consumer: sender-origin nonce conflict resolve-then-verify (#397
     // txid_map must be written
     const txidMapEntry = await kv.get("txid_map:0x6084cc29");
     expect(txidMapEntry).toBe("pay_resolve_match");
+    // sender_addr_map must be written (bookkeeping for chainhook/confirm-reconcile healer)
+    const senderAddrMap = await kv.get("sender_addr_map:SP3TVW9PM000000000000000000000000000000");
+    expect(senderAddrMap).toBe("signer_resolve");
+    // updateSenderNonceOnBroadcast must have been called
+    expect(mocks.updateSenderNonceOnBroadcast).toHaveBeenCalledWith(
+      kv,
+      "signer_resolve",
+      93,
+      "0x6084cc29"
+    );
+    // verifyPaymentParams must have been called with the on-chain raw hex (stripped of 0x prefix)
+    expect(mocks.verifyPaymentParams).toHaveBeenCalledWith("deadbeef1234", DEFAULT_SETTLE);
     // Message must be acked
     expect(message.ack).toHaveBeenCalledTimes(1);
     expect(message.retry).not.toHaveBeenCalled();
@@ -248,10 +275,11 @@ describe("queue consumer: sender-origin nonce conflict resolve-then-verify (#397
       retryable: false,
     });
 
-    // Hiro lookup returns a confirmed tx
-    mocks.fetch.mockResolvedValue(
-      hiroTxResponse([{ tx_id: "0xwrongtx00", tx_status: "success", nonce: 93 }])
-    );
+    // First fetch: Hiro address/transactions lookup returns a confirmed tx
+    // Second fetch: Hiro raw-tx returns the on-chain hex for the resolved txId
+    mocks.fetch
+      .mockResolvedValueOnce(hiroTxResponse([{ tx_id: "0xwrongtx00", tx_status: "success", nonce: 93 }]))
+      .mockResolvedValueOnce(hiroRawTxResponse("wrongtxhex"));
 
     // Settle verification FAILS — different recipient
     mocks.verifyPaymentParams.mockReturnValue({
@@ -287,6 +315,8 @@ describe("queue consumer: sender-origin nonce conflict resolve-then-verify (#397
     expect(txidMapEntry).toBeNull();
     // record.txid should not be set (the wrong tx should not be wired)
     expect(finalRecord?.txid).toBeUndefined();
+    // No sender bookkeeping for an unverified txid
+    expect(mocks.updateSenderNonceOnBroadcast).not.toHaveBeenCalled();
     expect(message.ack).toHaveBeenCalledTimes(1);
     expect(message.retry).not.toHaveBeenCalled();
     // Never sponsor_failure
@@ -544,6 +574,168 @@ describe("queue consumer: sender-origin nonce conflict resolve-then-verify (#397
     expect(finalRecord?.terminalReason).toBe("sponsor_failure");
     // No Hiro lookup should have been attempted (nonceConflict=false)
     expect(mocks.fetch).not.toHaveBeenCalled();
+    expect(message.ack).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. P1 regression: queued txHex matches settle, but on-chain tx is a DIFFERENT tx
+  //    (wrong recipient) — must NOT write txid_map / set record.txid
+  // -------------------------------------------------------------------------
+  it("does NOT wire txid_map when on-chain tx has wrong recipient (P1 regression guard)", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_p1_regression", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 42;
+    record.senderAddress = "SP3TVWP1REGRESS000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    const originalTx = { auth: { spendingCondition: { signer: "signer_p1" } } };
+    const sponsoredTx = { id: "sponsored_p1_tx" };
+
+    mocks.deserializeTransaction.mockImplementation((hex: string) => {
+      if (hex === "queued_tx_hex") return originalTx;
+      if (hex === "sponsored_p1_hex") return sponsoredTx;
+      throw new Error(`unexpected hex: ${hex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_p1_hex",
+      walletIndex: 0,
+      fee: "1000",
+    });
+    mocks.broadcastOnly.mockResolvedValue({
+      error: "ConflictingNonceInMempool",
+      nonceConflict: true,
+      retryable: false,
+    });
+
+    // Lookup finds a confirmed tx at nonce 42 — but it is a DIFFERENT tx (different sender)
+    mocks.fetch
+      .mockResolvedValueOnce(hiroTxResponse([
+        { tx_id: "0xdifferenttx", tx_status: "success", nonce: 42 },
+      ]))
+      // Raw-tx fetch succeeds but returns the *different* on-chain tx hex
+      .mockResolvedValueOnce(hiroRawTxResponse("different_tx_bytes"));
+
+    // Critically: verifyPaymentParams is called with the ON-CHAIN hex ("different_tx_bytes"),
+    // NOT with the queued "queued_tx_hex". The on-chain tx goes to a WRONG recipient.
+    // If the old code had been used (verifying queued_tx_hex), this mock would have returned
+    // { valid: true } instead — demonstrating the P1 bug.
+    mocks.verifyPaymentParams.mockImplementation((rawHex: string) => {
+      if (rawHex === "different_tx_bytes") {
+        return {
+          valid: false,
+          error: "recipient_mismatch",
+          details: "On-chain tx sends to SP_WRONG_RECIPIENT, expected SP3RECIPIENT000000000000000000000000000",
+        };
+      }
+      // If called with the queued txHex (old buggy behaviour), return valid to expose the bug
+      return { valid: true };
+    });
+
+    const message = createMessage(
+      {
+        paymentId: "pay_p1_regression",
+        txHex: "queued_tx_hex",
+        network: "testnet",
+        attempt: 5,
+        settle: DEFAULT_SETTLE,
+      },
+      5
+    );
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    const finalRecord = await getPaymentRecord(kv, "pay_p1_regression");
+
+    // Must be superseded — the on-chain tx didn't satisfy settle requirements
+    expect(finalRecord?.status).toBe("replaced");
+    expect(finalRecord?.terminalReason).toBe("superseded");
+    // MUST NOT write txid_map for the unverified on-chain txid
+    const txidMapEntry = await kv.get("txid_map:0xdifferenttx");
+    expect(txidMapEntry).toBeNull();
+    // record.txid must NOT be set to the unrelated on-chain txid
+    expect(finalRecord?.txid).toBeUndefined();
+    // No sender bookkeeping for an unverified txid
+    expect(mocks.updateSenderNonceOnBroadcast).not.toHaveBeenCalled();
+    // Confirm verifyPaymentParams was called with the on-chain hex (not the queued txHex)
+    expect(mocks.verifyPaymentParams).toHaveBeenCalledWith("different_tx_bytes", DEFAULT_SETTLE);
+    expect(mocks.verifyPaymentParams).not.toHaveBeenCalledWith("queued_tx_hex", DEFAULT_SETTLE);
+    expect(message.ack).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. Raw-tx fetch fails (timeout or HTTP error) — fail safe, fall back to
+  //    sender_nonce_duplicate (do NOT write txid_map for unverified txid)
+  // -------------------------------------------------------------------------
+  it("falls back to sender_nonce_duplicate when raw-tx fetch fails", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_rawfetch_fail", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 77;
+    record.senderAddress = "SP3TVWRAWFAIL00000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    mocks.deserializeTransaction.mockImplementation((hex: string) => {
+      if (hex === "rawfail_tx") return { auth: { spendingCondition: { signer: "signer_rawfail" } } };
+      if (hex === "sponsored_rawfail") return { id: "sponsored_rawfail" };
+      throw new Error(`unexpected hex: ${hex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_rawfail",
+      walletIndex: 0,
+      fee: "1000",
+    });
+    mocks.broadcastOnly.mockResolvedValue({
+      error: "ConflictingNonceInMempool",
+      nonceConflict: true,
+      retryable: false,
+    });
+
+    // First fetch (address/transactions lookup) succeeds — finds a confirmed tx at nonce 77
+    // Second fetch (raw-tx) fails — simulates Hiro timeout or 500
+    mocks.fetch
+      .mockResolvedValueOnce(hiroTxResponse([{ tx_id: "0xconfirmedtx", tx_status: "success", nonce: 77 }]))
+      .mockRejectedValueOnce(new Error("Hiro raw-tx endpoint timed out"));
+
+    const message = createMessage(
+      {
+        paymentId: "pay_rawfetch_fail",
+        txHex: "rawfail_tx",
+        network: "testnet",
+        attempt: 5,
+        settle: DEFAULT_SETTLE,
+      },
+      5
+    );
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    const finalRecord = await getPaymentRecord(kv, "pay_rawfetch_fail");
+
+    // Fail safe: must NOT write txid_map for an unverified txid
+    expect(await kv.get("txid_map:0xconfirmedtx")).toBeNull();
+    expect(finalRecord?.txid).toBeUndefined();
+    // Must fall back to sender_nonce_duplicate (can't verify, so don't claim it resolved)
+    expect(finalRecord?.status).toBe("failed");
+    expect(finalRecord?.terminalReason).toBe("sender_nonce_duplicate");
+    // No sender bookkeeping for an unverified txid
+    expect(mocks.updateSenderNonceOnBroadcast).not.toHaveBeenCalled();
+    // verifyPaymentParams must NOT be called (raw hex was unavailable)
+    expect(mocks.verifyPaymentParams).not.toHaveBeenCalled();
     expect(message.ack).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/queue-sender-conflict-resolve.test.ts
+++ b/src/__tests__/queue-sender-conflict-resolve.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Tests for Mode A fix: sender-origin ConflictingNonceInMempool resolve-then-verify path.
+ *
+ * When a payment terminates on a sender-origin nonce conflict, the relay must:
+ * 1. Look up the sender's actual on-chain txid by (senderAddress, senderNonce)
+ * 2. Verify the on-chain tx satisfies the payment's settle requirements
+ * 3. Wire in txid + txid_map on match, "replaced"/superseded on mismatch, fallback on error
+ * 4. Never report responsibleParty="sponsor" or terminalReason="sponsor_failure" for sender conflicts
+ *
+ * Issue: #397
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPaymentRecord,
+  getPaymentRecord,
+  putPaymentRecord,
+  transitionPayment,
+} from "../services/payment-status";
+import { handlePaymentQueue } from "../queue-consumer";
+import { MemoryKV } from "./helpers/memory-kv";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  deserializeTransaction: vi.fn(),
+  sponsorTransaction: vi.fn(),
+  broadcastOnly: vi.fn(),
+  verifyPaymentParams: vi.fn(),
+  clearInFlight: vi.fn(),
+  updateSenderNonceOnBroadcast: vi.fn(),
+  extractSponsorNonce: vi.fn(),
+  releaseNonceDO: vi.fn(),
+  nonceLifecycleOnBroadcastSuccess: vi.fn(),
+  repairSenderWedgeDO: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock("@stacks/transactions", () => ({
+  deserializeTransaction: mocks.deserializeTransaction,
+}));
+
+vi.mock("../services/sender-nonce", () => ({
+  clearInFlight: mocks.clearInFlight,
+  updateSenderNonceOnBroadcast: mocks.updateSenderNonceOnBroadcast,
+}));
+
+vi.mock("../services", async () => {
+  const actual = await vi.importActual("../services");
+  return {
+    ...actual,
+    SponsorService: class {
+      async sponsorTransaction(transaction: unknown) {
+        return mocks.sponsorTransaction(transaction);
+      }
+    },
+    SettlementService: class {
+      async broadcastOnly(transaction: unknown) {
+        return mocks.broadcastOnly(transaction);
+      }
+      verifyPaymentParams(txHex: unknown, settle: unknown) {
+        return mocks.verifyPaymentParams(txHex, settle);
+      }
+    },
+    extractSponsorNonce: mocks.extractSponsorNonce,
+    releaseNonceDO: mocks.releaseNonceDO,
+    nonceLifecycleOnBroadcastSuccess: mocks.nonceLifecycleOnBroadcastSuccess,
+    repairSenderWedgeDO: mocks.repairSenderWedgeDO,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const executionContext = {
+  waitUntil: (_promise: Promise<unknown>) => {},
+} as ExecutionContext;
+
+type TestMessageBody = {
+  paymentId: string;
+  txHex: string;
+  network: "mainnet" | "testnet";
+  attempt: number;
+  settle?: {
+    expectedRecipient: string;
+    minAmount: string;
+    tokenType?: string;
+  };
+};
+
+function createMessage(body: TestMessageBody, attempts = 1) {
+  return {
+    body,
+    attempts,
+    ack: vi.fn(),
+    retry: vi.fn(),
+  } as unknown as Message<TestMessageBody>;
+}
+
+/** Build a minimal Hiro address/transactions API response */
+function hiroTxResponse(txs: Array<{ tx_id: string; tx_status: string; nonce: number }>) {
+  return {
+    ok: true,
+    json: async () => ({ results: txs }),
+  };
+}
+
+const DEFAULT_SETTLE = {
+  expectedRecipient: "SP3RECIPIENT000000000000000000000000000",
+  minAmount: "1000",
+  tokenType: "STX" as const,
+};
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+describe("queue consumer: sender-origin nonce conflict resolve-then-verify (#397)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.extractSponsorNonce.mockReturnValue(55);
+    mocks.clearInFlight.mockResolvedValue(undefined);
+    mocks.updateSenderNonceOnBroadcast.mockResolvedValue(undefined);
+    mocks.releaseNonceDO.mockResolvedValue(undefined);
+    mocks.nonceLifecycleOnBroadcastSuccess.mockResolvedValue(undefined);
+    mocks.repairSenderWedgeDO.mockResolvedValue(null);
+    // Replace global fetch with the vitest mock
+    vi.stubGlobal("fetch", mocks.fetch);
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Sender-origin conflict, on-chain tx MATCHES settle requirements
+  // -------------------------------------------------------------------------
+  it("wires txid and txid_map when on-chain tx matches settle requirements", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_resolve_match", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 93;
+    record.senderAddress = "SP3TVW9PM000000000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    const originalTx = { auth: { spendingCondition: { signer: "signer_resolve" } } };
+    const sponsoredTx = { id: "sponsored_resolve_tx" };
+
+    mocks.deserializeTransaction.mockImplementation((hex: string) => {
+      if (hex === "sender_tx") return originalTx;
+      if (hex === "sponsored_hex") return sponsoredTx;
+      throw new Error(`unexpected hex: ${hex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_hex",
+      walletIndex: 0,
+      fee: "1000",
+    });
+    mocks.broadcastOnly.mockResolvedValue({
+      error: "ConflictingNonceInMempool",
+      nonceConflict: true,
+      retryable: false,
+    });
+
+    // Hiro lookup returns the confirmed tx
+    mocks.fetch.mockResolvedValue(
+      hiroTxResponse([{ tx_id: "0x6084cc29", tx_status: "success", nonce: 93 }])
+    );
+
+    // Settle verification passes
+    mocks.verifyPaymentParams.mockReturnValue({
+      valid: true,
+      data: {
+        sender: "signer_resolve",
+        recipient: DEFAULT_SETTLE.expectedRecipient,
+        amount: "1000",
+        tokenType: "STX",
+      },
+    });
+
+    const message = createMessage(
+      {
+        paymentId: "pay_resolve_match",
+        txHex: "sender_tx",
+        network: "testnet",
+        attempt: 5,
+        settle: DEFAULT_SETTLE,
+      },
+      5 // attempts = MAX_ATTEMPTS → terminal path
+    );
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    const finalRecord = await getPaymentRecord(kv, "pay_resolve_match");
+
+    // Record must NOT be terminalized as failed
+    expect(finalRecord?.status).not.toBe("failed");
+    // Record must have the resolved txid
+    expect(finalRecord?.txid).toBe("0x6084cc29");
+    // Record must be in mempool (for healers)
+    expect(finalRecord?.status).toBe("mempool");
+    // txid_map must be written
+    const txidMapEntry = await kv.get("txid_map:0x6084cc29");
+    expect(txidMapEntry).toBe("pay_resolve_match");
+    // Message must be acked
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+    // Never terminalReason=sponsor_failure
+    expect(finalRecord?.terminalReason).not.toBe("sponsor_failure");
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Sender-origin conflict, on-chain tx MISMATCHES settle requirements
+  // -------------------------------------------------------------------------
+  it("marks superseded when on-chain tx does not satisfy settle requirements", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_mismatch", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 93;
+    record.senderAddress = "SP3TVWMISMATCH0000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    const originalTx = { auth: { spendingCondition: { signer: "signer_mismatch" } } };
+    const sponsoredTx = { id: "sponsored_mismatch_tx" };
+
+    mocks.deserializeTransaction.mockImplementation((hex: string) => {
+      if (hex === "mismatch_tx") return originalTx;
+      if (hex === "sponsored_mismatch") return sponsoredTx;
+      throw new Error(`unexpected hex: ${hex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_mismatch",
+      walletIndex: 1,
+      fee: "1000",
+    });
+    mocks.broadcastOnly.mockResolvedValue({
+      error: "ConflictingNonceInMempool",
+      nonceConflict: true,
+      retryable: false,
+    });
+
+    // Hiro lookup returns a confirmed tx
+    mocks.fetch.mockResolvedValue(
+      hiroTxResponse([{ tx_id: "0xwrongtx00", tx_status: "success", nonce: 93 }])
+    );
+
+    // Settle verification FAILS — different recipient
+    mocks.verifyPaymentParams.mockReturnValue({
+      valid: false,
+      error: "recipient_mismatch",
+      details: "Transaction sends to SP_WRONG, expected SP3RECIPIENT000000000000000000000000000",
+    });
+
+    const message = createMessage(
+      {
+        paymentId: "pay_mismatch",
+        txHex: "mismatch_tx",
+        network: "testnet",
+        attempt: 5,
+        settle: DEFAULT_SETTLE,
+      },
+      5
+    );
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    const finalRecord = await getPaymentRecord(kv, "pay_mismatch");
+
+    // Must be replaced/superseded — not failed/sponsor_failure
+    expect(finalRecord?.status).toBe("replaced");
+    expect(finalRecord?.terminalReason).toBe("superseded");
+    // No txid_map written for the wrong txid
+    const txidMapEntry = await kv.get("txid_map:0xwrongtx00");
+    expect(txidMapEntry).toBeNull();
+    // record.txid should not be set (the wrong tx should not be wired)
+    expect(finalRecord?.txid).toBeUndefined();
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+    // Never sponsor_failure
+    expect(finalRecord?.terminalReason).not.toBe("sponsor_failure");
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Hiro lookup fails (fetch throws)
+  // -------------------------------------------------------------------------
+  it("falls back to sender_nonce_duplicate when Hiro lookup throws", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_lookup_fail", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 93;
+    record.senderAddress = "SP3TVWFAIL000000000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    mocks.deserializeTransaction.mockImplementation((hex: string) => {
+      if (hex === "fail_tx") return { auth: { spendingCondition: { signer: "signer_fail" } } };
+      if (hex === "sponsored_fail") return { id: "sponsored" };
+      throw new Error(`unexpected: ${hex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_fail",
+      walletIndex: 0,
+      fee: "1000",
+    });
+    mocks.broadcastOnly.mockResolvedValue({
+      error: "ConflictingNonceInMempool",
+      nonceConflict: true,
+      retryable: false,
+    });
+
+    // Hiro lookup throws (network error)
+    mocks.fetch.mockRejectedValue(new Error("Network failure"));
+
+    const message = createMessage(
+      {
+        paymentId: "pay_lookup_fail",
+        txHex: "fail_tx",
+        network: "testnet",
+        attempt: 5,
+        settle: DEFAULT_SETTLE,
+      },
+      5
+    );
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    const finalRecord = await getPaymentRecord(kv, "pay_lookup_fail");
+
+    expect(finalRecord?.status).toBe("failed");
+    expect(finalRecord?.terminalReason).toBe("sender_nonce_duplicate");
+    // No spurious txid
+    expect(finalRecord?.txid).toBeUndefined();
+    // No txid_map written
+    expect(await kv.get("txid_map:anything")).toBeNull();
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    // Never sponsor_failure
+    expect(finalRecord?.terminalReason).not.toBe("sponsor_failure");
+    // Never responsibleParty=sponsor (check no spurious txid written)
+    expect(finalRecord?.terminalReason).not.toBe("sponsor_failure");
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Hiro returns valid JSON but nonce not in results
+  // -------------------------------------------------------------------------
+  it("falls back to sender_nonce_duplicate when nonce is not in Hiro results", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_not_found", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 93;
+    record.senderAddress = "SP3TVWNOTFOUND00000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    mocks.deserializeTransaction.mockImplementation((hex: string) => {
+      if (hex === "notfound_tx") return { auth: { spendingCondition: { signer: "signer_notfound" } } };
+      if (hex === "sponsored_notfound") return { id: "sponsored" };
+      throw new Error(`unexpected: ${hex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_notfound",
+      walletIndex: 0,
+      fee: "1000",
+    });
+    mocks.broadcastOnly.mockResolvedValue({
+      error: "ConflictingNonceInMempool",
+      nonceConflict: true,
+      retryable: false,
+    });
+
+    // Hiro returns results but nonce 93 is not there
+    mocks.fetch.mockResolvedValue(
+      hiroTxResponse([
+        { tx_id: "0xother", tx_status: "success", nonce: 90 },
+        { tx_id: "0xother2", tx_status: "success", nonce: 91 },
+      ])
+    );
+
+    const message = createMessage(
+      {
+        paymentId: "pay_not_found",
+        txHex: "notfound_tx",
+        network: "testnet",
+        attempt: 5,
+        settle: DEFAULT_SETTLE,
+      },
+      5
+    );
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    const finalRecord = await getPaymentRecord(kv, "pay_not_found");
+
+    expect(finalRecord?.status).toBe("failed");
+    expect(finalRecord?.terminalReason).toBe("sender_nonce_duplicate");
+    expect(finalRecord?.txid).toBeUndefined();
+    expect(finalRecord?.terminalReason).not.toBe("sponsor_failure");
+    expect(message.ack).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Attribution: sender-origin conflict RETRY never reports responsibleParty=sponsor
+  // -------------------------------------------------------------------------
+  it("emits responsibleParty=sender for retryable sender-origin nonce conflict", async () => {
+    const kv = new MemoryKV();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const record = transitionPayment(
+      createPaymentRecord("pay_attr", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 93;
+    record.senderAddress = "SP3TVWATTR000000000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    mocks.deserializeTransaction.mockImplementation((hex: string) => {
+      if (hex === "attr_tx") return { auth: { spendingCondition: { signer: "signer_attr" } } };
+      if (hex === "sponsored_attr") return { id: "sponsored_attr" };
+      throw new Error(`unexpected: ${hex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_attr",
+      walletIndex: 0,
+      fee: "1000",
+    });
+    mocks.broadcastOnly.mockResolvedValue({
+      error: "ConflictingNonceInMempool",
+      nonceConflict: true,
+      retryable: true,
+    });
+
+    // attempt=1 < MAX_ATTEMPTS (5) → retry path, not terminal
+    const message = createMessage(
+      {
+        paymentId: "pay_attr",
+        txHex: "attr_tx",
+        network: "testnet",
+        attempt: 1,
+        settle: DEFAULT_SETTLE,
+      },
+      1
+    );
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    // Should have retried, not acked
+    expect(message.retry).toHaveBeenCalledTimes(1);
+    expect(message.ack).not.toHaveBeenCalled();
+
+    // The lifecycle event must carry responsibleParty="sender".
+    // emitPaymentLifecycleEvent serializes the field as "responsibleParty" in the log object.
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[WARN] payment.retry_decision",
+      expect.objectContaining({
+        action: "queue_retry_nonce_conflict",
+        responsibleParty: "sender",
+      })
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Regression: genuine sponsor-side TooMuchChaining still terminalizes as sponsor_failure
+  // -------------------------------------------------------------------------
+  it("still terminalizes sponsor-side TooMuchChaining as sponsor_failure (regression guard)", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_sponsor_chaining", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 5;
+    record.senderAddress = "SP3TVWSPONSOR000000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    mocks.deserializeTransaction.mockImplementation((hex: string) => {
+      if (hex === "sponsor_tx") return { auth: { spendingCondition: { signer: "signer_sponsor" } } };
+      if (hex === "sponsored_sponsor") return { id: "sponsored_sponsor" };
+      throw new Error(`unexpected: ${hex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_sponsor",
+      walletIndex: 2,
+      fee: "2000",
+    });
+    // TooMuchChaining is sponsor-side (isTooMuchChaining=true, isNonceConflict=false)
+    mocks.broadcastOnly.mockResolvedValue({
+      error: "TooMuchChaining",
+      tooMuchChaining: true,
+      isOriginChaining: false,
+      retryable: false,
+    });
+
+    const message = createMessage(
+      {
+        paymentId: "pay_sponsor_chaining",
+        txHex: "sponsor_tx",
+        network: "testnet",
+        attempt: 5,
+        settle: DEFAULT_SETTLE,
+      },
+      5
+    );
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    const finalRecord = await getPaymentRecord(kv, "pay_sponsor_chaining");
+
+    // Sponsor-side TooMuchChaining must still be sponsor_failure
+    expect(finalRecord?.status).toBe("failed");
+    expect(finalRecord?.terminalReason).toBe("sponsor_failure");
+    // No Hiro lookup should have been attempted (nonceConflict=false)
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    expect(message.ack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -21,7 +21,7 @@
 
 import { deserializeTransaction } from "@stacks/transactions";
 import type { Env, Logger } from "./types";
-import { createWorkerLogger, emitPaymentLifecycleEvent } from "./utils";
+import { createWorkerLogger, emitPaymentLifecycleEvent, getHiroBaseUrl, getHiroHeaders } from "./utils";
 import {
   getPaymentRecord,
   putPaymentRecord,
@@ -49,6 +49,43 @@ const TRANSIENT_ERROR_FIELDS: Partial<PaymentRecord> = {
   errorCode: undefined,
   retryable: undefined,
 };
+
+/**
+ * Resolve the on-chain transaction for a sender address at a specific nonce.
+ *
+ * Queries Hiro GET /extended/v1/address/{sender}/transactions?limit=50 and finds
+ * the entry whose nonce matches senderNonce. Used to recover the real txid when a
+ * payment is terminated due to a sender-origin ConflictingNonceInMempool — the
+ * sender's own in-flight tx occupied the nonce before the relay could sponsor a new one.
+ *
+ * Never throws — returns null on any error or when no match is found.
+ *
+ * @param env - Worker env (for STACKS_NETWORK and optional HIRO_API_KEY)
+ * @param senderAddress - Stacks sender address (SP... / ST...)
+ * @param senderNonce - The nonce to look up
+ * @returns { txId, txStatus } if a matching tx is found, null otherwise
+ */
+async function lookupTxByAddressNonce(
+  env: Env,
+  senderAddress: string,
+  senderNonce: number
+): Promise<{ txId: string; txStatus: string } | null> {
+  try {
+    const base = getHiroBaseUrl(env.STACKS_NETWORK ?? "testnet");
+    const headers = getHiroHeaders(env.HIRO_API_KEY);
+    const url = `${base}/extended/v1/address/${senderAddress}/transactions?limit=50`;
+    const response = await fetch(url, { headers });
+    if (!response.ok) return null;
+    const json = await response.json() as { results?: Array<{ tx_id: string; tx_status: string; nonce: number }> };
+    const results = json?.results;
+    if (!Array.isArray(results)) return null;
+    const match = results.find((tx) => tx.nonce === senderNonce);
+    if (!match) return null;
+    return { txId: match.tx_id, txStatus: match.tx_status };
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Process a single payment queue message.
@@ -336,8 +373,10 @@ async function processPaymentMessage(
       }
 
       // #328: attribute contention to the responsible wallet so operators
-      // can tell sender-side congestion (origin chaining) from sponsor-side
-      // contention (nonce conflicts, sponsor-pool chaining limits).
+      // can tell sender-side congestion (origin chaining / nonce conflicts) from
+      // sponsor-side contention (chaining limits on sponsor wallets).
+      // ConflictingNonceInMempool (isNonceConflict) is sender-origin: the sender's
+      // own in-flight tx already occupied the nonce before the relay could sponsor.
       emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
         route: "PAYMENT_QUEUE",
         paymentId,
@@ -350,7 +389,7 @@ async function processPaymentMessage(
         checkStatusUrlPresent: false,
         compatShimUsed: false,
         attempt,
-        responsibleParty: isOriginChaining ? "sender" : "sponsor",
+        responsibleParty: (isOriginChaining || isNonceConflict) ? "sender" : "sponsor",
       }, "warn");
       logger.warn("Broadcast contention, retrying via queue", {
         paymentId,
@@ -388,6 +427,132 @@ async function processPaymentMessage(
       );
     }
 
+    // Sender-origin nonce conflict: the sender's own in-flight tx already occupied
+    // the nonce before the relay could sponsor this payment. Resolve the actual
+    // on-chain txid and verify settle requirements so healers can finalize the record
+    // rather than leaving it falsely reported as sponsor_failure. (#397)
+    if (isNonceConflict && record.senderAddress && record.senderNonce !== undefined) {
+      const resolved = await lookupTxByAddressNonce(env, record.senderAddress, record.senderNonce);
+      const settle = message.body.settle;
+
+      if (resolved) {
+        if (resolved.txStatus === "success" && settle) {
+          // Verify the on-chain tx satisfies this payment's settle requirements.
+          // We use the original sender txHex because ConflictingNonceInMempool means
+          // the sender's own tx (same nonce, same content) was already in the mempool
+          // — so the tx hex IS what went on-chain.
+          const settlementService = new SettlementService(env, logger);
+          const verifyResult = settlementService.verifyPaymentParams(txHex, settle);
+          if (verifyResult.valid) {
+            // Settle requirements matched: wire in the txid so healers can confirm.
+            // Transition to mempool — do NOT mark confirmed directly.
+            record = transitionPayment(record, "mempool", { txid: resolved.txId });
+            await putPaymentRecord(kv, record);
+            await kv
+              .put(`txid_map:${resolved.txId}`, paymentId, { expirationTtl: 86_400 })
+              .catch((e) => logger.warn("Failed to write txid mapping on sender conflict resolve", { error: String(e) }));
+            emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
+              route: "PAYMENT_QUEUE",
+              paymentId,
+              status: record.status,
+              action: "sender_conflict_resolved_txid",
+              checkStatusUrlPresent: false,
+              compatShimUsed: false,
+              attempt,
+              txid: resolved.txId,
+              responsibleParty: "sender",
+            });
+            logger.info("Sender-origin nonce conflict resolved: txid wired for healers", {
+              paymentId,
+              txid: resolved.txId,
+              senderAddress: record.senderAddress,
+              senderNonce: record.senderNonce,
+            });
+            message.ack();
+            return;
+          } else {
+            // Tx on-chain but settle requirements don't match — a different tx took this nonce.
+            record = transitionPayment(record, "replaced", {
+              error: verifyResult.details ?? verifyResult.error ?? "On-chain tx does not satisfy settle requirements",
+              terminalReason: "superseded",
+              retryable: false,
+            });
+            await putPaymentRecord(kv, record);
+            emitPaymentLifecycleEvent(logger, "payment.finalized", {
+              route: "PAYMENT_QUEUE",
+              paymentId,
+              status: record.status,
+              terminalReason: record.terminalReason,
+              action: "sender_conflict_superseded",
+              checkStatusUrlPresent: false,
+              compatShimUsed: false,
+              attempt,
+              responsibleParty: "sender",
+            }, "warn");
+            logger.warn("Sender-origin nonce conflict: on-chain tx does not satisfy settle requirements", {
+              paymentId,
+              resolvedTxId: resolved.txId,
+              senderAddress: record.senderAddress,
+              senderNonce: record.senderNonce,
+              verifyError: verifyResult.error,
+            });
+            message.ack();
+            return;
+          }
+        } else if (resolved.txStatus !== "success") {
+          // Tx is in mempool/pending — wire in txid without settle verification.
+          // Leave for healers to finalize on confirmation.
+          record = transitionPayment(record, "mempool", { txid: resolved.txId });
+          await putPaymentRecord(kv, record);
+          await kv
+            .put(`txid_map:${resolved.txId}`, paymentId, { expirationTtl: 86_400 })
+            .catch((e) => logger.warn("Failed to write txid mapping on sender conflict pending", { error: String(e) }));
+          emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
+            route: "PAYMENT_QUEUE",
+            paymentId,
+            status: record.status,
+            action: "sender_conflict_resolved_txid_pending",
+            checkStatusUrlPresent: false,
+            compatShimUsed: false,
+            attempt,
+            txid: resolved.txId,
+            responsibleParty: "sender",
+          });
+          logger.info("Sender-origin nonce conflict: in-flight txid wired, awaiting healer confirmation", {
+            paymentId,
+            txid: resolved.txId,
+            txStatus: resolved.txStatus,
+            senderAddress: record.senderAddress,
+            senderNonce: record.senderNonce,
+          });
+          message.ack();
+          return;
+        }
+        // resolved exists but txStatus=success with no settle — fall through to sender_nonce_duplicate
+      }
+      // Lookup returned null or unresolvable — fall through to sender_nonce_duplicate
+      record = transitionPayment(record, "failed", {
+        error: broadcastResult.error,
+        errorCode: "SENDER_NONCE_CONFLICT",
+        terminalReason: "sender_nonce_duplicate",
+        retryable: false,
+      });
+      await putPaymentRecord(kv, record);
+      emitPaymentLifecycleEvent(logger, "payment.finalized", {
+        route: "PAYMENT_QUEUE",
+        paymentId,
+        status: record.status,
+        terminalReason: record.terminalReason,
+        action: "sender_conflict_unresolvable",
+        checkStatusUrlPresent: false,
+        compatShimUsed: false,
+        attempt,
+        responsibleParty: "sender",
+      }, "warn");
+      message.ack();
+      return;
+    }
+
     record = transitionPayment(record, "failed", {
       error: broadcastResult.error,
       errorCode: broadcastResult.clientRejection
@@ -395,7 +560,7 @@ async function processPaymentMessage(
         : "BROADCAST_FAILED",
       terminalReason: isOriginChaining
         ? "origin_chaining_limit"
-        : (isTooMuchChaining || isNonceConflict)
+        : isTooMuchChaining
           ? "sponsor_failure"
           : "broadcast_failure",
       retryable: broadcastResult.retryable,

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -43,6 +43,10 @@ import {
 /** Max retries before dead-lettering */
 const MAX_ATTEMPTS = 5;
 
+/** Timeout for Hiro address/transactions lookup and raw-tx fetch (ms).
+ *  Mirrors seedSenderNonceFromHiro's HIRO_NONCE_SEED_TIMEOUT_MS value. */
+const HIRO_LOOKUP_TIMEOUT_MS = 8_000;
+
 /** Fields set during retryable contention — cleared on next attempt */
 const TRANSIENT_ERROR_FIELDS: Partial<PaymentRecord> = {
   error: undefined,
@@ -70,11 +74,13 @@ async function lookupTxByAddressNonce(
   senderAddress: string,
   senderNonce: number
 ): Promise<{ txId: string; txStatus: string } | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), HIRO_LOOKUP_TIMEOUT_MS);
   try {
     const base = getHiroBaseUrl(env.STACKS_NETWORK ?? "testnet");
     const headers = getHiroHeaders(env.HIRO_API_KEY);
     const url = `${base}/extended/v1/address/${senderAddress}/transactions?limit=50`;
-    const response = await fetch(url, { headers });
+    const response = await fetch(url, { headers, signal: controller.signal });
     if (!response.ok) return null;
     const json = await response.json() as { results?: Array<{ tx_id: string; tx_status: string; nonce: number }> };
     const results = json?.results;
@@ -84,6 +90,39 @@ async function lookupTxByAddressNonce(
     return { txId: match.tx_id, txStatus: match.tx_status };
   } catch {
     return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Fetch the raw hex of an on-chain transaction from Hiro.
+ *
+ * Uses GET /extended/v1/tx/{txId}/raw which returns { raw_tx: "0x..." }.
+ * Returns the raw hex string (with or without the leading "0x") on success,
+ * null on any error or timeout. Applies the same AbortController timeout as
+ * lookupTxByAddressNonce so a slow Hiro response cannot stall the queue consumer.
+ *
+ * Fail-safe: never throws.
+ */
+async function fetchOnChainRawTx(env: Env, txId: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), HIRO_LOOKUP_TIMEOUT_MS);
+  try {
+    const base = getHiroBaseUrl(env.STACKS_NETWORK ?? "testnet");
+    const headers = getHiroHeaders(env.HIRO_API_KEY);
+    const url = `${base}/extended/v1/tx/${txId}/raw`;
+    const response = await fetch(url, { headers, signal: controller.signal });
+    if (!response.ok) return null;
+    const json = await response.json() as { raw_tx?: string };
+    const rawTx = json?.raw_tx;
+    if (typeof rawTx !== "string" || rawTx.length === 0) return null;
+    // Hiro returns "0x<hex>" — strip the prefix so verifyPaymentParams gets bare hex
+    return rawTx.startsWith("0x") ? rawTx.slice(2) : rawTx;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -437,67 +476,102 @@ async function processPaymentMessage(
 
       if (resolved) {
         if (resolved.txStatus === "success" && settle) {
-          // Verify the on-chain tx satisfies this payment's settle requirements.
-          // We use the original sender txHex because ConflictingNonceInMempool means
-          // the sender's own tx (same nonce, same content) was already in the mempool
-          // — so the tx hex IS what went on-chain.
-          const settlementService = new SettlementService(env, logger);
-          const verifyResult = settlementService.verifyPaymentParams(txHex, settle);
-          if (verifyResult.valid) {
-            // Settle requirements matched: wire in the txid so healers can confirm.
-            // Transition to mempool — do NOT mark confirmed directly.
-            record = transitionPayment(record, "mempool", { txid: resolved.txId });
-            await putPaymentRecord(kv, record);
-            await kv
-              .put(`txid_map:${resolved.txId}`, paymentId, { expirationTtl: 86_400 })
-              .catch((e) => logger.warn("Failed to write txid mapping on sender conflict resolve", { error: String(e) }));
-            emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
-              route: "PAYMENT_QUEUE",
-              paymentId,
-              status: record.status,
-              action: "sender_conflict_resolved_txid",
-              checkStatusUrlPresent: false,
-              compatShimUsed: false,
-              attempt,
-              txid: resolved.txId,
-              responsibleParty: "sender",
-            });
-            logger.info("Sender-origin nonce conflict resolved: txid wired for healers", {
-              paymentId,
-              txid: resolved.txId,
-              senderAddress: record.senderAddress,
-              senderNonce: record.senderNonce,
-            });
-            message.ack();
-            return;
-          } else {
-            // Tx on-chain but settle requirements don't match — a different tx took this nonce.
-            record = transitionPayment(record, "replaced", {
-              error: verifyResult.details ?? verifyResult.error ?? "On-chain tx does not satisfy settle requirements",
-              terminalReason: "superseded",
-              retryable: false,
-            });
-            await putPaymentRecord(kv, record);
-            emitPaymentLifecycleEvent(logger, "payment.finalized", {
-              route: "PAYMENT_QUEUE",
-              paymentId,
-              status: record.status,
-              terminalReason: record.terminalReason,
-              action: "sender_conflict_superseded",
-              checkStatusUrlPresent: false,
-              compatShimUsed: false,
-              attempt,
-              responsibleParty: "sender",
-            }, "warn");
-            logger.warn("Sender-origin nonce conflict: on-chain tx does not satisfy settle requirements", {
+          // P1: Verify the ACTUAL on-chain tx (not the queued txHex) satisfies settle
+          // requirements. A different sender tx could have taken the nonce — verifying
+          // our queued txHex would pass even though resolved.txId points to an unrelated
+          // tx with a different recipient/amount/token.
+          //
+          // Fetch the raw on-chain tx hex via Hiro GET /extended/v1/tx/{txId}/raw and
+          // run verifyPaymentParams against it. On fetch failure or timeout: fail safe —
+          // do NOT write txid_map for an unverified txid; fall through to the
+          // not-resolvable / sender_nonce_duplicate path.
+          const onChainRawHex = await fetchOnChainRawTx(env, resolved.txId);
+          if (onChainRawHex === null) {
+            // Hiro raw-tx fetch failed or timed out — cannot verify; fall through to sender_nonce_duplicate.
+            logger.warn("Sender-origin nonce conflict: raw-tx fetch failed, cannot verify on-chain tx", {
               paymentId,
               resolvedTxId: resolved.txId,
               senderAddress: record.senderAddress,
               senderNonce: record.senderNonce,
-              verifyError: verifyResult.error,
             });
-            message.ack();
-            return;
+          } else {
+            // Reuse the SettlementService instance that was already created for broadcastOnly above.
+            const verifyResult = settlementService.verifyPaymentParams(onChainRawHex, settle);
+            if (verifyResult.valid) {
+              // On-chain tx satisfies settle requirements. Wire in the txid so healers can confirm.
+              // Mirror the normal broadcast-success bookkeeping so chainhook/confirm-reconcile
+              // can finalize the record and keep the sender nonce cache current:
+              //   1. Update sender nonce cache (lastSeen)
+              //   2. Write sender_addr_map so the chainhook healer can look up signerHash
+              //   3. Write txid_map so chainhook can find the paymentId
+              // Transition to mempool — do NOT mark confirmed directly.
+              record = transitionPayment(record, "mempool", { txid: resolved.txId });
+              await putPaymentRecord(kv, record);
+              await kv
+                .put(`txid_map:${resolved.txId}`, paymentId, { expirationTtl: 86_400 })
+                .catch((e) => logger.warn("Failed to write txid mapping on sender conflict resolve", { error: String(e) }));
+              // Mirror updateSenderNonceOnBroadcast + sender_addr_map from the happy broadcast path
+              if (record.senderNonce !== undefined && record.senderAddress) {
+                await updateSenderNonceOnBroadcast(
+                  kv,
+                  signerHash,
+                  record.senderNonce,
+                  resolved.txId
+                ).catch((e) => logger.warn("Failed to update sender nonce cache on conflict resolve", { error: String(e) }));
+                await kv
+                  .put(`sender_addr_map:${record.senderAddress}`, signerHash, { expirationTtl: 86_400 })
+                  .catch((e) => logger.warn("Failed to write sender address mapping on conflict resolve", { error: String(e) }));
+              }
+              emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
+                route: "PAYMENT_QUEUE",
+                paymentId,
+                status: record.status,
+                action: "sender_conflict_resolved_txid",
+                checkStatusUrlPresent: false,
+                compatShimUsed: false,
+                attempt,
+                txid: resolved.txId,
+                responsibleParty: "sender",
+              });
+              logger.info("Sender-origin nonce conflict resolved: txid wired for healers", {
+                paymentId,
+                txid: resolved.txId,
+                senderAddress: record.senderAddress,
+                senderNonce: record.senderNonce,
+              });
+              message.ack();
+              return;
+            } else {
+              // On-chain tx does not match settle requirements — a different/unrelated tx
+              // occupied this nonce (e.g. a different recipient, different amount, or a
+              // non-payment tx). Do NOT write txid_map for an unverified txid.
+              record = transitionPayment(record, "replaced", {
+                error: verifyResult.details ?? verifyResult.error ?? "On-chain tx does not satisfy settle requirements",
+                terminalReason: "superseded",
+                retryable: false,
+              });
+              await putPaymentRecord(kv, record);
+              emitPaymentLifecycleEvent(logger, "payment.finalized", {
+                route: "PAYMENT_QUEUE",
+                paymentId,
+                status: record.status,
+                terminalReason: record.terminalReason,
+                action: "sender_conflict_superseded",
+                checkStatusUrlPresent: false,
+                compatShimUsed: false,
+                attempt,
+                responsibleParty: "sender",
+              }, "warn");
+              logger.warn("Sender-origin nonce conflict: on-chain tx does not satisfy settle requirements", {
+                paymentId,
+                resolvedTxId: resolved.txId,
+                senderAddress: record.senderAddress,
+                senderNonce: record.senderNonce,
+                verifyError: verifyResult.error,
+              });
+              message.ack();
+              return;
+            }
           }
         } else if (resolved.txStatus !== "success") {
           // Tx is in mempool/pending — wire in txid without settle verification.
@@ -528,7 +602,8 @@ async function processPaymentMessage(
           message.ack();
           return;
         }
-        // resolved exists but txStatus=success with no settle — fall through to sender_nonce_duplicate
+        // resolved exists but txStatus=success with no settle, or raw-tx fetch failed
+        // — fall through to sender_nonce_duplicate
       }
       // Lookup returned null or unresolvable — fall through to sender_nonce_duplicate
       record = transitionPayment(record, "failed", {


### PR DESCRIPTION
## Summary

Fixes the \"paid-on-chain but reported failed\" bug (#397) where payments confirmed on-chain were falsely reported as `status=failed / terminalReason=sponsor_failure` with no txid, preventing healers from ever advancing them.

**Root cause:** When `ConflictingNonceInMempool` exhausted retries, the queue consumer terminated the payment with `sponsor_failure` — but this error means the sender's own in-flight tx already occupied the nonce. The relay was the observer, not the cause. It also never resolved the real txid, so chainhook and confirm-reconcile had no txid_map entry to work with.

**Live proof (prod):** 3 payment IDs for sender `SP3TVW9PM…` all at nonce 93 marked `failed/sponsor_failure`, but nonce 93 was `success` on-chain (`0x6084cc29…`, block 8083085).

## Fix (STRICT resolve-then-verify variant)

1. **`lookupTxByAddressNonce` helper** — queries Hiro `GET /extended/v1/address/{sender}/transactions?limit=50` to find the actual txid for `(senderAddress, senderNonce)`. Fail-open: returns null on any error.

2. **Resolve-then-verify path** inserted BEFORE the fallback termination:
   - **Confirmed match** (`tx_status=success` + settle requirements pass via `SettlementService.verifyPaymentParams`): wire `record.txid` + write `txid_map:{txid}` (86_400s TTL), transition to `mempool`. **Delegates to existing healers** (chainhook/confirm-reconcile). Never marks `confirmed` directly.
   - **Pending match** (`tx_status != success`): wire txid + txid_map, leave for healers.
   - **Settle mismatch** (verify fails): `status=replaced`, `terminalReason=superseded`.
   - **No resolve** (lookup null or nonce not found): `status=failed`, `terminalReason=sender_nonce_duplicate`.

3. **Attribution fix** — retryable `ConflictingNonceInMempool` events now emit `responsibleParty=sender` (not `sponsor`).

## What does NOT change

- Sponsor-side `TooMuchChaining` (`isNonceConflict=false`) still terminalizes as `sponsor_failure` unchanged.
- No new background sweeps or direct `confirmed` writes.
- All existing healer paths (chainhook, confirm-reconcile) unchanged.

## Tests

Adds `src/__tests__/queue-sender-conflict-resolve.test.ts` with 6 tests:
- Match: txid wired, txid_map written, record left for healers (not terminalized as failed)
- Mismatch: `status=replaced`, `terminalReason=superseded`, no txid_map
- Lookup failure (fetch throws): `sender_nonce_duplicate` fallback, no spurious txid
- Nonce not in results: `sender_nonce_duplicate` fallback
- Attribution: retry events emit `responsibleParty=sender`
- Regression: sponsor-side TooMuchChaining still `sponsor_failure`

## Pre-existing failure

`src/__tests__/nonce-do-sponsor-status.test.ts` has 1 pre-existing failure tracked in #405 — not introduced by this PR.

## Verify gate

- `npm run check` — green
- `npm test` — 225 pass, 1 fail (pre-existing #405 only)
- `npm run deploy:dry-run` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)