### PR TITLE
fix(deps): upgrade hono 4.12.14 → 4.12.25 (CVE-2026-54290)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2197,9 +2197,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "@stacks/transactions": "^7.3.1",
     "@stacks/wallet-sdk": "^7.2.0",
     "chanfana": "^3.0.0",
-    "hono": "^4.12.14"
+    "hono": "^4.12.25"
   }
 }


### PR DESCRIPTION
## Security Fix

Upgrades hono from 4.12.14 to 4.12.25 to resolve [CVE-2026-54290](https://github.com/aibtcdev/x402-sponsor-relay/security/dependabot/51).

### Vulnerability

**CVE-2026-54290** (high, CVSS 7.1): CORS middleware reflects any request `Origin` with `Access-Control-Allow-Credentials: true` when `credentials: true` is set and `origin` is unset (defaults to wildcard). This allows any third-party page a logged-in user visits to make credentialed cross-origin requests.

### Impact Assessment

Our usage in `src/index.ts`:
```ts
app.use("/*", cors());
```

Bare `cors()` with no options — `credentials: true` is **not set**. The vulnerability requires both `credentials: true` **and** no explicit `origin`. This service is **not exploitable** under the current configuration.

Upgrading anyway to clear the Dependabot alert and stay on a patched release.

### Changes

- `package.json`: `hono ^4.12.14` → `^4.12.25`
- `package-lock.json`: version + integrity hash updated