### PR TITLE
fix(deps): pin postcss to 8.5.18 (GHSA-r28c-9q8g-f849)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2306,9 +2306,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2399,9 +2399,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dev": true,
       "funding": [
         {
@@ -2419,7 +2419,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "overrides": {
     "vite": "7.3.2",
-    "lodash": "4.18.0"
+    "lodash": "4.18.0",
+    "postcss": "8.5.18"
   },
   "dependencies": {
     "@aibtc/tx-schemas": "^1.1.0",


### PR DESCRIPTION
## Summary
- Dependabot alert #70 flagged `postcss` transitively resolved to 8.5.12 (via `vite`/`vitest`, dev-only), vulnerable to path-traversal .map file disclosure (GHSA-r28c-9q8g-f849, CVSS 7.5 high).
- Added `overrides.postcss = "8.5.18"` (first patched version) alongside the existing `vite`/`lodash` overrides, matching the repo's existing pattern for pinning transitive deps.
- `postcss` is a transitive **dev** dependency here (build tooling only, no runtime CSS processing / no untrusted CSS input in this service), so exploitability was already low — this closes the alert regardless.

## Test plan
- [x] `npm install` succeeds; `node_modules/postcss/package.json` version confirmed at 8.5.18
- [x] `git diff package-lock.json` shows only `postcss` + its `nanoid` sub-dependency bump — no unrelated lockfile churn
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)