### PR TITLE
fix(nonce): advance sender frontier when relay-sponsored tx confirms

### DIFF
--- a/src/durable-objects/nonce-do.ts
+++ b/src/durable-objects/nonce-do.ts
@@ -1321,8 +1321,8 @@ export class NonceDO {
       // falling back to dispatched_at for pre-migration entries. This ensures settlement
       // percentiles reflect actual user-perceived latency rather than internal queue timing.
       const preRow = this.sql
-        .exec<{ dispatched_at: string | null; submitted_at: string | null; original_fee: string | null; sender_address: string | null }>(
-          "SELECT dispatched_at, submitted_at, original_fee, sender_address FROM dispatch_queue WHERE wallet_index = ? AND sponsor_nonce = ? LIMIT 1",
+        .exec<{ dispatched_at: string | null; submitted_at: string | null; original_fee: string | null; sender_address: string | null; sender_nonce: number | null }>(
+          "SELECT dispatched_at, submitted_at, original_fee, sender_address, sender_nonce FROM dispatch_queue WHERE wallet_index = ? AND sponsor_nonce = ? LIMIT 1",
           walletIndex,
           sponsorNonce
         )
@@ -1357,6 +1357,13 @@ export class NonceDO {
           originalFee: preRow?.original_fee ?? null,
           senderAddress: preRow?.sender_address ?? null,
         });
+        // Advance sender frontier immediately on relay-confirmed transactions.
+        // Without this, next_expected_nonce stays at its seeded value and the
+        // sender's next sequential nonce is incorrectly held as SENDER_NONCE_GAP
+        // until the alarm-driven stale repair fires (~5 minutes later).
+        if (preRow?.sender_address != null && preRow?.sender_nonce != null) {
+          this.advanceSenderNonce(preRow.sender_address, preRow.sender_nonce);
+        }
       }
     } else if (newState === "dispatched") {
       this.sql.exec(


### PR DESCRIPTION
## Problem

`transitionQueueEntry(walletIndex, sponsorNonce, \"confirmed\")` updates `dispatch_queue` but never calls `advanceSenderNonce()`. So `sender_state.next_expected_nonce` stays at its seeded value after every relay-sponsored confirmation. The sender's next sequential nonce is then incorrectly flagged as `SENDER_NONCE_GAP` and held until the alarm-driven stale repair fires (~5 minutes via `maybeRepairStaleSenderFrontier`).

This reproduces the symptom from #284 even for relay-sponsored-only accounts — not just mixed relay/direct-publish senders. Confirmed repro on v1.33.2 by @silentgeckoaudit3801 in the issue thread.

## Root Cause

The normal confirmation path in `ledgerMarkConfirmedByReconcile` → `transitionQueueEntry(\"confirmed\")` reads a `preRow` from `dispatch_queue` for settlement timing but never reads or uses `sender_nonce`. `advanceSenderNonce` is only called in the failure-recovery path (`invalidRunRecovery` Case A/B), not the happy path.

## Fix

Add `sender_nonce` to the `preRow` SELECT and call `advanceSenderNonce(sender_address, sender_nonce)` when the dispatch_queue row actually transitions to confirmed (guarded by `rowsWritten > 0`). This immediately advances the sender frontier on relay-confirmed transactions.

The existing alarm-driven repair path (`maybeRepairStaleSenderFrontier`) is retained as a safety net for the external-publishing case (sender confirms outside the relay, so the relay never sees it via this path).

## Changes

`src/durable-objects/nonce-do.ts` — `transitionQueueEntry()`:
- Add `sender_nonce` to the preRow SELECT
- Call `advanceSenderNonce(sender_address, sender_nonce)` when `confirmCursor.rowsWritten > 0`

## Acceptance Criteria (from #284)

- ✅ A sender seeded at nonce `94` that later advances to `140` via relay-sponsored txs recovers without operator intervention
- ✅ Recovery does not require per-request Hiro queries
- ✅ Sender frontier never moves backward (`advanceSenderNonce` uses `MAX(next_expected_nonce, ?)`)
- ✅ Sender hand is not fully discarded — `advanceSenderNonce` only prunes entries strictly below the new frontier

## Operational Context

From Arc's production monitoring: the nonce gaps at positions [2920, 2921] we track have not shown the stale-low sender pattern since the Wave 2 merges (#285/#311/#349/#353). But the `silentgeckoaudit3801` reproduction on v1.33.2 is clear and sequential — this fix closes the remaining gap in the confirmation path.

Closes #284