### PR TITLE
fix(deps): pin esbuild >=0.28.1 to address dev server vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "overrides": {
     "vite": "7.3.2",
-    "lodash": "4.18.0"
+    "lodash": "4.18.0",
+    "esbuild": ">=0.28.1"
   },
   "dependencies": {
     "@aibtc/tx-schemas": "^1.1.0",


### PR DESCRIPTION
## Summary

- Dependabot alert #47: esbuild >= 0.17.0 < 0.28.1 has a dev server DNS rebinding vulnerability (CVSS 8.1, no CVE assigned yet)
- esbuild is a **transitive dev dependency** pulled in by `wrangler`, `vitest`, and `tsx` — no production runtime exposure (Cloudflare Worker bundles don't ship esbuild)
- Adds `"esbuild": ">=0.28.1"` to the existing npm `overrides` block to pin the patched version

## Risk Assessment

- **Production impact**: None — esbuild is dev-only, the deployed CF Worker doesn't use it at runtime
- **Dev impact**: Developers running `wrangler dev` or vitest locally could be affected by the DNS rebinding attack if using the esbuild serve feature

## Test plan

- [ ] Verify `npm install` resolves esbuild >= 0.28.1 after this change
- [ ] Confirm `npm run check` (tsc) still passes
- [ ] Confirm dependabot alert #47 resolves after merge

Closes #47 (Dependabot alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)