### PR TITLE
fix(deps): bump transitive js-yaml to 4.3.0 (CVE-2026-59869)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2206,9 +2206,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "overrides": {
     "vite": "7.3.2",
-    "lodash": "4.18.0"
+    "lodash": "4.18.0",
+    "js-yaml": "4.3.0"
   },
   "dependencies": {
     "@aibtc/tx-schemas": "^1.1.0",


### PR DESCRIPTION
## Summary
- Dependabot alert #69: js-yaml (high, CVSS 7.5) — CVE-2026-59869 / GHSA-52cp-r559-cp3m, quadratic-CPU DoS via chained YAML merge keys
- js-yaml is a transitive dependency of `chanfana` (^4.1.0), not a direct dependency — pinned via `overrides` in `package.json` to 4.3.0 (first patched version)
- `package-lock.json` regenerated accordingly (only the js-yaml entry changed)

## Test plan
- [x] Verified `node_modules/js-yaml` resolves to 4.3.0 after `npm install`
- [x] Diff limited to the js-yaml entry in package-lock.json + one line in package.json overrides
- [ ] CI / deploy checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)