### PR TITLE
fix(queue): do not wire aborted sender tx as confirmable in nonce-conflict recovery (#397)

### DIFF
--- a/src/__tests__/queue-sender-conflict-resolve.test.ts
+++ b/src/__tests__/queue-sender-conflict-resolve.test.ts
@@ -671,7 +671,88 @@ describe("queue consumer: sender-origin nonce conflict resolve-then-verify (#397
   });
 
   // -------------------------------------------------------------------------
-  // 8. Raw-tx fetch fails (timeout or HTTP error) — fail safe, fall back to
+  // 8. REGRESSION: resolved tx has an aborted status (abort_by_response)
+  //    lookupTxByAddressNonce only returns MINED txs, so non-"success" means
+  //    aborted on-chain — NOT pending/mempool. Must terminalize as
+  //    failed/sender_nonce_duplicate and NOT write txid_map or set record.txid.
+  //    (Wiring an aborted tx to "mempool" creates a stuck-forever record.)
+  // -------------------------------------------------------------------------
+  it("terminalizes as failed/sender_nonce_duplicate when resolved tx is aborted on-chain (not wired)", async () => {
+    const kv = new MemoryKV();
+    const record = transitionPayment(
+      createPaymentRecord("pay_aborted", "testnet"),
+      "queued"
+    );
+    record.senderNonce = 55;
+    record.senderAddress = "SP3TVWABORTED000000000000000000000000000";
+    await putPaymentRecord(kv, record);
+
+    mocks.deserializeTransaction.mockImplementation((hex: string) => {
+      if (hex === "aborted_tx") return { auth: { spendingCondition: { signer: "signer_aborted" } } };
+      if (hex === "sponsored_aborted") return { id: "sponsored_aborted" };
+      throw new Error(`unexpected hex: ${hex}`);
+    });
+    mocks.sponsorTransaction.mockResolvedValue({
+      success: true,
+      sponsoredTxHex: "sponsored_aborted",
+      walletIndex: 0,
+      fee: "1000",
+    });
+    mocks.broadcastOnly.mockResolvedValue({
+      error: "ConflictingNonceInMempool",
+      nonceConflict: true,
+      retryable: false,
+    });
+
+    // Hiro address/transactions lookup returns a tx at nonce 55 — but it is ABORTED
+    // (abort_by_response / abort_by_post_condition). The /address/{sender}/transactions
+    // endpoint only returns mined txs, so this is an on-chain abortion, not a mempool tx.
+    mocks.fetch.mockResolvedValueOnce(
+      hiroTxResponse([{ tx_id: "0xabortedtx99", tx_status: "abort_by_response", nonce: 55 }])
+    );
+
+    const message = createMessage(
+      {
+        paymentId: "pay_aborted",
+        txHex: "aborted_tx",
+        network: "testnet",
+        attempt: 5,
+        settle: DEFAULT_SETTLE,
+      },
+      5
+    );
+
+    await handlePaymentQueue(
+      { messages: [message] } as MessageBatch<never>,
+      { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
+      executionContext
+    );
+
+    const finalRecord = await getPaymentRecord(kv, "pay_aborted");
+
+    // Must terminalize as failed/sender_nonce_duplicate — not stuck in mempool
+    expect(finalRecord?.status).toBe("failed");
+    expect(finalRecord?.terminalReason).toBe("sender_nonce_duplicate");
+    // MUST NOT set record.txid to the aborted tx (aborted tx never confirms)
+    expect(finalRecord?.txid).toBeUndefined();
+    // MUST NOT write txid_map (healers would wait forever for a tx that already aborted)
+    const txidMapEntry = await kv.get("txid_map:0xabortedtx99");
+    expect(txidMapEntry).toBeNull();
+    // Must NOT call updateSenderNonceOnBroadcast for an aborted tx
+    expect(mocks.updateSenderNonceOnBroadcast).not.toHaveBeenCalled();
+    // Must NOT fetch raw tx (aborted branch does not need raw hex)
+    expect(mocks.fetch).toHaveBeenCalledTimes(1); // only the address/transactions lookup
+    // verifyPaymentParams must NOT be called (no raw hex to verify)
+    expect(mocks.verifyPaymentParams).not.toHaveBeenCalled();
+    // Message must be acked (not retried)
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+    // Never sponsor_failure for a sender-origin conflict
+    expect(finalRecord?.terminalReason).not.toBe("sponsor_failure");
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. Raw-tx fetch fails (timeout or HTTP error) — fail safe, fall back to
   //    sender_nonce_duplicate (do NOT write txid_map for unverified txid)
   // -------------------------------------------------------------------------
   it("falls back to sender_nonce_duplicate when raw-tx fetch fails", async () => {

--- a/src/__tests__/queue-sender-conflict-resolve.test.ts
+++ b/src/__tests__/queue-sender-conflict-resolve.test.ts
@@ -722,6 +722,8 @@ describe("queue consumer: sender-origin nonce conflict resolve-then-verify (#397
       5
     );
 
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     await handlePaymentQueue(
       { messages: [message] } as MessageBatch<never>,
       { RELAY_KV: kv, STACKS_NETWORK: "testnet" } as never,
@@ -749,6 +751,26 @@ describe("queue consumer: sender-origin nonce conflict resolve-then-verify (#397
     expect(message.retry).not.toHaveBeenCalled();
     // Never sponsor_failure for a sender-origin conflict
     expect(finalRecord?.terminalReason).not.toBe("sponsor_failure");
+
+    // P2 guard: exactly ONE payment.finalized event, carrying the aborted-onchain action.
+    // The aborted branch is self-contained (persist-then-emit-once) and must NOT fall
+    // through to the unresolvable terminalization, which would emit a second finalized event.
+    const finalizedCalls = warnSpy.mock.calls.filter(
+      ([msg]) => msg === "[WARN] payment.finalized"
+    );
+    expect(finalizedCalls).toHaveLength(1);
+    expect(finalizedCalls[0][1]).toEqual(
+      expect.objectContaining({
+        action: "sender_conflict_aborted_onchain",
+        terminalReason: "sender_nonce_duplicate",
+        responsibleParty: "sender",
+      })
+    );
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      "[WARN] payment.finalized",
+      expect.objectContaining({ action: "sender_conflict_unresolvable" })
+    );
+    warnSpy.mockRestore();
   });
 
   // -------------------------------------------------------------------------

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -574,33 +574,35 @@ async function processPaymentMessage(
             }
           }
         } else if (resolved.txStatus !== "success") {
-          // Tx is in mempool/pending — wire in txid without settle verification.
-          // Leave for healers to finalize on confirmation.
-          record = transitionPayment(record, "mempool", { txid: resolved.txId });
-          await putPaymentRecord(kv, record);
-          await kv
-            .put(`txid_map:${resolved.txId}`, paymentId, { expirationTtl: 86_400 })
-            .catch((e) => logger.warn("Failed to write txid mapping on sender conflict pending", { error: String(e) }));
-          emitPaymentLifecycleEvent(logger, "payment.retry_decision", {
+          // NOTE: lookupTxByAddressNonce queries Hiro GET /extended/v1/address/{sender}/transactions,
+          // which returns ONLY mined (anchored) transactions — NOT mempool txs.
+          // Therefore a non-"success" tx_status here is an aborted on-chain status
+          // (abort_by_response / abort_by_post_condition), NOT a pending/mempool tx.
+          //
+          // Do NOT wire txid_map or park in "mempool": an aborted tx never confirms, so
+          // chainhook/confirm-reconcile healers would never finalize the record, creating
+          // a stuck-forever payment. Terminalize as sender_nonce_duplicate instead.
+          emitPaymentLifecycleEvent(logger, "payment.finalized", {
             route: "PAYMENT_QUEUE",
             paymentId,
-            status: record.status,
-            action: "sender_conflict_resolved_txid_pending",
+            status: "failed",
+            terminalReason: "sender_nonce_duplicate",
+            action: "sender_conflict_aborted_onchain",
             checkStatusUrlPresent: false,
             compatShimUsed: false,
             attempt,
-            txid: resolved.txId,
+            resolvedTxId: resolved.txId,
+            txStatus: resolved.txStatus,
             responsibleParty: "sender",
-          });
-          logger.info("Sender-origin nonce conflict: in-flight txid wired, awaiting healer confirmation", {
+          }, "warn");
+          logger.warn("Sender-origin nonce conflict: resolved tx is aborted on-chain, terminalizing", {
             paymentId,
-            txid: resolved.txId,
+            resolvedTxId: resolved.txId,
             txStatus: resolved.txStatus,
             senderAddress: record.senderAddress,
             senderNonce: record.senderNonce,
           });
-          message.ack();
-          return;
+          // Fall through to sender_nonce_duplicate terminalization below.
         }
         // resolved exists but txStatus=success with no settle, or raw-tx fetch failed
         // — fall through to sender_nonce_duplicate

--- a/src/queue-consumer.ts
+++ b/src/queue-consumer.ts
@@ -582,11 +582,24 @@ async function processPaymentMessage(
           // Do NOT wire txid_map or park in "mempool": an aborted tx never confirms, so
           // chainhook/confirm-reconcile healers would never finalize the record, creating
           // a stuck-forever payment. Terminalize as sender_nonce_duplicate instead.
+          //
+          // Self-contained terminalization: persist the failed state BEFORE emitting the
+          // single payment.finalized event (so a transient KV failure cannot report the
+          // payment finalized while the message is retried), then ack and return — do NOT
+          // fall through to the unresolvable block below, which would emit a second
+          // payment.finalized for the same payment.
+          record = transitionPayment(record, "failed", {
+            error: broadcastResult.error,
+            errorCode: "SENDER_NONCE_CONFLICT",
+            terminalReason: "sender_nonce_duplicate",
+            retryable: false,
+          });
+          await putPaymentRecord(kv, record);
           emitPaymentLifecycleEvent(logger, "payment.finalized", {
             route: "PAYMENT_QUEUE",
             paymentId,
-            status: "failed",
-            terminalReason: "sender_nonce_duplicate",
+            status: record.status,
+            terminalReason: record.terminalReason,
             action: "sender_conflict_aborted_onchain",
             checkStatusUrlPresent: false,
             compatShimUsed: false,
@@ -602,7 +615,8 @@ async function processPaymentMessage(
             senderAddress: record.senderAddress,
             senderNonce: record.senderNonce,
           });
-          // Fall through to sender_nonce_duplicate terminalization below.
+          message.ack();
+          return;
         }
         // resolved exists but txStatus=success with no settle, or raw-tx fetch failed
         // — fall through to sender_nonce_duplicate


### PR DESCRIPTION
## Summary

- **Bug:** In the Mode A sender-conflict recovery path, a resolved tx with a non-`success` `tx_status` was being wired into `txid_map` and the payment record transitioned to `mempool` state, ostensibly to await healer confirmation. This created stuck-forever payment records.

- **Root cause:** `lookupTxByAddressNonce` queries `GET /extended/v1/address/{sender}/transactions` — a **mined-transactions-only** endpoint. A non-`success` status there is an **aborted on-chain status** (`abort_by_response` / `abort_by_post_condition`), not a pending/mempool tx. The comment in the code ("Tx is in mempool/pending") was factually wrong. An aborted tx never confirms, so healers waiting on `txid_map` would wait forever.

- **Fix:** Remove the write of `txid_map` and the transition to `mempool` for the aborted case. Emit a distinct lifecycle event (`action: sender_conflict_aborted_onchain`, includes `resolvedTxId` and `txStatus`) for operator visibility, then fall through to the existing `sender_nonce_duplicate` terminalization. The verified-`success` match path and superseded/mismatch path are unchanged.

- **Regression test added:** `queue-sender-conflict-resolve.test.ts` test 8 — resolved tx with `abort_by_response` status → `failed/sender_nonce_duplicate`, no `txid_map` written, `record.txid` not set, only one fetch call (no raw-tx fetch attempted).

## Test plan

- [x] `npm run check` — TypeScript clean
- [x] `npm test` — 228 passing, 1 pre-existing red (`nonce-do-sponsor-status.test.ts` #405)
- [x] `npm run deploy:dry-run` — build clean
- [x] New test 8 guards the aborted-tx regression
- [x] All 8 existing sender-conflict tests remain green

## Related

- Parent issue: #397
- Follow-up: #410 — add mempool lookup for genuinely-pending sender txs (low priority; current retry window typically allows sender tx to mine before terminalization)

## Pre-existing failures

`nonce-do-sponsor-status.test.ts` has 1 failing test pre-dating this branch (tracked in #405). Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)