### PR TITLE
fix: pin undici >=7.28.0 to address CVE-2026-9697

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "overrides": {
     "vite": "7.3.2",
-    "lodash": "4.18.0"
+    "lodash": "4.18.0",
+    "undici": ">=7.28.0"
   },
   "dependencies": {
     "@aibtc/tx-schemas": "^1.1.0",


### PR DESCRIPTION
## Summary

Adds an npm `overrides` pin for `undici >=7.28.0` to resolve Dependabot alert #54.

## Vulnerability

**CVE-2026-9697** — TLS certificate validation bypass in undici's `ProxyAgent` when configured with a SOCKS5 proxy URI. The `requestTls` option is silently dropped, causing the connection to fall back to the default Mozilla CA bundle, breaking custom CA pins and enabling potential MITM.

- Affected range: `>=7.23.0, <7.28.0`
- Fix: `>=7.28.0`
- CVSS: 7.4 (High)

## Risk Assessment

**Low impact for this project:**
- `undici` is a **dev-only transitive dependency** (`wrangler → miniflare → undici`)
- Zero usage of SOCKS5 proxying or `ProxyAgent` in the codebase (confirmed via code search)
- Not present in production bundle (Cloudflare Workers runtime)

## Change

Added `undici: >=7.28.0` to the existing `overrides` block in `package.json`. No other changes. A `package-lock.json` regeneration on next `npm install` will resolve the transitive dep to the patched version.

Resolves: https://github.com/aibtcdev/x402-sponsor-relay/security/dependabot/54